### PR TITLE
FEAT[TE-16468]: Validate DB and table element data

### DIFF
--- a/validate_db_data_with_table_element_data/pom.xml
+++ b/validate_db_data_with_table_element_data/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.testsigma.addons</groupId>
+    <artifactId>validate_db_data_with_table_element_data</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <testsigma.sdk.version>1.2.6_cloud</testsigma.sdk.version>
+        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <lombok.version>1.18.20</lombok.version>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.testsigma</groupId>
+            <artifactId>testsigma-java-sdk</artifactId>
+            <version>${testsigma.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.14.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>23.2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.1</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <finalName>validate_db_data_with_table_element_data</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/validate_db_data_with_table_element_data/src/main/java/com/testsigma/addons/web/CompareDataInDbAndWebTableElement.java
+++ b/validate_db_data_with_table_element_data/src/main/java/com/testsigma/addons/web/CompareDataInDbAndWebTableElement.java
@@ -1,0 +1,136 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.Element;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import java.sql.*;
+import java.util.List;
+@Data
+@Action(actionText = "Execute query: query_ in the database db with connection url: url_, username: username_"+
+        " and password: password_ to fetch the data and compare it with data option case-sensitivity in table element table_element",
+        description = "Verifies data from DB and web table element are equal or not",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class CompareDataInDbAndWebTableElement extends WebAction {
+
+    @TestData(reference = "url_")
+    private com.testsigma.sdk.TestData url_;
+    @TestData(reference = "username_")
+    private com.testsigma.sdk.TestData username_;
+    @TestData(reference = "password_")
+    private com.testsigma.sdk.TestData password_;
+    @TestData(reference = "db",allowedValues = {"Oracle","MySQL","PostgreSQL"})
+    private com.testsigma.sdk.TestData db;
+    @TestData(reference = "option",allowedValues = {"with","without"})
+    private com.testsigma.sdk.TestData option;
+    @TestData(reference = "query_")
+    private com.testsigma.sdk.TestData query_;
+    @Element(reference = "table_element")
+    private com.testsigma.sdk.Element element;
+    private static final String COLUMN_COUNT_MISMATCH = "Column count in DB data and element data mismatched.\n" +
+            " Column count in DB : %d,\n Column count in table element : %d.";
+    private static final String ROW_COUNT_MISMATCH = "Row count in DB data and element data mismatched.\n" +
+            " Row count in DB : %d,\n Row count in table element : %d.";
+    private static final String DATA_MISMATCH = "Data mismatched at column - %d and row - %d.\n" +
+            " Data in DB : %s,\n Data in table element : %s.";
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        WebElement table = element.getElement();
+        String url = url_.getValue().toString();
+        String username = username_.getValue().toString();
+        String password = password_.getValue().toString();
+        String query = query_.getValue().toString();
+        Connection connection = null;
+        Statement statement = null;
+        try {
+            getClassForDb(db.getValue().toString());
+            connection = DriverManager.getConnection(url,username, password);
+            logger.info("Opened database successfully");
+            statement = connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+            ResultSet resultSet = statement.executeQuery(query);
+            logger.info("Query executed successfully");
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            List<WebElement> tableRows = getRows(table);
+            List<WebElement> tableHeaders = getHeaders(tableRows.get(0));
+            int tableColumnCount = tableHeaders.size();
+            resultSet.last();
+            checkColumnAndRowCount(metaData.getColumnCount(),tableColumnCount,resultSet.getRow(),(tableRows.size() - 1));
+            logger.info("Both data sizes are equal");
+            resultSet.beforeFirst();
+            checkData(tableRows,resultSet,tableColumnCount,option.getValue().toString());
+            logger.info("Data in both DB and web table element are equal");
+            resultSet.close();
+            statement.close();
+            connection.close();
+            logger.info("Connection closed");
+        } catch (Exception e) {
+            result = com.testsigma.sdk.Result.FAILED;
+            logger.debug("Execution failed. "+e.getMessage());
+            setErrorMessage(e.getMessage());
+        }
+        setSuccessMessage("Data in both DB and web table element are equal");
+        return result;
+    }
+    protected List<WebElement> getRows(WebElement table){
+        return table.findElements(By.tagName("tr"));
+    }
+
+    protected List<WebElement> getHeaders(WebElement row){
+        return row.findElements(By.tagName("th"));
+    }
+
+    protected List<WebElement> getCellsOfRow(WebElement row){
+        return row.findElements(By.tagName("td"));
+    }
+
+    protected Class<?> getClassForDb(String db) throws Exception{
+        switch (db){
+            case "Oracle":
+                return Class.forName("oracle.jdbc.driver.OracleDriver");
+            case "MySQL":
+                return Class.forName("com.mysql.cj.jdbc.Driver");
+            case "PostgreSQL":
+                return Class.forName("org.postgresql.Driver");
+            default:
+                return null;
+        }
+    }
+    protected void checkColumnAndRowCount (int dbColumnCount, int tableColumnCount, int dbRowCount, int tableRowCount)
+            throws Exception{
+        if(dbColumnCount != tableColumnCount)
+            throw new Exception(String.format(COLUMN_COUNT_MISMATCH,dbColumnCount,tableColumnCount));
+        if(dbRowCount != tableRowCount)
+            throw new Exception(String.format(ROW_COUNT_MISMATCH,dbRowCount,tableRowCount));
+    }
+    protected void checkData(List<WebElement> tableRows, ResultSet resultSet, int columnCount, String option) throws Exception{
+        int rowIndex = 1;
+        if(option.equals("with")){
+            while (resultSet.next()) {
+                List<WebElement> cells = getCellsOfRow(tableRows.get(rowIndex));
+                for (int i = 0; i < columnCount; i++) {
+                    if(!cells.get(i).getText().equals(resultSet.getString(i + 1)))
+                        throw new Exception(String.format(DATA_MISMATCH,i + 1,rowIndex,resultSet.getString(i + 1),cells.get(i).getText()));
+                }
+                rowIndex++;
+            }
+        } else {
+            while (resultSet.next()) {
+                List<WebElement> cells = getCellsOfRow(tableRows.get(rowIndex));
+                for (int i = 0; i < columnCount; i++) {
+                    if(!cells.get(i).getText().equalsIgnoreCase(resultSet.getString(i + 1)))
+                        throw new Exception(String.format(DATA_MISMATCH,i + 1,rowIndex,resultSet.getString(i + 1),cells.get(i).getText()));
+                }
+                rowIndex++;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Addon supports Oracle, PostgreSQL, MySQL databases

UI table element should be constructed using <table> tags and all

Inputs : DB type, connection URL, username and password for database, Query to be executed, UI table element

NLP : Execute query:` query_` in the database `ORACLE/POSTGRESQL/MYSQL` with connection url: `url_`, username: `username_`  and password:` password_ ` to fetch the data and compare it with data `WITH/WITHOUT` case-sensitivity in table element `table_element`