### PR TITLE
Feat: Added Network simulation for LambdaTest

### DIFF
--- a/network_configuration/pom.xml
+++ b/network_configuration/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.testsigma.addons</groupId>
+    <artifactId>network_configuration</artifactId>
+    <version>1.0.2</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <testsigma.sdk.version>1.2.18_cloud</testsigma.sdk.version>
+        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <lombok.version>1.18.20</lombok.version>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.testsigma</groupId>
+            <artifactId>testsigma-java-sdk</artifactId>
+            <version>${testsigma.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.14.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+
+        <!-- Additional Dependencies-->
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20230227</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <finalName>network_configuration</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/network_configuration/src/main/java/com/testsigma/addons/browserstack/android/SwitchToNetworkProfile.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/browserstack/android/SwitchToNetworkProfile.java
@@ -1,0 +1,97 @@
+package com.testsigma.addons.browserstack.android;
+
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.android.AndroidDriver;
+import lombok.Data;
+import org.json.JSONObject;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+
+@Data
+@Action(actionText = "switch to network configuration profile-name",
+        description = "switches the network type to no-network/3G/4G & default resets the initial network configuration",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class SwitchToNetworkProfile extends AndroidAction {
+    @TestData(reference = "profile-name", allowedValues = {"no-network", "default", "2G", "3G", "4G"})
+    com.testsigma.sdk.TestData profileName;
+
+    @Override
+    protected com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        logger.info("Initiating execution to simulate network configuration");
+
+        final String successMessage = "Successfully switched to network-configuration : " + profileName.getValue().toString();
+        final String errorMessage = "Failed to switch to network configuration";
+        AndroidDriver androidDriver = (AndroidDriver) this.driver;
+
+        String sessionId = androidDriver.getSessionId().toString().toLowerCase();
+
+        String apiUrl = "https://api-cloud.browserstack.com/app-automate/sessions/" + sessionId + "/update_network.json";
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String modifiedProfileName = getBrowserStackProfileName(profileName.getValue().toString());
+
+            // Prepare the request body
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("networkProfile", modifiedProfileName);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiUrl))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Basic cnVrbWFuZ2FkYTE6UHpwelNGRUdOUVVhV1hwek5vazU=")
+                    .PUT(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            int statusCode = response.statusCode();
+            if (statusCode == 200) {
+                logger.info("response code: " + statusCode);
+            } else {
+                logger.warn("Failed to switch to network profile. Response Status Code: " + statusCode + ", Response Body: " + response.body());
+                setErrorMessage("Failed to switch to network configuration " + modifiedProfileName +" Response Status Code: " + statusCode );
+                result = com.testsigma.sdk.Result.FAILED;
+            }
+        } catch (IOException | InterruptedException e) {
+            logger.warn(errorMessage + e.getMessage());
+            setErrorMessage(errorMessage + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        setSuccessMessage(successMessage + profileName.getValue().toString());
+        return result;
+    }
+
+    private String getBrowserStackProfileName(String modifiedProfileName) {
+        switch (modifiedProfileName) {
+            case "no-network":
+                modifiedProfileName = "no-network";
+                break;
+            case "2g":
+                modifiedProfileName = "2g-gprs-good";
+                break;
+            case "3g":
+                modifiedProfileName = "3g-umts-good";
+                break;
+            case "4g":
+                modifiedProfileName = "4g-umts-good";
+                break;
+            case "default":
+                modifiedProfileName = "reset";
+                break;
+        }
+        return modifiedProfileName;
+    }
+
+}

--- a/network_configuration/src/main/java/com/testsigma/addons/browserstack/android/SwitchToNetworkProfile.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/browserstack/android/SwitchToNetworkProfile.java
@@ -49,7 +49,7 @@ public class SwitchToNetworkProfile extends AndroidAction {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiUrl))
                     .header("Content-Type", "application/json")
-                    .header("Authorization", "Basic cnVrbWFuZ2FkYTE6UHpwelNGRUdOUVVhV1hwek5vazU=")
+                    .header("Authorization", "Basic <UserName:Password>")
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
                     .build();
 

