### PR TITLE
[TE-26961] Add-On to store the count of non-empty cells in a Excel file.

### DIFF
--- a/excelActions_cloud/src/main/java/com/testsigma/addons/util/PdfAndDocUtilities.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/util/PdfAndDocUtilities.java
@@ -1,6 +1,9 @@
 package com.testsigma.addons.util;
 
 import com.testsigma.sdk.Logger;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -137,5 +140,63 @@ public class PdfAndDocUtilities {
 
     }
 
+    public static int calculateExcelDataCount(String countType, XSSFSheet sheet) {
+        int count = 0;
+
+        if (countType.equalsIgnoreCase("non-empty cells")) {
+            count = countNonEmptyCells(sheet);
+        } else if (countType.equalsIgnoreCase("rows")) {
+            count = countNonEmptyRows(sheet);
+        } else if (countType.equalsIgnoreCase("columns")) {
+            count = countMaxColumns(sheet);
+        }
+
+        return count;
+    }
+
+    private static int countNonEmptyCells(XSSFSheet sheet) {
+        int cellCount = 0;
+        for (int i = 0; i <= sheet.getLastRowNum(); i++) {
+            if (sheet.getRow(i) != null) {
+                for (int j = 0; j < sheet.getRow(i).getPhysicalNumberOfCells(); j++) {
+                    if (sheet.getRow(i).getCell(j) != null && !sheet.getRow(i).getCell(j).toString().isEmpty()) {
+                        cellCount++;
+                    }
+                }
+            }
+        }
+        return cellCount;
+    }
+
+    private static int countNonEmptyRows(XSSFSheet sheet) {
+        int rowCount = 0;
+        for (Row row : sheet) {
+            boolean hasData = false;
+            for (Cell cell : row) {
+                if (cell != null && !cell.toString().trim().isEmpty()) {
+                    hasData = true;
+                    break;
+                }
+            }
+            if (hasData) rowCount++;
+        }
+        return rowCount;
+    }
+
+    private static int countMaxColumns(XSSFSheet sheet) {
+        int maxColumnCount = 0;
+        for (Row row : sheet) {
+            int currentColumnCount = 0;
+            for (Cell cell : row) {
+                if (cell != null && !cell.toString().trim().isEmpty()) {
+                    currentColumnCount = cell.getColumnIndex() + 1; // +1 because column index is zero-based
+                }
+            }
+            if (currentColumnCount > maxColumnCount) {
+                maxColumnCount = currentColumnCount;
+            }
+        }
+        return maxColumnCount;
+    }
 
 }

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
@@ -115,7 +115,7 @@ public class StoreNonEmptyCellCount extends WebAction {
                 logger.info("Given is s3 url ...");
                 URL urlObject = new URL(url);
                 File tempFile = File.createTempFile("tempExcelFile", "."
-                        + ".xlsx");
+                        + "xlsx");
                 FileUtils.copyURLToFile(urlObject, tempFile);
                 logger.info("Temp file created with name for s3 file" + tempFile.getName()
                         + " at path " + tempFile.getAbsolutePath());

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
@@ -67,7 +67,7 @@ public class StoreNonEmptyCellCount extends WebAction {
                         runTimeData.getKey() + " = " + runTimeData.getValue());
             } else if (testData1.getValue().toString().equalsIgnoreCase("rows")) {
                 // using the below logic instead of sheet.getPhysicalNumberOfRows() as it is returning larger values
-                // then expected no of rows...
+                // than expected no of rows...
                 int rowCount = 0;
                 for (Row row : sheet) {
                     boolean hasData = false;
@@ -81,7 +81,7 @@ public class StoreNonEmptyCellCount extends WebAction {
                 }
                 runTimeData.setValue(rowCount);
                 runTimeData.setKey(testData3.getValue().toString());
-                setSuccessMessage("Successfully stored the number of cells from excel file " +
+                setSuccessMessage("Successfully stored the number of rows from excel file " +
                         runTimeData.getKey() + " = " + runTimeData.getValue());
             } else if (testData1.getValue().toString().equalsIgnoreCase("columns")) {
                 int maxColumns = 0;
@@ -98,7 +98,7 @@ public class StoreNonEmptyCellCount extends WebAction {
                 }
                 runTimeData.setValue(maxColumns);
                 runTimeData.setKey(testData3.getValue().toString());
-                setSuccessMessage("Successfully stored the number of cells from excel file " +
+                setSuccessMessage("Successfully stored the number of columns from excel file " +
                         runTimeData.getKey() + " = " + runTimeData.getValue());
             }
             return result;

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
@@ -1,6 +1,6 @@
 package com.testsigma.addons.web;
 
-
+import com.testsigma.addons.util.PdfAndDocUtilities;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
@@ -9,8 +9,6 @@ import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
@@ -25,13 +23,12 @@ import java.net.URL;
         useCustomScreenshot = false)
 public class StoreNonEmptyCellCount extends WebAction {
 
-
     @TestData(reference = "test-data", allowedValues = {"Non-Empty cells", "Rows", "Columns"})
-    private com.testsigma.sdk.TestData testData1;
+    private com.testsigma.sdk.TestData countTypeData;
     @TestData(reference = "file-url")
-    private com.testsigma.sdk.TestData testData2;
+    private com.testsigma.sdk.TestData fileUrlData;
     @TestData(reference = "runtime-variable", isRuntimeVariable = true)
-    private com.testsigma.sdk.TestData testData3;
+    private com.testsigma.sdk.TestData runtimeVariableName;
 
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;
@@ -40,94 +37,50 @@ public class StoreNonEmptyCellCount extends WebAction {
     public com.testsigma.sdk.Result execute() {
         com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
         logger.info("Initiating execution");
-        logger.info("test-data: " + testData1.getValue().toString());
-        logger.info("file url: " + testData2.getValue().toString());
+        logger.info("Count type: " + countTypeData.getValue().toString());
+        logger.info("File URL: " + fileUrlData.getValue().toString());
 
         try {
-            File newFile = urlToFileConverter(testData2.getValue().toString());
-            logger.info("getting the workbook");
-            FileInputStream inputStream = new FileInputStream(newFile);
-            XSSFWorkbook wb = new XSSFWorkbook(inputStream);
+            File excelFile = downloadFileFromUrl(fileUrlData.getValue().toString());
+            logger.info("Opening workbook");
+            FileInputStream inputStream = new FileInputStream(excelFile);
+            XSSFWorkbook workbook = new XSSFWorkbook(inputStream);
 
-            logger.info("got the workbook");
-            XSSFSheet sheet = wb.getSheetAt(0);
-            if (testData1.getValue().toString().equalsIgnoreCase("non-empty cells")) {
-                int nonEmptyCellCount = 0;
-                for (int i = 0; i <= sheet.getLastRowNum(); i++) {
-                    for (int j = 0; j < sheet.getRow(i).getPhysicalNumberOfCells(); j++) {
-                        if (sheet.getRow(i).getCell(j) != null && !sheet.getRow(i).getCell(j).toString().isEmpty()) {
-                            nonEmptyCellCount++;
-                        }
-                    }
-                }
-                logger.info("non-empty cell count: " + nonEmptyCellCount);
-                runTimeData.setValue(nonEmptyCellCount);
-                runTimeData.setKey(testData3.getValue().toString());
-                setSuccessMessage("Successfully stored the count of non-empty cells from excel file " +
-                        runTimeData.getKey() + " = " + runTimeData.getValue());
-            } else if (testData1.getValue().toString().equalsIgnoreCase("rows")) {
-                // using the below logic instead of sheet.getPhysicalNumberOfRows() as it is returning larger values
-                // than expected no of rows...
-                int rowCount = 0;
-                for (Row row : sheet) {
-                    boolean hasData = false;
-                    for (Cell cell : row) {
-                        if (cell != null && !cell.toString().trim().isEmpty()) {
-                            hasData = true;
-                            break;
-                        }
-                    }
-                    if (hasData) rowCount++;
-                }
-                runTimeData.setValue(rowCount);
-                runTimeData.setKey(testData3.getValue().toString());
-                setSuccessMessage("Successfully stored the number of rows from excel file " +
-                        runTimeData.getKey() + " = " + runTimeData.getValue());
-            } else if (testData1.getValue().toString().equalsIgnoreCase("columns")) {
-                int maxColumns = 0;
-                for (Row row : sheet) {
-                    int currentColCount = 0;
-                    for (Cell cell : row) {
-                        if (cell != null && !cell.toString().trim().isEmpty()) {
-                            currentColCount = cell.getColumnIndex() + 1; // +1 because column index is zero-based
-                        }
-                    }
-                    if (currentColCount > maxColumns) {
-                        maxColumns = currentColCount;
-                    }
-                }
-                runTimeData.setValue(maxColumns);
-                runTimeData.setKey(testData3.getValue().toString());
-                setSuccessMessage("Successfully stored the number of columns from excel file " +
-                        runTimeData.getKey() + " = " + runTimeData.getValue());
-            }
+            logger.info("Successfully opened workbook");
+            XSSFSheet sheet = workbook.getSheetAt(0);
+            String countType = countTypeData.getValue().toString();
+            int calculatedCount = PdfAndDocUtilities.calculateExcelDataCount(countType, sheet);
+
+            String variableName = runtimeVariableName.getValue().toString();
+            runTimeData.setValue(calculatedCount);
+            runTimeData.setKey(variableName);
+
+            setSuccessMessage("Successfully stored the count of " + countType + " from excel file to " +
+                    variableName + " = " + calculatedCount);
             return result;
         } catch (Exception e) {
-            logger.info("Unable to read the file: " + ExceptionUtils.getStackTrace(e));
-            setErrorMessage("Unable to read the file: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Failed to read the excel file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Failed to read the excel file: " + ExceptionUtils.getStackTrace(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }
 
-    private File urlToFileConverter(String url) {
+    private File downloadFileFromUrl(String url) {
         try {
             if (url.startsWith("https://") || url.startsWith("http://")) {
-                logger.info("Given is s3 url ...");
+                logger.info("Processing remote URL...");
                 URL urlObject = new URL(url);
-                File tempFile = File.createTempFile("tempExcelFile", "."
-                        + "xlsx");
+                File tempFile = File.createTempFile("excelData", ".xlsx");
                 FileUtils.copyURLToFile(urlObject, tempFile);
-                logger.info("Temp file created with name for s3 file" + tempFile.getName()
-                        + " at path " + tempFile.getAbsolutePath());
+                logger.info("Temporary file created: " + tempFile.getName() + " at path: " + tempFile.getAbsolutePath());
                 return tempFile;
             } else {
-                logger.info("Given is local file path..");
+                logger.info("Processing local file path...");
                 return new File(url);
             }
         } catch (Exception e) {
-            logger.info("Error while accessing: " + url);
-            throw new RuntimeException("Unable to access the given pdfs, please check the given inputs.");
+            logger.info("Error accessing file: " + url);
+            throw new RuntimeException("Unable to access the specified Excel file. Please check the provided URL or file path.");
         }
     }
-
 }

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
@@ -1,0 +1,133 @@
+package com.testsigma.addons.web;
+
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+
+@Data
+@Action(actionText = "Store the count of test-data from the excel file file-url into runtime variable runtime-variable",
+        description = "Read the data from latest excel file",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class StoreNonEmptyCellCount extends WebAction {
+
+
+    @TestData(reference = "test-data", allowedValues = {"Non-Empty cells", "Rows", "Columns"})
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "file-url")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "runtime-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        logger.info("Initiating execution");
+        logger.info("test-data: " + testData1.getValue().toString());
+        logger.info("file url: " + testData2.getValue().toString());
+
+        try {
+            File newFile = urlToFileConverter(testData2.getValue().toString());
+            logger.info("getting the workbook");
+            FileInputStream inputStream = new FileInputStream(newFile);
+            XSSFWorkbook wb = new XSSFWorkbook(inputStream);
+
+            logger.info("got the workbook");
+            XSSFSheet sheet = wb.getSheetAt(0);
+            if (testData1.getValue().toString().equalsIgnoreCase("non-empty cells")) {
+                int nonEmptyCellCount = 0;
+                for (int i = 0; i <= sheet.getLastRowNum(); i++) {
+                    for (int j = 0; j < sheet.getRow(i).getPhysicalNumberOfCells(); j++) {
+                        if (sheet.getRow(i).getCell(j) != null && !sheet.getRow(i).getCell(j).toString().isEmpty()) {
+                            nonEmptyCellCount++;
+                        }
+                    }
+                }
+                logger.info("non-empty cell count: " + nonEmptyCellCount);
+                runTimeData.setValue(nonEmptyCellCount);
+                runTimeData.setKey(testData3.getValue().toString());
+                setSuccessMessage("Successfully stored the count of non-empty cells from excel file " +
+                        runTimeData.getKey() + " = " + runTimeData.getValue());
+            } else if (testData1.getValue().toString().equalsIgnoreCase("rows")) {
+                // using the below logic instead of sheet.getPhysicalNumberOfRows() as it is returning larger values
+                // then expected no of rows...
+                int rowCount = 0;
+                for (Row row : sheet) {
+                    boolean hasData = false;
+                    for (Cell cell : row) {
+                        if (cell != null && !cell.toString().trim().isEmpty()) {
+                            hasData = true;
+                            break;
+                        }
+                    }
+                    if (hasData) rowCount++;
+                }
+                runTimeData.setValue(rowCount);
+                runTimeData.setKey(testData3.getValue().toString());
+                setSuccessMessage("Successfully stored the number of cells from excel file " +
+                        runTimeData.getKey() + " = " + runTimeData.getValue());
+            } else if (testData1.getValue().toString().equalsIgnoreCase("columns")) {
+                int maxColumns = 0;
+                for (Row row : sheet) {
+                    int currentColCount = 0;
+                    for (Cell cell : row) {
+                        if (cell != null && !cell.toString().trim().isEmpty()) {
+                            currentColCount = cell.getColumnIndex() + 1; // +1 because column index is zero-based
+                        }
+                    }
+                    if (currentColCount > maxColumns) {
+                        maxColumns = currentColCount;
+                    }
+                }
+                runTimeData.setValue(maxColumns);
+                runTimeData.setKey(testData3.getValue().toString());
+                setSuccessMessage("Successfully stored the number of cells from excel file " +
+                        runTimeData.getKey() + " = " + runTimeData.getValue());
+            }
+            return result;
+        } catch (Exception e) {
+            logger.info("Unable to read the file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to read the file: " + ExceptionUtils.getStackTrace(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+
+    private File urlToFileConverter(String url) {
+        try {
+            if (url.startsWith("https://") || url.startsWith("http://")) {
+                logger.info("Given is s3 url ...");
+                URL urlObject = new URL(url);
+                File tempFile = File.createTempFile("tempExcelFile", "."
+                        + ".xlsx");
+                FileUtils.copyURLToFile(urlObject, tempFile);
+                logger.info("Temp file created with name for s3 file" + tempFile.getName()
+                        + " at path " + tempFile.getAbsolutePath());
+                return tempFile;
+            } else {
+                logger.info("Given is local file path..");
+                return new File(url);
+            }
+        } catch (Exception e) {
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access the given pdfs, please check the given inputs.");
+        }
+    }
+
+}


### PR DESCRIPTION
# JIRA 
https://testsigma.atlassian.net/browse/TE-26961

Addon Name: ExcelActions_cloud
Addon Account: nagupm@testsigmatech.com
Jarvis Link : https://jarvis.testsigma.com/ui/tenants/2817/addons


the addon nlp stores the count of these things from excel file into a runtime variable.
1. Store the count of Non-empty cells from the Excel file into the variable
2. Store the count of Rows from the Excel file into the variable
3. Store the count of colums from the Excel file into the variable

i am iterating through the cells instead of using default functions as "sheet.getPhysicalNumberOfRows()" returning larger values then the expected count...



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to count non-empty cells, rows, or columns in the first sheet of an Excel file (from a URL or local path) and store the result in a runtime variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->