### PR TITLE
Feat[TE-16276]: Added ContainsTextPDFWithAuth and ReadPdfContentWithAuth nlp actions

### DIFF
--- a/pdf_actions/pom.xml
+++ b/pdf_actions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>pdf_actions</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -59,13 +59,18 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
+            <version>4.14.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
 
     </dependencies>

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ContainsTextPDFWithAuth.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ContainsTextPDFWithAuth.java
@@ -1,0 +1,80 @@
+package com.testsigma.addons.pdf.web;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.testng.Assert;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+
+@Data
+@Action(actionText = "Verify if the pdf contains text test-data using username Username_Value and password Password_Value",
+        description = "This action will validate whether given test-data present in pdf or not using given username and password",
+        applicationType = ApplicationType.WEB)
+public class ContainsTextPDFWithAuth extends WebAction {
+
+    private static final String SUCCESS_MESSAGE = "Assertion passed PDF content contains test data";
+    private static final String ERROR_MESSAGE = "Assertion failed PDF content does not contain test data";
+    com.testsigma.sdk.Result result;
+    @TestData(reference = "test-data")
+    private com.testsigma.sdk.TestData testData;
+    @TestData(reference = "Username_Value")
+    private com.testsigma.sdk.TestData username;
+    @TestData(reference = "Password_Value")
+    private com.testsigma.sdk.TestData password;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        try {
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username.getValue().toString(),
+                            password.getValue().toString().toCharArray());
+                }
+            });
+
+            logger.info("Initiating execution");
+            logger.debug("test-data: " + this.testData.getValue());
+            StringBuffer sb = new StringBuffer();
+            URL url;
+            BufferedInputStream fileParse;
+            PDDocument doc = null;
+            try {
+                url = new URL(driver.getCurrentUrl());
+                InputStream is = url.openStream();   //Converting url as input
+                fileParse = new BufferedInputStream(is);   //reads data from file
+                doc = PDDocument.load(fileParse); //loads the file as pdf
+                sb.append(new PDFTextStripper().getText(doc));
+                Assert.assertTrue(sb.toString().contains((CharSequence) testData.getValue()));
+                setSuccessMessage(String.format(SUCCESS_MESSAGE + " " + testData.getValue()));
+                return Result.SUCCESS;
+            } catch (Exception e) {
+
+                String errorMessage = ExceptionUtils.getStackTrace(e);
+                logger.info(errorMessage);
+                setErrorMessage(String.format(ERROR_MESSAGE + " " + testData.getValue() + "   " + "Cause of Exception:"
+                        +errorMessage));
+                return Result.FAILED;
+            }
+        }
+        catch (Exception e){
+            String errorMessage = ExceptionUtils.getStackTrace(e);
+            logger.info(errorMessage);
+            setErrorMessage(ERROR_MESSAGE + ": "+ errorMessage);
+            return Result.FAILED;
+        }
+    }
+}
+

--- a/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ReadPdfContentWithAuth.java
+++ b/pdf_actions/src/main/java/com/testsigma/addons/pdf/web/ReadPdfContentWithAuth.java
@@ -1,0 +1,88 @@
+package com.testsigma.addons.pdf.web;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+
+@Data
+@Action(actionText = "Read the content from pdf using username Username_Value and password Password_Value and store the text into a runtime-variable Variable_Name",
+        description = "Extracts the text from the PDF using given username, password and stores the extracted text into a run time variable",
+        applicationType = ApplicationType.WEB)
+public class ReadPdfContentWithAuth extends WebAction {
+
+    @TestData(reference = "Variable_Name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData;
+    @TestData(reference = "Username_Value")
+    private com.testsigma.sdk.TestData username;
+    @TestData(reference = "Password_Value")
+    private com.testsigma.sdk.TestData password;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public Result execute() {
+        try{
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username.getValue().toString(),
+                            password.getValue().toString().toCharArray());
+                }
+            });
+            //Your Awesome code starts here
+            Result result = Result.SUCCESS;
+            logger.info("Initiating execution");
+            logger.debug("test-data: " + this.testData.getValue());
+            //StringBuffer sb = new StringBuffer();
+            URL url;
+            BufferedInputStream fileParse;
+            if (driver.getCurrentUrl().contains(".pdf")) {
+                setSuccessMessage("pdf file detected");
+                System.out.println("PDF detected");
+            } else {
+                setErrorMessage("Not a pdf file");
+                System.out.println("PDF not detected");
+                return Result.FAILED;
+            }
+            try {
+                url = new URL(driver.getCurrentUrl());
+                InputStream is = url.openStream();   //Converting url as input
+                fileParse = new BufferedInputStream(is);   //reads data from file
+                PDDocument doc = null;
+                doc = PDDocument.load(fileParse); //loads the file as pdf
+                String st = new PDFTextStripper().getText(doc);
+                //sb.append(new PDFTextStripper().getText(doc));
+                runTimeData = new com.testsigma.sdk.RunTimeData();
+                runTimeData.setValue(st.trim());
+                runTimeData.setKey(testData.getValue().toString());
+                setSuccessMessage("The Stored content in PDF is : " + st.trim() + "and stored in the runtime variable :"
+                        + testData.getValue());
+            } catch (Exception e) {
+                String errorMessage = ExceptionUtils.getStackTrace(e);
+                logger.info(errorMessage);
+                setErrorMessage("Error occurred while reading content from pdf: "+ errorMessage);
+                return Result.FAILED;
+            }
+            return result;
+        } catch (Exception e){
+            String errorMessage = ExceptionUtils.getStackTrace(e);
+            logger.info(errorMessage);
+            setErrorMessage("Error occurred while reading content from pdf: "+ errorMessage);
+            return Result.FAILED;
+        }
+    }
+}


### PR DESCRIPTION
https://testsigma.atlassian.net/browse/TE-16276

While accessing url which is having authentication, we cannot able to fetch data from the pdf. So Added the below actions to overcome this:

- Verify if the pdf contains text test-data using username Username_Value and password Password_Value (This action will validate whether given test-data present in pdf or not using given username and password)

- Read the content from pdf using username Username_Value and password Password_Value and store the text into a runtime-variable Variable_Name (Extracts the text from the PDF using given username, password and stores the extracted text into a run time variable)