--- a/network_configuration/src/main/java/com/testsigma/addons/browserstack/ios/SwitchToNetworkProfile.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/browserstack/ios/SwitchToNetworkProfile.java
@@ -1,0 +1,96 @@
+package com.testsigma.addons.browserstack.ios;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.IOSAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.ios.IOSDriver;
+import lombok.Data;
+import org.json.JSONObject;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+
+@Data
+@Action(actionText = "switch to network configuration profile-name",
+        description = "switches the network type to no-network/3G/4G & default resets the initial network configuration",
+        applicationType = ApplicationType.IOS,
+        useCustomScreenshot = false)
+public class SwitchToNetworkProfile extends IOSAction {
+    @TestData(reference = "profile-name", allowedValues = {"no-network", "default", "2G", "3G", "4G"})
+    com.testsigma.sdk.TestData profileName;
+
+    @Override
+    protected com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        logger.info("Initiating execution to simulate network configuration");
+
+        final String successMessage = "Successfully switched to network-configuration : " + profileName.getValue().toString();
+        final String errorMessage = "Failed to switch to network configuration";
+        IOSDriver iosDriver = (IOSDriver) this.driver;
+        String sessionId = iosDriver.getSessionId().toString().toLowerCase();
+
+        String apiUrl = "https://api-cloud.browserstack.com/app-automate/sessions/" + sessionId + "/update_network.json";
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String modifiedProfileName = getBrowserStackProfileName(profileName.getValue().toString());
+
+            // Prepare the request body
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("networkProfile", modifiedProfileName);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(apiUrl))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Basic cnVrbWFuZ2FkYTE6UHpwelNGRUdOUVVhV1hwek5vazU=")
+                    .PUT(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            int statusCode = response.statusCode();
+            if (statusCode == 200) {
+                logger.info("response code: " + statusCode);
+            } else {
+                logger.warn("Failed to switch to network profile. Response Status Code: " + statusCode + ", Response Body: " + response.body());
+                setErrorMessage("Failed to switch to network configuration " + modifiedProfileName +" Response Status Code: " + statusCode );
+                result = com.testsigma.sdk.Result.FAILED;
+            }
+        } catch (IOException | InterruptedException e) {
+            logger.warn(errorMessage + e.getMessage());
+            setErrorMessage(errorMessage + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        setSuccessMessage(successMessage + profileName.getValue().toString());
+        return result;
+    }
+
+    private String getBrowserStackProfileName(String modifiedProfileName) {
+        switch (modifiedProfileName) {
+            case "no-network":
+                modifiedProfileName = "no-network";
+                break;
+            case "2g":
+                modifiedProfileName = "2g-gprs-good";
+                break;
+            case "3g":
+                modifiedProfileName = "3g-umts-good";
+                break;
+            case "4g":
+                modifiedProfileName = "4g-umts-good";
+                break;
+            case "default":
+                modifiedProfileName = "reset";
+                break;
+        }
+        return modifiedProfileName;
+    }
+
+}

--- a/network_configuration/src/main/java/com/testsigma/addons/browserstack/ios/SwitchToNetworkProfile.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/browserstack/ios/SwitchToNetworkProfile.java
@@ -48,7 +48,7 @@ public class SwitchToNetworkProfile extends IOSAction {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiUrl))
                     .header("Content-Type", "application/json")
-                    .header("Authorization", "Basic cnVrbWFuZ2FkYTE6UHpwelNGRUdOUVVhV1hwek5vazU=")
+                    .header("Authorization", "Basic <UserName:Password>")
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
                     .build();
 

