### PR TITLE
[CR-2008] PDF visual testing added 2 Nlp's to get page count and visual diff at given page.

### DIFF
--- a/pdf_visual_testing/pom.xml
+++ b/pdf_visual_testing/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.testsigma.addons</groupId>
+    <artifactId>pdf_visual_testing_addon</artifactId>
+    <version>1.0.4</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <testsigma.sdk.version>1.2.12_cloud</testsigma.sdk.version>
+        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <lombok.version>1.18.20</lombok.version>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.testsigma</groupId>
+            <artifactId>testsigma-java-sdk</artifactId>
+            <version>${testsigma.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.14.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+
+        <!--        Extra dependenices       -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox-tools</artifactId>
+            <version>2.0.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.3</version> <!-- Make sure to use the latest version -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.2.4</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <finalName>pdf_visual_testing_addon</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/DecodeBase64.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/DecodeBase64.java
@@ -1,0 +1,80 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Action(actionText = "Convert base64 code base64-data into file with name (Ex:output.pdf) file-name and store " +
+        "filepath in runtime variable variable-name",
+        description = "Converts any type of file's base64 code into that type of file with given name and extension" +
+                " and stores the file path in run time variable",
+        applicationType = ApplicationType.WEB)
+public class DecodeBase64 extends WebAction {
+
+    @TestData(reference = "base64-data")
+    private com.testsigma.sdk.TestData base64Data_;
+
+    @TestData(reference = "file-name")
+    private com.testsigma.sdk.TestData fileName_;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData variable_;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        String base64Data = base64Data_.getValue().toString();
+        String fileName = fileName_.getValue().toString();
+        String variable = variable_.getValue().toString();
+
+        try {
+            String[] list = fileName.split("\\.");
+            if (list.length == 2) {
+                File tempFile = File.createTempFile(
+                                    list[0], "." + list[1]
+                                );
+                String filePath = tempFile.getAbsolutePath();
+                decodeBase64ToPDF(base64Data, filePath);
+                runTimeData.setKey(variable);
+                runTimeData.setValue(filePath);
+                setSuccessMessage(String.format("Successfully converted the base64 data to the file with" +
+                        " name %s and stored the file path <b>%s</b> in run time variable <b>%s</b>", fileName,
+                        filePath, variable));
+            } else {
+                result = Result.FAILED;
+                setErrorMessage("Invalid file name input, file name format should be in filname.extension format (Ex: output.pdf)");
+            }
+        } catch (RuntimeException e) {
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception occurred: " + ExceptionUtils.getStackTrace(e));
+            result = Result.FAILED;
+            setErrorMessage("Unable to perform the operation");
+        }
+        return result;
+    }
+
+    public void decodeBase64ToPDF(String base64Str, String outputFilePath) {
+        byte[] decodedBytes = Base64.getDecoder().decode(base64Str);
+        try (FileOutputStream fos = new FileOutputStream(outputFilePath)) {
+            fos.write(decodedBytes);
+        } catch (IOException e) {
+            logger.info("Exception occurred while decoding : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to decode the base64 string to given file");
+            throw new RuntimeException("Decoding error");
+        }
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/GetThePageCountOfPDF.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/GetThePageCountOfPDF.java
@@ -1,0 +1,67 @@
+package com.testsigma.addons.web;
+
+
+import com.testsigma.addons.web.util.PDFUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+
+@Data
+@Action(actionText = "store the page count of the pdf file pdf-file-path in runtime variable variable_name",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class GetThePageCountOfPDF extends WebAction {
+    @TestData(reference = "pdf-file-path")
+    private com.testsigma.sdk.TestData pdfFilePath;
+    @TestData(reference = "variable_name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        PDFUtils pdfUtils = new PDFUtils(driver, logger);
+        String basePdfPath = pdfFilePath.getValue().toString();
+
+        File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+
+        if (!basePDF.getName().endsWith(".pdf")) {
+            setErrorMessage("Unsupported file type give only pdf file as input");
+            throw new RuntimeException("Unsupported file types");
+        }
+
+        if (!basePDF.exists()) {
+            setErrorMessage("Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                    ", please given valid file input");
+            throw new RuntimeException("Base PDF not found");
+        }
+
+        try {
+            logger.info("getting page count of the pdf file");
+            int numberOfPagesInPdf = pdfUtils.getPdfPageCount(basePDF);
+            logger.info("Number of pages in the pdf file: " + numberOfPagesInPdf);
+            runTimeData.setValue(String.valueOf(numberOfPagesInPdf));
+            runTimeData.setKey(runtimeVariable.getValue().toString());
+            setSuccessMessage("Successfully stored the number of pages of a pdf file in runtime variable <b>"
+                    + runTimeData.getKey() + " = " + runTimeData.getValue() + "</b> " +
+                    "\n Screenshot might not be available for this step");
+        } catch (Exception e) {
+            logger.debug("Error creating temp directories and files" + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unexpected Error: " + ExceptionUtils.getStackTrace(e));
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+        return result;
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTesting.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTesting.java
@@ -77,7 +77,7 @@ public class PDFVisualTesting extends WebAction {
             File basePDF = urlToFileConverter("base.pdf", basePdfPath);
             File actualPDF = urlToFileConverter("actual.pdf", actualPdfPath);
 
-            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+            if (!basePDF.getName().endsWith(".pdf") || !actualPDF.getName().endsWith(".pdf")) {
                 setErrorMessage("Unsupported file types give only pdf files as input");
                 throw new RuntimeException("Unsupported file types");
             }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTesting.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTesting.java
@@ -1,0 +1,333 @@
+package com.testsigma.addons.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.Coordinate;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.TestStepResult;
+import lombok.Data;
+import okhttp3.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.List;
+
+
+@Data
+@Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
+        " same by performing visual analysis",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = true)
+public class PDFVisualTesting extends WebAction {
+
+
+    @TestData(reference = "base-pdf-file-path")
+    private com.testsigma.sdk.TestData basePdfPath_;
+
+    @TestData(reference = "actual-pdf-file-path")
+    private com.testsigma.sdk.TestData actualPdfPath_;
+
+    @TestStepResult
+    private com.testsigma.sdk.TestStepResult testStepResult;
+
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+    ObjectMapper mapper = new ObjectMapper();
+    ResponseObject responseObject = new ResponseObject();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+        String basePdfPath = basePdfPath_.getValue().toString();
+        String actualPdfPath = actualPdfPath_.getValue().toString();
+
+        int page;
+        try {
+            File basePDF = urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+                setErrorMessage("Unsupported file types give only pdf files as input");
+                throw new RuntimeException("Unsupported file types");
+            }
+
+            if (!basePDF.exists()) {
+                setErrorMessage("Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input");
+                throw new RuntimeException("Base PDF not found");
+            }
+
+            if (!actualPDF.exists()) {
+                setErrorMessage("Actual PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input");
+                throw new RuntimeException("Actual PDF not found");
+            }
+
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            File combinedImage = File.createTempFile("combined",".png");
+            logger.info("Created.");
+
+
+            logger.info("Converting pages of both pdfs to images");
+            pdfToImages(basePDF.getAbsolutePath(), basePdfDirectoryPath, "input1");
+            pdfToImages(actualPDF.getAbsolutePath(), actualPdfDirectoryPath, "input2");
+            logger.info("Converted both pdf pages into images");
+
+            logger.info("Validating the pages of images at both directories");
+            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
+            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
+            if (basePdfDirImages == null || actualPdfDirImages == null) {
+                setErrorMessage("Unable to retrieve pages from the pdfs, make sure both pdfs are not empty and accessible");
+                throw new RuntimeException("Unable retrieve pages from pdfs");
+            }
+            if (basePdfDirImages.length != actualPdfDirImages.length) {
+                setErrorMessage(String.format("Unequal page counts - pages in base pdf are %s, pages in actual " +
+                        "pdf are %s", basePdfDirImages.length, actualPdfDirImages.length));
+                throw new RuntimeException("Unequal page count");
+            }
+            logger.info("No errors in the directories");
+            logger.info("Initiating visual testing");
+            boolean compareResult = true;
+            BufferedImage combined = null;
+
+            for (page = 1; page <= actualPdfDirImages.length; page++) {
+                File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+                File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+                if (file1.exists() && file2.exists()) {
+                    BufferedImage baseImage = ImageIO.read(file1);
+                    BufferedImage actualImage = ImageIO.read(file2);
+
+                    boolean apiResult = performApiCall(file1, file2, page);
+                    if (!apiResult) {
+                        compareResult = false;
+                        combined = mergeImagesAndHighlightDifferences(baseImage , actualImage, combined, responseObject.getDiff_coordinates());
+                    }
+                }
+            }
+            String s3Url = testStepResult.getScreenshotUrl();
+
+            // if there are no changes in the pdf, uploading the first page of the actualPdf
+            if (compareResult) {
+                boolean uploadS3Result = uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to s3, screenshot might not be displayed");
+                }
+                System.out.println("Upload complete.");
+                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. (Note: Step screenshot contains the image of actual PDF)");
+            } else {
+                // uploading the screenshot of the image where we encounter the difference (side-by-side).
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = uploadFile(s3Url, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to S3, screenshot might not be displayed");
+                }
+                result = Result.FAILED;
+                setErrorMessage("Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results");
+            }
+        } catch (RuntimeException e) {
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation");
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+
+    public File urlToFileConverter(String fileName, String url) {
+        try {
+            if (url.startsWith("https://") || url.startsWith("http://")) {
+                logger.info("Given is s3 url ...File name:" + fileName);
+                URL urlObject = new URL(url);
+                File tempFile = File.createTempFile(fileName.split("\\.")[0], "." + fileName.split("\\.")[1]);
+                FileUtils.copyURLToFile(urlObject, tempFile);
+                logger.info("Temp file created with name for s3 file" + tempFile.getName() + " at path " + tempFile.getAbsolutePath());
+                return tempFile;
+            } else {
+                logger.info("Given is local file path..");
+                return new File(url);
+            }
+        } catch (Exception e) {
+            setErrorMessage("Unable to access the given pdfs, please check the given inputs.");
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access pdfs");
+        }
+    }
+
+    public void pdfToImages(String pdfFilePath, String imageOutputDir, String type) {
+        try {
+            logger.info(String.format("Converting every page in pdf at %s path to image and storing those images" +
+                    " in directory %s", pdfFilePath, imageOutputDir));
+            PDDocument document = Loader.loadPDF(new File(pdfFilePath));
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            for (int page = 0; page < document.getNumberOfPages(); ++page) {
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300);
+                ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, page + 1), 300);
+            }
+            document.close();
+            logger.info("Pdf to image conversion successful for the pdf " + pdfFilePath);
+        } catch (IOException e) {
+            String message = "Unable to convert pdf into image pages";
+            logger.info(String.format("Exception while converting pdf %s into pages: %s", pdfFilePath,
+                    ExceptionUtils.getStackTrace(e)));
+            setErrorMessage(message);
+            throw new RuntimeException(message);
+        }
+    }
+
+    public boolean performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            OkHttpClient client = new OkHttpClient();
+            logger.info("Initiating http client");
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            logger.info("Making api call to visual server");
+            Response response = client.newCall(request).execute();
+            if (response.isSuccessful()) {
+                logger.info("Response is successful");
+                if (response.body() != null) {
+                    logger.info("Response body received");
+                    String responseBody = response.body().string();
+                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                    logger.info("Deserialized the response body");
+                    double percentage = responseObject.getPer_similar();
+                    logger.info("Percentage similarity: " + percentage * 100);
+                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                } else {
+                    setErrorMessage(String.format("Visual testing failed at <b>page %s</b> no response body " +
+                            "present in the visual test response", page));
+                    throw new RuntimeException("Visual testing failed with no response body");
+                }
+            } else {
+                setErrorMessage(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                        page));
+                throw new RuntimeException("Visual testing failed with internal server error");
+            }
+        } catch (IOException e) {
+
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            setErrorMessage(String.format("Unable to perform visual testing for : <b>page %s</b>", page));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page);
+        }
+    }
+
+    private boolean uploadFile(String s3SignedURL, String localPath) {
+        logger.debug("s3SignedURL - " + s3SignedURL);
+        logger.debug("localPath - " + localPath);
+        boolean localUrlExists = new File(localPath).exists();
+        if (localUrlExists) {
+            logger.info(String.format("Uploading test asset to storage, presigned-URL:%s, localFilePath:%s", s3SignedURL, localPath));
+            try (CloseableHttpClient httpclient = HttpClients.custom().setDefaultRequestConfig(config).build()) {
+                HttpPut httpPut = new HttpPut(s3SignedURL);
+
+                File file = new File(localPath);
+                HttpEntity entity = EntityBuilder.create().setFile(file).build();
+                httpPut.setEntity(entity);
+                HttpResponse response = httpclient.execute(httpPut);
+                logger.info("Response from s3: " + response.getStatusLine().getStatusCode());
+                logger.info("Upload completed");
+                return true;
+            } catch (Exception e) {
+                logger.info("Exception while uploading custom screenshot to s3: "+ExceptionUtils.getStackTrace(e));
+                return false;
+            }
+        }
+        else {
+            logger.info("Local path does not exist");
+            return false;
+        }
+    }
+
+    private BufferedImage mergeImagesAndHighlightDifferences(BufferedImage baseImage, BufferedImage overlayImage, BufferedImage combined, List<Coordinate> coordinates) {
+        int height = Math.max(baseImage.getHeight(), overlayImage.getHeight());
+        int width = baseImage.getWidth() + overlayImage.getWidth();
+
+        if (combined == null) {
+            combined = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        }
+
+        Graphics2D g2d = combined.createGraphics();
+        g2d.setColor(Color.WHITE); // Optional: Set a background color
+        g2d.fillRect(0, 0, width, height); // Optional: Fill the background
+
+        g2d.drawImage(baseImage, 0, 0, null);
+        g2d.drawImage(overlayImage, baseImage.getWidth(), 0, null);
+
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f)); // 0.5f for 50% transparency
+
+        // Set the color for filling rectangles
+        g2d.setColor(new Color(255, 0, 0)); // Red color
+
+        // Iterate over the list of coordinates and fill rectangles
+        for (Coordinate coordinate : coordinates) {
+            g2d.fillRect(coordinate.getX(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+        }
+
+        for (Coordinate coordinate : coordinates) {
+            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+        }
+
+        g2d.dispose();
+
+        return combined;
+    }
+
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
@@ -94,7 +94,7 @@ public class PDFVisualTestingForGivenPage extends WebAction {
             File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
             File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
 
-            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+            if (!basePDF.getName().endsWith(".pdf") || !actualPDF.getName().endsWith(".pdf")) {
                 String message = "Unsupported file types give only pdf files as input, screenshot" +
                         " might not be displayed";
                 errorMessageBuilder.append(message);

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
@@ -1,0 +1,296 @@
+package com.testsigma.addons.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.PDFUtils;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.TestStepResult;
+import lombok.Data;
+import okhttp3.*;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.ParseException;
+import org.apache.http.client.config.RequestConfig;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Data
+@Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
+        " same for page page-number by performing visual analysis",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis. (indexing starts from 1)",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = true)
+public class PDFVisualTestingForGivenPage extends WebAction {
+
+    @TestData(reference = "base-pdf-file-path")
+    private com.testsigma.sdk.TestData basePdfPath_;
+
+    @TestData(reference = "actual-pdf-file-path")
+    private com.testsigma.sdk.TestData actualPdfPath_;
+
+    @TestData(reference = "page-number")
+    private com.testsigma.sdk.TestData pageNumber_;
+
+    @TestStepResult
+    private com.testsigma.sdk.TestStepResult testStepResult;
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+    ObjectMapper mapper = new ObjectMapper();
+    ResponseObject responseObject = new ResponseObject();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+        String basePdfPath = basePdfPath_.getValue().toString();
+        String actualPdfPath = actualPdfPath_.getValue().toString();
+        PDFUtils pdfUtils = new PDFUtils(driver, logger);
+
+        try {
+            // Use StringBuilder to capture error messages
+            StringBuilder errorMessageBuilder = new StringBuilder();
+            result = checkBaseConditions(basePdfPath, actualPdfPath, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+                return result;
+            }
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            result = performVisualTesting(basePdfPath, actualPdfPath, page, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+            }
+            setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. " +
+                    "(Note: Step screenshot contains the image of actual PDF)");
+        } catch (RuntimeException e) {
+            logger.info("Runtime Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, PDFUtils pdfUtils,
+                                       StringBuilder errorMessageBuilder) {
+        try {
+            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+                String message = "Unsupported file types give only pdf files as input, screenshot" +
+                        " might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!basePDF.exists()) {
+                String message = "Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input, screenshot might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!actualPDF.exists()) {
+                String message = "Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
+                        ", please given valid file input. (Note: screenshot is not displayed)";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
+            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
+
+            if (basePdfPageCount != actualPdfPageCount) {
+                String message = "Number of pages in the base pdf and actual pdf are not same, " +
+                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
+                        + actualPdfPageCount + "</b>";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            if (page > basePdfPageCount) {
+                logger.info(String.format("page = %s, base pdf page count = %s", page, actualPdfPageCount));
+                String message = String.format("given page number is greater than the number of pages in base pdf. " +
+                                "page number = <b>%s</b> and base pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
+                        page, basePdfPageCount);
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (ParseException e) {
+            String message = "Unsupported input for page-number, please provide a valid integer value " +
+                    "(Note: screenshot is not displayed)";
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation : " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        }
+        return Result.SUCCESS;
+    }
+
+    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page, PDFUtils pdfUtils,
+                                        StringBuilder errorMessageBuilder) {
+        try {
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            File combinedImage = File.createTempFile("combined", ".png");
+            logger.info("Converting pages of both pdfs to images");
+            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
+            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
+            logger.info("Converted both pdf pages into images");
+
+            logger.info("Validating the pages of images at both directories");
+            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
+            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
+            if (basePdfDirImages == null || actualPdfDirImages == null) {
+                String message = "Unable to retrieve pages from the pdfs, make sure both pdfs " +
+                        "are not empty and accessible";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+            logger.info("Initiating visual testing");
+            boolean compareResult = true;
+            BufferedImage combined = null;
+
+            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+            if (file1.exists() && file2.exists()) {
+                BufferedImage baseImage = ImageIO.read(file1);
+                BufferedImage actualImage = ImageIO.read(file2);
+
+                boolean apiResult = performApiCall(file1, file2, page, errorMessageBuilder);
+                if (!apiResult) {
+                    compareResult = false;
+                    logger.info("dissimilarities found in the pdfs, creating side-by-side image");
+                    logger.info("responseObject " + responseObject.getDiff_coordinates());
+                    logger.info("responseObject " + responseObject);
+                    combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
+                            combined, responseObject.getDiff_coordinates());
+                    logger.info("Created side-by-side image");
+                }
+            }
+            return uploadScreenshot(compareResult, actualPdfDirImages, combined, combinedImage, errorMessageBuilder);
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during visual testing: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+    }
+
+    private Result uploadScreenshot(boolean compareResult, File[] actualPdfDirImages, BufferedImage combined,
+                                    File combinedImage, StringBuilder errorMessageBuilder) {
+        try {
+            PDFUtils pdfUtils = new PDFUtils(driver, logger);
+            String s3Url = testStepResult.getScreenshotUrl();
+            if (compareResult) {
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to s3," +
+                            " screenshot might not be displayed");
+                }
+                logger.info("Upload complete.");
+                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing." +
+                        " (Note: Step screenshot contains the image of actual PDF)");
+            } else {
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.debug("Error occurred while uploading combined image to S3," +
+                            " screenshot might not be displayed");
+                }
+                String message = "Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during screenshot upload: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+        return Result.SUCCESS;
+    }
+
+    public boolean performApiCall(File baseImage, File actualImage, int page, StringBuilder errorMessageBuilder) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            OkHttpClient client = new OkHttpClient();
+            logger.info("Initiating http client");
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            logger.info("Making api call to visual server");
+            Response response = client.newCall(request).execute();
+            if (response.isSuccessful()) {
+                logger.info("Response is successful");
+                if (response.body() != null) {
+                    logger.info("Response body received");
+                    String responseBody = response.body().string();
+                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                    logger.info("Deserialized the response body");
+                    double percentage = responseObject.getPer_similar();
+                    logger.info("Percentage similarity: " + percentage * 100);
+                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                } else {
+                    errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> no response" +
+                            " body present in the visual test response", page));
+                    throw new RuntimeException("Visual testing failed with no response body");
+                }
+            } else {
+                errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                        page));
+                throw new RuntimeException("Visual testing failed with internal server error");
+            }
+        } catch (IOException e) {
+            errorMessageBuilder.append(String.format("Exception occurred while performing visual test at page %s : %s",
+                    page, ExceptionUtils.getStackTrace(e)));
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page);
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Constants.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Constants.java
@@ -1,0 +1,6 @@
+package com.testsigma.addons.web.util;
+
+public class Constants {
+    public static String VISUAL_SERVER_API_END_POINT = "https://visualtesting-staging.testsigma.com/image_analysis_with_files";
+    public static String API_TOKEN = "DHRNEYFTDCDGOEDDCOEICVYOEEUY";
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Constants.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Constants.java
@@ -2,5 +2,5 @@ package com.testsigma.addons.web.util;
 
 public class Constants {
     public static String VISUAL_SERVER_API_END_POINT = "https://visualtesting-staging.testsigma.com/image_analysis_with_files";
-    public static String API_TOKEN = "DHRNEYFTDCDGOEDDCOEICVYOEEUY";
+    public static String API_TOKEN = "<TOKEN>";
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Coordinate.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/Coordinate.java
@@ -1,0 +1,11 @@
+package com.testsigma.addons.web.util;
+
+import lombok.Data;
+
+@Data
+public class Coordinate {
+    private int x;
+    private int y;
+    private int w;
+    private int h;
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/CoordinateListDeserializer.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/CoordinateListDeserializer.java
@@ -1,0 +1,20 @@
+package com.testsigma.addons.web.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+public class CoordinateListDeserializer extends JsonDeserializer<List<Coordinate>> {
+    @Override
+    public List<Coordinate> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        String coordinatesJson = p.getText();
+        return mapper.readValue(coordinatesJson, mapper.getTypeFactory().constructCollectionType(List.class, Coordinate.class));
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/PDFUtils.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/PDFUtils.java
@@ -1,0 +1,200 @@
+package com.testsigma.addons.web.util;
+
+import com.testsigma.sdk.Logger;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+import org.openqa.selenium.WebDriver;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+public class PDFUtils {
+    WebDriver driver;
+    Logger logger;
+
+    public PDFUtils(WebDriver driver, Logger logger) {
+        this.driver = driver;
+        this.logger = logger;
+    }
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+
+    public File urlToFileConverter(String fileName, String url) {
+        try {
+            if (url.startsWith("https://") || url.startsWith("http://")) {
+                logger.info("Given is s3 url ...File name:" + fileName);
+                URL urlObject = new URL(url);
+                File tempFile = File.createTempFile(fileName.split("\\.")[0], "."
+                        + fileName.split("\\.")[1]);
+                FileUtils.copyURLToFile(urlObject, tempFile);
+                logger.info("Temp file created with name for s3 file" + tempFile.getName()
+                        + " at path " + tempFile.getAbsolutePath());
+                return tempFile;
+            } else {
+                logger.info("Given is local file path..");
+                return new File(url);
+            }
+        } catch (Exception e) {
+//            setErrorMessage("Unable to access the given pdfs, please check the given inputs.");
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access the given pdfs, please check the given inputs.");
+        }
+    }
+
+
+    public boolean uploadFile(String s3SignedURL, String localPath) {
+        logger.debug("s3SignedURL - " + s3SignedURL);
+        logger.debug("localPath - " + localPath);
+        boolean localUrlExists = new File(localPath).exists();
+        if (localUrlExists) {
+            logger.info(String.format("Uploading test asset to storage, presigned-URL:%s, localFilePath:%s", s3SignedURL, localPath));
+            try (CloseableHttpClient httpclient = HttpClients.custom().setDefaultRequestConfig(config).build()) {
+                HttpPut httpPut = new HttpPut(s3SignedURL);
+
+                File file = new File(localPath);
+                HttpEntity entity = EntityBuilder.create().setFile(file).build();
+                httpPut.setEntity(entity);
+                HttpResponse response = httpclient.execute(httpPut);
+                logger.info("Upload completed");
+                return true;
+            } catch (Exception e) {
+                logger.info("Exception while uploading custom screenshot to s3: " + ExceptionUtils.getStackTrace(e));
+                return false;
+            }
+        } else {
+            logger.info("Local path does not exist");
+            return false;
+        }
+    }
+
+    public BufferedImage mergeImagesAndHighlightDifferences(BufferedImage baseImage, BufferedImage overlayImage,
+                                                            BufferedImage combined, List<Coordinate> coordinates) {
+        try {
+//            logger.info("Coordinates: " + coordinates.size());
+            logger.info("Coordinates: " + coordinates);
+            int height = Math.max(baseImage.getHeight(), overlayImage.getHeight());
+            int width = baseImage.getWidth() + overlayImage.getWidth();
+            logger.info("Height: " + height + ", Width: " + width);
+            if (combined == null) {
+                combined = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            }
+
+            Graphics2D g2d = combined.createGraphics();
+            g2d.setColor(Color.WHITE); // Optional: Set a background color
+            g2d.fillRect(0, 0, width, height); // Optional: Fill the background
+
+            g2d.drawImage(baseImage, 0, 0, null);
+            g2d.drawImage(overlayImage, baseImage.getWidth(), 0, null);
+
+            g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f)); // 0.5f for 50% transparency
+
+            // Set the color for filling rectangles
+            g2d.setColor(new Color(255, 0, 0)); // Red color
+
+            // Iterate over the list of coordinates and fill rectangles
+            for (Coordinate coordinate : coordinates) {
+                g2d.fillRect(coordinate.getX(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+            }
+
+            for (Coordinate coordinate : coordinates) {
+                g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY(),
+                        coordinate.getW(), coordinate.getH());
+            }
+
+            g2d.dispose();
+        } catch (Exception e) {
+            logger.debug("Error while merging images and highlighting differences: " + ExceptionUtils.getStackTrace(e));
+            throw new RuntimeException(e);
+        }
+        logger.info("Images merged and differences highlighted");
+        return combined;
+    }
+
+
+    public int getPdfPageCount(File pdfFile) {
+        try {
+            PDDocument document = Loader.loadPDF(pdfFile);
+            int numberOfPagesInPdf = document.getNumberOfPages();
+            document.close();
+            return numberOfPagesInPdf;
+        } catch (IOException e) {
+            logger.info("Exception while getting the number of pages in the pdf: " + ExceptionUtils.getStackTrace(e));
+            return -1;
+        }
+    }
+
+
+    public void pdfToImage(String pdfFilePath, String imageOutputDir, String type, int index) {
+        try {
+            logger.info(String.format("Converting page %d in pdf to image and storing in directory %s",
+                    index, imageOutputDir));
+
+            // Handle S3 URL by downloading to a temporary file first
+            File pdfFile;
+            if (pdfFilePath.startsWith("http://") || pdfFilePath.startsWith("https://")) {
+                String tempFileName = "temp_" + System.currentTimeMillis() + ".pdf";
+                pdfFile = downloadFromUrl(pdfFilePath, tempFileName);
+                logger.info("Downloaded S3 URL to temporary file: " + pdfFile.getAbsolutePath());
+            } else {
+                // This is a local file path
+                pdfFile = new File(pdfFilePath);
+            }
+
+            // Now process the PDF file
+            PDDocument document = Loader.loadPDF(pdfFile);
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            BufferedImage bim = pdfRenderer.renderImageWithDPI(index - 1, 300);
+            ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, index), 300);
+            document.close();
+
+            // Clean up temp file if we created one
+            if (pdfFilePath.startsWith("http")) {
+                boolean deleted = pdfFile.delete();
+                if (deleted) {
+                    logger.info("Temporary PDF file deleted successfully");
+                }
+            }
+
+            logger.info("Pdf to image conversion successful for page " + index);
+        } catch (IOException e) {
+            String message = "Unable to convert pdf into image pages: " + e.getMessage();
+            logger.info(String.format("Exception while converting pdf %s into pages: %s", pdfFilePath,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException(message);
+        }
+    }
+
+    // Helper method to download from URL to a local file
+    private File downloadFromUrl(String url, String fileName) throws IOException {
+        File tempFile = File.createTempFile(fileName, ".pdf");
+        try (InputStream in = new URL(url).openStream()) {
+            Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return tempFile;
+    }
+
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/ResponseObject.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/ResponseObject.java
@@ -1,0 +1,16 @@
+package com.testsigma.addons.web.util;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ResponseObject {
+    @JsonDeserialize(using = CoordinateListDeserializer.class)
+    private List<Coordinate> diff_coordinates;
+    private String error;
+    private List<Integer> image_shape;
+    private double per_similar;
+    private String scalingType;
+}


### PR DESCRIPTION
first NLP gets the page count and stores it in runtime variable.
second NLP performs visual testing for the given page number.

Added PDFUtils class for code reuseablity...

Jira : https://testsigma.atlassian.net/browse/CR-2008
Addon Name: PDF visual testing
account: rajesh@testsigmatech.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added robust PDF visual testing capabilities that convert pages to images, compare them visually, and highlight differences.
  - Introduced functionality to decode Base64 data directly into files.
  - Enabled retrieval of PDF page counts.
  - Provided targeted visual testing for specific pages, offering detailed diagnostics for PDF consistency.
  - Added utility methods for handling PDF files and images, including file uploads and image merging.
  
- **New Classes**
  - Introduced several new classes to enhance PDF handling and visual testing, including `DecodeBase64`, `GetThePageCountOfPDF`, `PDFVisualTesting`, `PDFVisualTestingForGivenPage`, `PDFUtils`, `ResponseObject`, and utility classes for coordinates and constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->