### PR TITLE
Feat[CR-1298]: Add - on to extract data from one location to another location for (.CSV.GZ) files

### DIFF
--- a/unzipfileandupload/pom.xml
+++ b/unzipfileandupload/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.testsigma.addons</groupId>
+    <artifactId>unzipfileandupload</artifactId>
+    <version>1.0.2</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <testsigma.sdk.version>1.2.8_cloud</testsigma.sdk.version>
+        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <lombok.version>1.18.20</lombok.version>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.testsigma</groupId>
+            <artifactId>testsigma-java-sdk</artifactId>
+            <version>${testsigma.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.14.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-lang3</artifactId>
+    <version>3.12.0</version>
+</dependency>
+
+    </dependencies>
+    <build>
+        <finalName>unzipfileandupload</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/UnzipCSVGZFile.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/UnzipCSVGZFile.java
@@ -1,0 +1,76 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+
+import lombok.Data;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Data
+@Action(actionText = "Unzip the CSV.GZ file absolutefilepath to destination destfilepath and store the filepath into a variable testdata",
+        description = "Unzip the CSV.GZ file and store the extracted file path",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class UnzipCSVGZFile extends WebAction {
+
+    @TestData(reference = "absolutefilepath")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "destfilepath")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "testdata" , isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        //Your Awesome code starts here
+        logger.info("Initiating execution");
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        try {
+            String zipFilePath = testData1.getValue().toString();
+            String destDir = testData2.getValue().toString();
+            String fileNameUpload = "output" + System.currentTimeMillis() + ".csv";
+            String filePath = destDir + File.separator + fileNameUpload;
+            unzip(zipFilePath, filePath);
+            logger.info("Storing the filepath in runtime variable");
+            runTimeData.setValue(filePath);
+            runTimeData.setKey(testData3.getValue().toString());
+            logger.info("Stored successfully");
+            setSuccessMessage("File was unzipped and stored successfully in : " + testData3.getValue().toString() + " and the filepath is :" + filePath);
+        } catch (Exception e) {
+            String errorMessage = ExceptionUtils.getStackTrace(e);
+            result = com.testsigma.sdk.Result.FAILED;
+            setErrorMessage(errorMessage);
+            logger.warn(errorMessage);
+        }
+        return result;
+    }
+    private void unzip(String zipFilePath, String destFilepath) throws IOException {
+        logger.info("Extracting the file");
+        FileInputStream fis = new FileInputStream(zipFilePath);
+        GZIPInputStream gis = new GZIPInputStream(fis);
+        FileOutputStream fos = new FileOutputStream(destFilepath);
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = gis.read(buffer)) > 0) {
+            fos.write(buffer, 0, len);
+        }
+        fos.close();
+        gis.close();
+        fis.close();
+        logger.info("Successfully extracted to location: " + destFilepath);
+    }
+}

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/UnzipCSVGZFile.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/UnzipCSVGZFile.java
@@ -18,8 +18,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 @Data
-@Action(actionText = "Unzip the CSV.GZ file absolutefilepath to destination destfilepath and store the filepath into a variable testdata",
-        description = "Unzip the CSV.GZ file and store the extracted file path",
+@Action(actionText = "Unzip the .CSV.GZ file absolutefilepath to destination destfilepath and store the filepath into a variable testdata",
+        description = "Unzip the .CSV.GZ file and store the extracted file path",
         applicationType = ApplicationType.WEB,
         useCustomScreenshot = false)
 public class UnzipCSVGZFile extends WebAction {

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/Uploadunzip.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/Uploadunzip.java
@@ -1,0 +1,97 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.Element;
+import lombok.Data;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Data
+@Action(actionText = "Unzip the zipfile absolutefilepath to destination destfilepath and upload into a element element-locator",
+description = "Unzip the file and upload into a element",
+applicationType = ApplicationType.WEB,
+useCustomScreenshot = false)
+public class Uploadunzip extends WebAction {
+
+	@TestData(reference = "absolutefilepath")
+	private com.testsigma.sdk.TestData testData1;
+	@TestData(reference = "destfilepath")
+	private com.testsigma.sdk.TestData testData2;
+	@Element(reference = "element-locator")
+	private com.testsigma.sdk.Element element;
+
+
+	@Override
+	public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+		//Your Awesome code starts here
+		logger.info("Initiating execution");
+		com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+		try {
+			String zipFilePath = testData1.getValue().toString();
+			String destDir = testData2.getValue().toString();
+
+			WebElement webElement = element.getElement();
+			String fileNameupload = unzip(zipFilePath, destDir);
+			String filePath = destDir + File.separator + fileNameupload;
+			Thread.sleep(1000);
+			webElement.sendKeys(filePath);
+			Thread.sleep(1000);
+		}catch (Exception e) {
+			String errorMessage = ExceptionUtils.getStackTrace(e);
+			result = com.testsigma.sdk.Result.FAILED;
+			setErrorMessage(errorMessage);
+			logger.warn(errorMessage);	
+		}
+		setSuccessMessage("File was unzipped and uploaded successfully on the specific element location");
+		return result;		
+	}
+	private static String unzip(String zipFilePath, String destDir) throws InterruptedException {
+		String fileName = null;
+		Thread.sleep(1000);
+		File dir = new File(destDir);
+		// create output directory if it doesn't exist
+		if (!dir.exists()) dir.mkdirs();
+		FileInputStream fis;
+		// buffer for read and write data to file
+		byte[] buffer = new byte[1024];
+		try {
+			fis = new FileInputStream(zipFilePath);
+			ZipInputStream zis = new ZipInputStream(fis);
+			ZipEntry ze = zis.getNextEntry();
+			while (ze != null) {
+				fileName = ze.getName();
+				File newFile = new File(destDir + File.separator + fileName);
+				// create directories for sub directories in zip
+				new File(newFile.getParent()).mkdirs();
+				FileOutputStream fos = new FileOutputStream(newFile);
+				Thread.sleep(1000);
+				int len;
+				while ((len = zis.read(buffer)) > 0) {
+					fos.write(buffer, 0, len);
+				}
+				fos.close();
+				zis.closeEntry();
+				ze = zis.getNextEntry();
+				Thread.sleep(1000);
+			}
+			zis.closeEntry();
+			zis.close();
+			fis.close();
+			Thread.sleep(1000);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return fileName;
+	}
+}

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/Uploadunziplatest.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/Uploadunziplatest.java
@@ -1,0 +1,119 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.Element;
+import lombok.Data;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Data
+@Action(actionText = "Unzip the latest zipfile filedirectory to destination destfilepath and upload into a element element-locator",
+description = "Unzip the file and upload into a element",
+applicationType = ApplicationType.WEB,
+useCustomScreenshot = false)
+public class Uploadunziplatest extends WebAction {
+
+	@TestData(reference = "filedirectory")
+	private com.testsigma.sdk.TestData testData1;
+	@TestData(reference = "destfilepath")
+	private com.testsigma.sdk.TestData testData2;
+	@Element(reference = "element-locator")
+	private com.testsigma.sdk.Element element;
+
+
+	@Override
+	public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+		//Your Awesome code starts here
+		logger.info("Initiating execution");
+		com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+		try {
+			File zipFilePath = getLastModified(testData1.getValue().toString());
+			String destDir = testData2.getValue().toString();
+
+			WebElement webElement = element.getElement();
+			String fileNameupload = unzip(zipFilePath, destDir);
+			String filePath = destDir + File.separator + fileNameupload;
+			Thread.sleep(1000);
+			webElement.sendKeys(filePath);
+			Thread.sleep(1000);
+		}catch (Exception e) {
+			String errorMessage = ExceptionUtils.getStackTrace(e);
+			result = com.testsigma.sdk.Result.FAILED;
+			setErrorMessage(errorMessage);
+			logger.warn(errorMessage);	
+		}
+		setSuccessMessage("File was unzipped and uploaded successfully on the specific element location");
+		return result;		
+	}
+	private static String unzip(File zipFilePath, String destDir) throws InterruptedException {
+		String fileName = null;
+		Thread.sleep(1000);
+		File dir = new File(destDir);
+		// create output directory if it doesn't exist
+		if (!dir.exists()) dir.mkdirs();
+		FileInputStream fis;
+		// buffer for read and write data to file
+		byte[] buffer = new byte[1024];
+		try {
+			fis = new FileInputStream(zipFilePath);
+			ZipInputStream zis = new ZipInputStream(fis);
+			ZipEntry ze = zis.getNextEntry();
+			while (ze != null) {
+				fileName = ze.getName();
+				File newFile = new File(destDir + File.separator + fileName);
+				// create directories for sub directories in zip
+				new File(newFile.getParent()).mkdirs();
+				FileOutputStream fos = new FileOutputStream(newFile);
+				Thread.sleep(1000);
+				int len;
+				while ((len = zis.read(buffer)) > 0) {
+					fos.write(buffer, 0, len);
+				}
+				fos.close();
+				zis.closeEntry();
+				ze = zis.getNextEntry();
+				Thread.sleep(1000);
+			}
+			zis.closeEntry();
+			zis.close();
+			fis.close();
+			Thread.sleep(1000);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return fileName;
+	}
+	
+	public static File getLastModified(String directoryFilePath)
+	{
+		File directory = new File(directoryFilePath);
+		File[] files = directory.listFiles(File::isFile);
+		long lastModifiedTime = Long.MIN_VALUE;
+		File chosenFile = null;
+
+		if (files != null)
+		{
+			for (File file : files)
+			{
+				if (file.lastModified() > lastModifiedTime)
+				{
+					chosenFile = file;
+					lastModifiedTime = file.lastModified();
+				}
+			}
+		}
+
+		return chosenFile;
+	}
+}

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/unzipfile.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/unzipfile.java
@@ -1,0 +1,98 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+
+import lombok.Data;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Data
+@Action(actionText = "Unzip the zipfile absolutefilepath to destination destfilepath and store the filepath into a variable testdata",
+description = "Unzip the file and upload into a element",
+applicationType = ApplicationType.WEB,
+useCustomScreenshot = false)
+public class unzipfile extends WebAction {
+
+	@TestData(reference = "absolutefilepath")
+	private com.testsigma.sdk.TestData testData1;
+	@TestData(reference = "destfilepath")
+	private com.testsigma.sdk.TestData testData2;
+	@TestData(reference = "testdata" , isRuntimeVariable = true)
+	private com.testsigma.sdk.TestData testData3;
+	
+	@RunTimeData
+	private com.testsigma.sdk.RunTimeData runTimeData;
+
+
+	@Override
+	public com.testsigma.sdk.Result execute() {
+		//Your Awesome code starts here
+		logger.info("Initiating execution");
+		com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+		try {
+			String zipFilePath = testData1.getValue().toString();
+			String destDir = testData2.getValue().toString();
+			
+			String fileNameupload = unzip(zipFilePath, destDir);
+			String filePath = destDir + File.separator + fileNameupload;
+			runTimeData.setValue(filePath);
+	        runTimeData.setKey(testData3.getValue().toString());
+			Thread.sleep(1000);
+			setSuccessMessage("File was unzipped and stored successfully in : " + testData3.getValue().toString() + " and the filepath is :" + filePath);
+		}catch (Exception e) {
+			String errorMessage = ExceptionUtils.getStackTrace(e);
+			result = com.testsigma.sdk.Result.FAILED;
+			setErrorMessage(errorMessage);
+			logger.warn(errorMessage);	
+		}
+		return result;		
+	}
+	private static String unzip(String zipFilePath, String destDir) throws InterruptedException {
+		String fileName = null;
+		Thread.sleep(1000);
+		File dir = new File(destDir);
+		// create output directory if it doesn't exist
+		if (!dir.exists()) dir.mkdirs();
+		FileInputStream fis;
+		// buffer for read and write data to file
+		byte[] buffer = new byte[1024];
+		try {
+			fis = new FileInputStream(zipFilePath);
+			ZipInputStream zis = new ZipInputStream(fis);
+			ZipEntry ze = zis.getNextEntry();
+			while (ze != null) {
+				fileName = ze.getName();
+				File newFile = new File(destDir + File.separator + fileName);
+				// create directories for sub directories in zip
+				new File(newFile.getParent()).mkdirs();
+				FileOutputStream fos = new FileOutputStream(newFile);
+				Thread.sleep(1000);
+				int len;
+				while ((len = zis.read(buffer)) > 0) {
+					fos.write(buffer, 0, len);
+				}
+				fos.close();
+				zis.closeEntry();
+				ze = zis.getNextEntry();
+				Thread.sleep(1000);
+			}
+			zis.closeEntry();
+			zis.close();
+			fis.close();
+			Thread.sleep(1000);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return fileName;
+	}
+}

--- a/unzipfileandupload/src/main/java/com/testsigma/addons/web/unzipfilelatest.java
+++ b/unzipfileandupload/src/main/java/com/testsigma/addons/web/unzipfilelatest.java
@@ -1,0 +1,123 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.Element;
+import com.testsigma.sdk.annotation.RunTimeData;
+
+import lombok.Data;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Data
+@Action(actionText = "Unzip the latest zipfile filedirectory to destination destfilepath and store the filepath into a variable testdata",
+description = "Unzip the file and upload into a element",
+applicationType = ApplicationType.WEB,
+useCustomScreenshot = false)
+public class unzipfilelatest extends WebAction {
+
+	@TestData(reference = "filedirectory")
+	private com.testsigma.sdk.TestData testData1;
+	@TestData(reference = "destfilepath")
+	private com.testsigma.sdk.TestData testData2;
+	@TestData(reference = "testdata" , isRuntimeVariable = true)
+	private com.testsigma.sdk.TestData testData3;
+	
+	@RunTimeData
+	private com.testsigma.sdk.RunTimeData runTimeData;
+
+
+	@Override
+	public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+		//Your Awesome code starts here
+		logger.info("Initiating execution");
+		com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+		try {
+			File zipFilePath = getLastModified(testData1.getValue().toString());
+			String destDir = testData2.getValue().toString();
+
+			String fileNameupload = unzip(zipFilePath, destDir);
+			String filePath = destDir + File.separator + fileNameupload;
+			runTimeData.setValue(filePath);
+	        runTimeData.setKey(testData3.getValue().toString());
+			Thread.sleep(1000);
+			setSuccessMessage("File was unzipped and stored successfully in : " + testData3.getValue().toString() + " and the filepath is :" + filePath);
+		}catch (Exception e) {
+			String errorMessage = ExceptionUtils.getStackTrace(e);
+			result = com.testsigma.sdk.Result.FAILED;
+			setErrorMessage(errorMessage);
+			logger.warn(errorMessage);	
+		}
+		return result;		
+	}
+	private static String unzip(File zipFilePath, String destDir) throws InterruptedException {
+		String fileName = null;
+		Thread.sleep(1000);
+		File dir = new File(destDir);
+		// create output directory if it doesn't exist
+		if (!dir.exists()) dir.mkdirs();
+		FileInputStream fis;
+		// buffer for read and write data to file
+		byte[] buffer = new byte[1024];
+		try {
+			fis = new FileInputStream(zipFilePath);
+			ZipInputStream zis = new ZipInputStream(fis);
+			ZipEntry ze = zis.getNextEntry();
+			while (ze != null) {
+				fileName = ze.getName();
+				File newFile = new File(destDir + File.separator + fileName);
+				// create directories for sub directories in zip
+				new File(newFile.getParent()).mkdirs();
+				FileOutputStream fos = new FileOutputStream(newFile);
+				Thread.sleep(1000);
+				int len;
+				while ((len = zis.read(buffer)) > 0) {
+					fos.write(buffer, 0, len);
+				}
+				fos.close();
+				zis.closeEntry();
+				ze = zis.getNextEntry();
+				Thread.sleep(1000);
+			}
+			zis.closeEntry();
+			zis.close();
+			fis.close();
+			Thread.sleep(1000);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return fileName;
+	}
+	
+	public static File getLastModified(String directoryFilePath)
+	{
+		File directory = new File(directoryFilePath);
+		File[] files = directory.listFiles(File::isFile);
+		long lastModifiedTime = Long.MIN_VALUE;
+		File chosenFile = null;
+
+		if (files != null)
+		{
+			for (File file : files)
+			{
+				if (file.lastModified() > lastModifiedTime)
+				{
+					chosenFile = file;
+					lastModifiedTime = file.lastModified();
+				}
+			}
+		}
+
+		return chosenFile;
+	}
+}


### PR DESCRIPTION
Previously this UnzipFileAndUpload is an already existed public addon but it wasn't uploaded in this repo.

Now I have added another nlp UnzipCSVGZFile for this ticket https://testsigma.atlassian.net/browse/CR-1298. Please review the UnzipCSVGZFile.java file. I haven't made any changes other than UnzipCSVGZFile.java file.