--- a/network_configuration/src/main/java/com/testsigma/addons/lambdatest/android/SimulateNetworks.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/lambdatest/android/SimulateNetworks.java
@@ -1,0 +1,67 @@
+package com.testsigma.addons.lambdatest.android;
+
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.android.AndroidDriver;
+import lombok.Data;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+
+@Data
+@Action(actionText = "simulate network to profile-name mode",
+        description = "Simulates the behavior of given network.",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class SimulateNetworks extends AndroidAction {
+
+    @TestData(reference = "profile-name", allowedValues = {"no-network", "default", "2G", "3G", "4G"})
+    com.testsigma.sdk.TestData profileName;
+    @Override
+    protected com.testsigma.sdk.Result execute() {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        logger.info("Initiating execution to simulate network configuration on LambdaTest");
+
+        final String successMessage = "Successfully switched to network-configuration : ";
+        final String errorMessage = "Failed to switch to network configuration ";
+
+        // REFERENCE : https://www.lambdatest.com/support/docs/app-auto-network-throttling/
+
+        try {
+            AndroidDriver androidDriver = (AndroidDriver) this.driver;
+            logger.info("profile-name: " + profileName.getValue().toString());
+            String networkProfile = getLambdaTestProfileName(profileName.getValue().toString().toLowerCase());
+            logger.info("updateNetworkProfile : " + networkProfile);
+            androidDriver.executeScript("updateNetworkProfile="+networkProfile);
+            setSuccessMessage(successMessage + networkProfile);
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            logger.warn("stack trace: " + sw.toString());
+            setErrorMessage(errorMessage + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        return result;
+    }
+
+    private String getLambdaTestProfileName(String modifiedProfileName) {
+        switch (modifiedProfileName) {
+            case "no-network":
+                return "offline";
+            case "2g":
+                return "2g-gprs-good";
+            case "3g":
+                return "3g-umts-good";
+            case "4g":
+                return "4g-lte-good";
+            default:
+                return "default";
+        }
+    }
+
+}

--- a/network_configuration/src/main/java/com/testsigma/addons/lambdatest/ios/SimulateNetworks.java
+++ b/network_configuration/src/main/java/com/testsigma/addons/lambdatest/ios/SimulateNetworks.java
@@ -1,0 +1,67 @@
+package com.testsigma.addons.lambdatest.ios;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.IOSAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.ios.IOSDriver;
+import lombok.Data;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+
+@Data
+@Action(actionText = "simulate network to profile-name mode",
+        description = "Simulates the behavior of given network.",
+        applicationType = ApplicationType.IOS,
+        useCustomScreenshot = false)
+public class SimulateNetworks extends IOSAction {
+
+    @TestData(reference = "profile-name", allowedValues = {"no-network", "default", "2G", "3G", "4G"})
+    com.testsigma.sdk.TestData profileName;
+    @Override
+    protected com.testsigma.sdk.Result execute() {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        logger.info("Initiating execution to simulate network configuration on LambdaTest");
+
+        final String successMessage = "Successfully switched to network-configuration : ";
+        final String errorMessage = "Failed to switch to network configuration ";
+
+        // source : https://www.lambdatest.com/support/docs/app-auto-network-throttling/
+
+        try {
+            logger.info("profile-name: " + profileName.getValue().toString());
+            IOSDriver iosDriver = (IOSDriver) this.driver;
+            String networkProfile = getLambdaTestProfileName(profileName.getValue().toString().toLowerCase());
+            logger.info("updateNetworkProfile : " + networkProfile);
+            iosDriver.executeScript("updateNetworkProfile="+networkProfile);
+            setSuccessMessage(successMessage + networkProfile);
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            logger.warn("stack trace: " + sw.toString());
+            setErrorMessage(errorMessage + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        return result;
+    }
+
+    private String getLambdaTestProfileName(String modifiedProfileName) {
+        switch (modifiedProfileName) {
+            case "no-network":
+                return "offline";
+            case "2g":
+                return "2g-gprs-good";
+            case "3g":
+                return "3g-umts-good";
+            case "4g":
+                return "4g-lte-good";
+            default:
+                return "default";
+        }
+    }
+
+}


### PR DESCRIPTION
This add-on simulates the behaviour of the chosen network-profile for both lambdaTest and BrowserStack executions.

ex: switch to 4G/3G/Offline Mode.


Reference : 
https://www.lambdatest.com/support/docs/app-auto-network-throttling/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced network testing capabilities with updated project configuration.
  - Added actions for switching network profiles on BrowserStack, enabling Android and iOS tests to mimic various network conditions.
  - Implemented features for simulating diverse network conditions on LambdaTest for both Android and iOS testing scenarios.
  - New POM file created for project dependencies and build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->