### PR TITLE
feat/TE-27384-Added timeout to stop the execution

### DIFF
--- a/command_executor/pom.xml
+++ b/command_executor/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>commandprompt_actions</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -17,7 +17,7 @@
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
     </properties>
 

--- a/command_executor/src/main/java/com/testsigma/addons/web/ExecuteCommandAndStoreOutput.java
+++ b/command_executor/src/main/java/com/testsigma/addons/web/ExecuteCommandAndStoreOutput.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Data
 @Action(actionText = "Execute command and store output in a variable. Command to execute: Executable-Command , variable name: Output-Variable",
@@ -31,6 +33,8 @@ public class ExecuteCommandAndStoreOutput extends WebAction {
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;
 
+    private static final long COMMAND_TIMEOUT_SECONDS = 120; // Set timeout to 120 seconds
+
 
     @Override
     public com.testsigma.sdk.Result execute() throws NoSuchElementException {
@@ -40,7 +44,7 @@ public class ExecuteCommandAndStoreOutput extends WebAction {
         String output = null; // Initialize output to null
         try {
             String command = commandToExecute.getValue().toString();
-            CommandResult commandResult = executeCommand(command); // Assign output from executeCommand
+            CommandResult commandResult = executeCommandWithTimeout(command, COMMAND_TIMEOUT_SECONDS); // Execute with timeout
             output = commandResult.getOutput(); // Get combined output (std + err)
 
             runTimeData = new com.testsigma.sdk.RunTimeData();
@@ -59,6 +63,10 @@ public class ExecuteCommandAndStoreOutput extends WebAction {
             setSuccessMessage(message); //Always Set Success Message even the output is empty
 
 
+        } catch (TimeoutException e) {
+            result = com.testsigma.sdk.Result.FAILED;
+            setErrorMessage("Command execution timed out after " + COMMAND_TIMEOUT_SECONDS + " seconds.");
+            logger.warn("Command execution timed out: " + ExceptionUtils.getStackTrace(e));
         } catch (Exception e) {
             String errorMessage = ExceptionUtils.getStackTrace(e);
             result = com.testsigma.sdk.Result.FAILED; // Keep failure as fallback
@@ -74,6 +82,35 @@ public class ExecuteCommandAndStoreOutput extends WebAction {
         }
         return result;
     }
+
+
+    private CommandResult executeCommandWithTimeout(String command, long timeoutSeconds) throws Exception, TimeoutException {
+        CompletableFuture<CommandResult> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                return executeCommand(command); // Your original executeCommand method
+            } catch (Exception e) {
+                // Wrap the exception so it can be handled in the main thread.
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (java.util.concurrent.ExecutionException e) {
+            // Unwrap the exception thrown by executeCommand
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause; // Re-throw the original exception
+            } else {
+                throw new Exception("Error during command execution", cause);
+            }
+
+        } catch (TimeoutException e) {
+            future.cancel(true); // Interrupt the process if it's still running
+            throw e;
+        }
+    }
+
 
     private CommandResult executeCommand(String command) throws Exception {
         StringBuilder output = new StringBuilder();

--- a/command_executor/src/main/java/com/testsigma/addons/web/desktopwindows/ExecuteCommandAndStoreOutput.java
+++ b/command_executor/src/main/java/com/testsigma/addons/web/desktopwindows/ExecuteCommandAndStoreOutput.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Data
 @Action(actionText = "Execute command and store output in a variable. Command to execute: Executable-Command , variable name: Output-Variable",
@@ -32,6 +34,8 @@ public class ExecuteCommandAndStoreOutput extends WindowsAction {
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;
 
+    private static final long COMMAND_TIMEOUT_SECONDS = 120; // Set timeout to 120 seconds
+
 
     @Override
     public com.testsigma.sdk.Result execute() throws NoSuchElementException {
@@ -41,7 +45,7 @@ public class ExecuteCommandAndStoreOutput extends WindowsAction {
         String output = null; // Initialize output to null
         try {
             String command = commandToExecute.getValue().toString();
-            CommandResult commandResult = executeCommand(command); // Assign output from executeCommand
+            CommandResult commandResult = executeCommandWithTimeout(command, COMMAND_TIMEOUT_SECONDS); // Execute with timeout
             output = commandResult.getOutput(); // Get combined output (std + err)
 
             runTimeData = new com.testsigma.sdk.RunTimeData();
@@ -60,6 +64,10 @@ public class ExecuteCommandAndStoreOutput extends WindowsAction {
             setSuccessMessage(message); //Always Set Success Message even the output is empty
 
 
+        } catch (TimeoutException e) {
+            result = com.testsigma.sdk.Result.FAILED;
+            setErrorMessage("Command execution timed out after " + COMMAND_TIMEOUT_SECONDS + " seconds.");
+            logger.warn("Command execution timed out: " + ExceptionUtils.getStackTrace(e));
         } catch (Exception e) {
             String errorMessage = ExceptionUtils.getStackTrace(e);
             result = com.testsigma.sdk.Result.FAILED; // Keep failure as fallback
@@ -75,6 +83,35 @@ public class ExecuteCommandAndStoreOutput extends WindowsAction {
         }
         return result;
     }
+
+
+    private CommandResult executeCommandWithTimeout(String command, long timeoutSeconds) throws Exception, TimeoutException {
+        CompletableFuture<CommandResult> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                return executeCommand(command); // Your original executeCommand method
+            } catch (Exception e) {
+                // Wrap the exception so it can be handled in the main thread.
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            return future.get(timeoutSeconds, TimeUnit.SECONDS);
+        } catch (java.util.concurrent.ExecutionException e) {
+            // Unwrap the exception thrown by executeCommand
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause; // Re-throw the original exception
+            } else {
+                throw new Exception("Error during command execution", cause);
+            }
+
+        } catch (TimeoutException e) {
+            future.cancel(true); // Interrupt the process if it's still running
+            throw e;
+        }
+    }
+
 
     private CommandResult executeCommand(String command) throws Exception {
         StringBuilder output = new StringBuilder();


### PR DESCRIPTION
Addon Name: Commandprompt_Actions
account : nagupm@testsigmatech.com
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/TE-27384
Added timeout to stop the execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a timeout mechanism for command execution, ensuring commands that exceed 120 seconds are automatically stopped and marked as failed with a clear timeout error message.

- **Chores**
  - Updated project and Lombok dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->