### PR TITLE
Fix[TE-10856]: When we store runtime variables in Addons it is not displayed in run-time Overlay --> This issue still exists for Community addons (Pre-existing addons)

### DIFF
--- a/basic_math_operations/pom.xml
+++ b/basic_math_operations/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>basic_math_operations</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsAndroid.java
+++ b/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsAndroid.java
@@ -22,7 +22,7 @@ public class MathematicalOperationsAndroid extends MathematicalOperationsWeb {
     private com.testsigma.sdk.TestData operator;
     @TestData(reference = "testdata2")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "runtimevariable")
+    @TestData(reference = "runtimevariable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @TestData(reference = "number")
     private com.testsigma.sdk.TestData testData4;

--- a/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsIos.java
+++ b/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsIos.java
@@ -21,7 +21,7 @@ public class MathematicalOperationsIos extends MathematicalOperationsWeb {
     private com.testsigma.sdk.TestData operator;
     @TestData(reference = "testdata2")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "runtimevariable")
+    @TestData(reference = "runtimevariable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @TestData(reference = "number")
     private com.testsigma.sdk.TestData testData4;

--- a/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsMw.java
+++ b/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsMw.java
@@ -22,7 +22,7 @@ public class MathematicalOperationsMw extends MathematicalOperationsWeb {
     private com.testsigma.sdk.TestData operator;
     @TestData(reference = "testdata2")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "runtimevariable")
+    @TestData(reference = "runtimevariable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @TestData(reference = "number")
     private com.testsigma.sdk.TestData testData4;

--- a/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsWeb.java
+++ b/basic_math_operations/src/main/java/com/testsigma/addons/web/MathematicalOperationsWeb.java
@@ -22,7 +22,7 @@ public class MathematicalOperationsWeb extends WebAction {
     private com.testsigma.sdk.TestData operator;
     @TestData(reference = "testdata2")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "runtimevariable")
+    @TestData(reference = "runtimevariable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @TestData(reference = "number")
     private com.testsigma.sdk.TestData testData4;

--- a/browser_local_storage_actions/pom.xml
+++ b/browser_local_storage_actions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>browser_local_storage_actions</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/browser_local_storage_actions/src/main/java/com/testsigma/addons/web/GetItemFromLocalStorage.java
+++ b/browser_local_storage_actions/src/main/java/com/testsigma/addons/web/GetItemFromLocalStorage.java
@@ -28,7 +28,7 @@ public class GetItemFromLocalStorage extends WebAction {
   @TestData(reference = "Key_Name")
   private com.testsigma.sdk.TestData keyNameTestData;
 
-  @TestData(reference = "Variable_Name")
+  @TestData(reference = "Variable_Name",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData variableNameTestData;
 
   @RunTimeData

--- a/html_table_actions/pom.xml
+++ b/html_table_actions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>html_table_actions</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/html_table_actions/src/main/java/com/testsigma/addons/html_tables/web/StoreTotalNumberOfCellsOfTable.java
+++ b/html_table_actions/src/main/java/com/testsigma/addons/html_tables/web/StoreTotalNumberOfCellsOfTable.java
@@ -24,7 +24,7 @@ public class StoreTotalNumberOfCellsOfTable extends WebAction {
     private static final String TABLE_ERROR_MESSAGE = "Expected Table Was Not Found";
     @Element(reference = "element")
     private com.testsigma.sdk.Element element;
-    @TestData(reference = "variable-name")
+    @TestData(reference = "variable-name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData variableName;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/html_table_actions/src/main/java/com/testsigma/addons/html_tables/web/StoreTotalNumberOfRowsOfTable.java
+++ b/html_table_actions/src/main/java/com/testsigma/addons/html_tables/web/StoreTotalNumberOfRowsOfTable.java
@@ -24,7 +24,7 @@ public class StoreTotalNumberOfRowsOfTable extends WebAction {
     private static final String TABLE_ERROR_MESSAGE = "Expected Table Was Not Found";
     @Element(reference = "element")
     private com.testsigma.sdk.Element element;
-    @TestData(reference = "variable-name")
+    @TestData(reference = "variable-name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData variableName;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/pdf_actions/pom.xml
+++ b/pdf_actions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>pdf_actions</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofCharaftertext.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofCharaftertext.java
@@ -30,7 +30,7 @@ public class NoofCharaftertext extends WebAction {
     private com.testsigma.sdk.TestData testData1;
     @TestData(reference = "test_data")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "Variable_Name")
+    @TestData(reference = "Variable_Name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofCharbeforetext.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofCharbeforetext.java
@@ -30,7 +30,7 @@ public class NoofCharbeforetext extends WebAction {
     private com.testsigma.sdk.TestData testData1;
     @TestData(reference = "test_data")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "Variable_Name")
+    @TestData(reference = "Variable_Name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofwordsAftertext.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofwordsAftertext.java
@@ -31,7 +31,7 @@ public class NoofwordsAftertext extends WebAction {
     private com.testsigma.sdk.TestData testData1;
     @TestData(reference = "test_data")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "Variable_Name")
+    @TestData(reference = "Variable_Name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofwordsBeforetext.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/NoofwordsBeforetext.java
@@ -31,7 +31,7 @@ public class NoofwordsBeforetext extends WebAction {
     private com.testsigma.sdk.TestData testData1;
     @TestData(reference = "test_data")
     private com.testsigma.sdk.TestData testData2;
-    @TestData(reference = "Variable_Name")
+    @TestData(reference = "Variable_Name",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData3;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ReadpdfContent.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ReadpdfContent.java
@@ -21,7 +21,7 @@ import java.net.URL;
         applicationType = ApplicationType.WEB)
 public class ReadpdfContent extends WebAction {
 
-    @TestData(reference = "variable")
+    @TestData(reference = "variable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData;
 
     @RunTimeData

--- a/remove_special_character/pom.xml
+++ b/remove_special_character/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>remove_special_character</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/remove_special_character/src/main/java/com/testsigma/addons/web/RemoveSpecialcharacter.java
+++ b/remove_special_character/src/main/java/com/testsigma/addons/web/RemoveSpecialcharacter.java
@@ -26,7 +26,7 @@ public class RemoveSpecialcharacter extends WebAction
     @TestData(reference = "testdata2")
     private com.testsigma.sdk.TestData testData2;
 
-    @TestData(reference = "Variable")
+    @TestData(reference = "Variable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData runtimeVar; 
 
     @RunTimeData

--- a/split_string_action/pom.xml
+++ b/split_string_action/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>split_string_action</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/split_string_action/src/main/java/com/testsigma/addons/web/SplitStringAction.java
+++ b/split_string_action/src/main/java/com/testsigma/addons/web/SplitStringAction.java
@@ -31,7 +31,7 @@ public class SplitStringAction extends WebAction {
     @TestData(reference = "position")
     private com.testsigma.sdk.TestData position;
 
-    @TestData(reference = "output-variable")
+    @TestData(reference = "output-variable",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData extractedString;
 
     @com.testsigma.sdk.annotation.RunTimeData

--- a/string_data_generators/pom.xml
+++ b/string_data_generators/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>string_data_generators</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/string_data_generators/src/main/java/com/testsigma/addons/string_utils/android/StoreTestDataParameterIntoRuntimeVariable.java
+++ b/string_data_generators/src/main/java/com/testsigma/addons/string_utils/android/StoreTestDataParameterIntoRuntimeVariable.java
@@ -16,7 +16,7 @@ import org.openqa.selenium.NoSuchElementException;
 public class StoreTestDataParameterIntoRuntimeVariable extends com.testsigma.addons.string_utils.web.StoreTestDataParameterIntoRuntimeVariable {
     @TestData(reference = "test-data-1")
     private com.testsigma.sdk.TestData testData1;
-    @TestData(reference = "test-data-2")
+    @TestData(reference = "test-data-2",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData2;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/string_data_generators/src/main/java/com/testsigma/addons/string_utils/ios/StoreTestDataParameterIntoRuntimeVariable.java
+++ b/string_data_generators/src/main/java/com/testsigma/addons/string_utils/ios/StoreTestDataParameterIntoRuntimeVariable.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.NoSuchElementException;
 public class StoreTestDataParameterIntoRuntimeVariable extends com.testsigma.addons.string_utils.web.StoreTestDataParameterIntoRuntimeVariable {
     @TestData(reference = "test-data-1")
     private com.testsigma.sdk.TestData testData1;
-    @TestData(reference = "test-data-2")
+    @TestData(reference = "test-data-2",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData2;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/string_data_generators/src/main/java/com/testsigma/addons/string_utils/mobile_web/StoreTestDataParameterIntoRuntimeVariable.java
+++ b/string_data_generators/src/main/java/com/testsigma/addons/string_utils/mobile_web/StoreTestDataParameterIntoRuntimeVariable.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.NoSuchElementException;
 public class StoreTestDataParameterIntoRuntimeVariable extends com.testsigma.addons.string_utils.web.StoreTestDataParameterIntoRuntimeVariable {
     @TestData(reference = "test-data-1")
     private com.testsigma.sdk.TestData testData1;
-    @TestData(reference = "test-data-2")
+    @TestData(reference = "test-data-2",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData2;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/string_data_generators/src/main/java/com/testsigma/addons/string_utils/web/StoreTestDataParameterIntoRuntimeVariable.java
+++ b/string_data_generators/src/main/java/com/testsigma/addons/string_utils/web/StoreTestDataParameterIntoRuntimeVariable.java
@@ -20,7 +20,7 @@ public class StoreTestDataParameterIntoRuntimeVariable extends WebAction {
     private static final String ERROR_MESSAGE = "Expected textarea Not Found";
     @TestData(reference = "test-data-1")
     private com.testsigma.sdk.TestData testData1;
-    @TestData(reference = "test-data-2")
+    @TestData(reference = "test-data-2",isRuntimeVariable = true)
     private com.testsigma.sdk.TestData testData2;
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;

--- a/while_loop_iteration/pom.xml
+++ b/while_loop_iteration/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>while_loop_iteration</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/android/SplitUsingSeparator.java
+++ b/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/android/SplitUsingSeparator.java
@@ -25,9 +25,9 @@ public class SplitUsingSeparator extends AndroidAction {
   @TestData(reference = "RUN_TIME_TESTDATA")
   private com.testsigma.sdk.TestData inputData;
 
-  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME")
+  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData runTimeVariableName;
-  @TestData(reference = "VARIABLE_NAME")
+  @TestData(reference = "VARIABLE_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData currentIterationRuntimeVarName;
 
   @RunTimeData

--- a/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/ios/SplitUsingSeparator.java
+++ b/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/ios/SplitUsingSeparator.java
@@ -20,9 +20,9 @@ public class SplitUsingSeparator extends IOSAction {
   @TestData(reference = "RUN_TIME_TESTDATA")
   private com.testsigma.sdk.TestData inputData;
 
-  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME")
+  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData runTimeVariableName;
-  @TestData(reference = "VARIABLE_NAME")
+  @TestData(reference = "VARIABLE_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData currentIterationRuntimeVarName;
 
   @RunTimeData

--- a/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/mobileweb/SplitUsingSeparator.java
+++ b/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/mobileweb/SplitUsingSeparator.java
@@ -17,12 +17,12 @@ public class SplitUsingSeparator extends WebAction {
   @TestData(reference = "SEPARATOR")
   private com.testsigma.sdk.TestData separator;
 
-  @TestData(reference = "RUN_TIME_TESTDATA")
+  @TestData(reference = "RUN_TIME_TESTDATA",)
   private com.testsigma.sdk.TestData inputData;
 
-  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME")
+  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData runTimeVariableName;
-  @TestData(reference = "VARIABLE_NAME")
+  @TestData(reference = "VARIABLE_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData currentIterationRuntimeVarName;
 
   @RunTimeData

--- a/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/web/SplitUsingSeparator.java
+++ b/while_loop_iteration/src/main/java/com/testsigma/addons/whileloop/web/SplitUsingSeparator.java
@@ -20,9 +20,9 @@ public class SplitUsingSeparator extends WebAction {
   @TestData(reference = "RUN_TIME_TESTDATA")
   private com.testsigma.sdk.TestData inputData;
 
-  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME")
+  @TestData(reference = "RUN_TIME_TESTDATA_VAR_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData runTimeVariableName;
-  @TestData(reference = "VARIABLE_NAME")
+  @TestData(reference = "VARIABLE_NAME",isRuntimeVariable = true)
   private com.testsigma.sdk.TestData currentIterationRuntimeVarName;
 
   @RunTimeData


### PR DESCRIPTION
**Impact areas**: create test case, runtime overlay, addons page
**Areas tested**: Addons page, test case, runtime overlay
**Screenshots**:
<img width="1728" alt="Screenshot 2023-10-20 at 11 14 44 AM" src="https://github.com/testsigmahq/testsigma-addons/assets/144768691/c211cda3-546e-4c29-9de4-179bab2869a8">
<img width="1728" alt="Screenshot 2023-10-20 at 11 14 58 AM" src="https://github.com/testsigmahq/testsigma-addons/assets/144768691/76ee7748-16ee-4f11-8c72-8aa5b545c428">
