### PR TITLE
feat/CR-2137-Added tap the second character in the element to android

### DIFF
--- a/tap_the_second_character_in_the_element/pom.xml
+++ b/tap_the_second_character_in_the_element/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>tap_the_second_character_in_the_element</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -17,7 +17,7 @@
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
     </properties>
 
@@ -61,6 +61,12 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.13.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+
 
     </dependencies>
     <build>

--- a/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/android/TapSecondCharacter.java
+++ b/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/android/TapSecondCharacter.java
@@ -1,0 +1,57 @@
+package com.testsigma.addons.android;
+
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.Element;
+import io.appium.java_client.TouchAction;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.touch.offset.PointOption;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+@Data
+@Action(actionText = "Tap the second character in the element element-locator",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class TapSecondCharacter extends AndroidAction {
+
+  @Element(reference = "element-locator")
+  private com.testsigma.sdk.Element element;
+
+  @Override
+  protected com.testsigma.sdk.Result execute() throws NoSuchElementException {
+    com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+    logger.info("Initiating execution");
+    logger.debug("Element Locator: "+ this.element.getValue() +" by:"+ this.element.getBy());
+    AndroidDriver androidDriver = (AndroidDriver)this.driver;
+    WebElement webElement = element.getElement();
+    if(webElement.isDisplayed()){
+      logger.info("Element is displayed, tapping the second character");
+      try {
+        int elementLeft = webElement.getLocation().getX();
+        int elementTop = webElement.getLocation().getY();
+        int elementWidth = webElement.getSize().getWidth();
+        int elementHeight = webElement.getSize().getHeight();
+
+        int y_offset = elementTop + (int)(elementHeight * 0.2);
+        int x_offset = elementLeft + (int)(elementWidth * 0.1);
+
+        TouchAction touchAction = new TouchAction(androidDriver);
+        touchAction.tap(PointOption.point(x_offset, y_offset)).perform();
+        setSuccessMessage("Successfully tapped the second character in the element");
+      } catch (Exception e) {
+        result = com.testsigma.sdk.Result.FAILED;
+        logger.warn("Failed to tap the second character in the element " + ExceptionUtils.getStackTrace(e));
+        setErrorMessage("Failed to tap the second character in the element: " + ExceptionUtils.getStackTrace(e));
+      }
+    }else{
+      result = com.testsigma.sdk.Result.FAILED;
+      logger.warn("Element with locator %s is not visible ::"+element.getBy()+"::"+element.getValue());
+      setErrorMessage(String.format("Element with locator %s is not visible",element.getBy()));
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Addon Name: Tap the second character in the element
account : appini.akhil@testsigma.com

Jira : https://testsigma.atlassian.net/browse/CR-2137
Added tap the second character in the element to android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new action that allows users to tap the second character within a specified UI element on Android devices.

- **Chores**
  - Updated project and dependency versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->