### PR TITLE
feat/TE-29278-Added support to extract content from password-protected PDFs (latest download & by file name) and store content in runtime variable

### DIFF
--- a/pdfdataextractor/pom.xml
+++ b/pdfdataextractor/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>pdfdataextractor</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -17,7 +17,7 @@
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
     </properties>
 

--- a/pdfdataextractor/src/main/java/com/testsigma/addons/web/ExtractLatestDownloadedPDFFileContentUsingPassword.java
+++ b/pdfdataextractor/src/main/java/com/testsigma/addons/web/ExtractLatestDownloadedPDFFileContentUsingPassword.java
@@ -1,0 +1,84 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.PdfDocUtilities;
+import com.testsigma.addons.web.util.PdfDocUtilitiesFactory;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+
+@Data
+@Action(
+        actionText = "PDF: Extract content from latest file in the downloads with password password-value and store it in runtime-variable variable-name",
+        description = "Extracts content from latest downloaded file in the downloads and stores that content in a run time variable",
+        applicationType = ApplicationType.WEB
+)
+public class ExtractLatestDownloadedPDFFileContentUsingPassword extends WebAction {
+
+    @TestData(reference = "password-value")
+    private com.testsigma.sdk.TestData passwordValue;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        PdfDocUtilities pdfAndDocUtilities = PdfDocUtilitiesFactory.create(driver, logger);
+
+        try {
+            logger.info("Initiated execution");
+
+            // Get the latest downloaded PDF file
+            File downloadedPdfFile = pdfAndDocUtilities.copyFileFromDownloads("pdf", null);
+            logger.info("Local path: " + downloadedPdfFile.getAbsolutePath());
+
+            // Load PDF with password
+            PDDocument document = Loader.loadPDF(downloadedPdfFile, passwordValue.getValue().toString());
+            try {
+                if (document.isEncrypted()) {
+                    logger.info("PDF was encrypted, but opened successfully with the provided password.");
+                }
+
+                // Extract content
+                PDFTextStripper pdfTextStripper = new PDFTextStripper();
+                String fileContent = pdfTextStripper.getText(document);
+
+                // Store in runtime variable
+                runTimeData.setKey(runtimeVariable.getValue().toString());
+                runTimeData.setValue(fileContent);
+
+                logger.info("File content: " + fileContent);
+                setSuccessMessage("Successfully extracted the data in the file and stored in run time variable "
+                        + runTimeData.getKey() + " value : " + runTimeData.getValue());
+            } finally {
+                document.close();
+            }
+
+        } catch (RuntimeException e) {
+            logger.info("Unable to find the latest file in the downloads " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to find the latest file in the downloads");
+            result = Result.FAILED;
+
+        } catch (Exception e) {
+            logger.info(ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to read the content in the given pdf file");
+            result = Result.FAILED;
+        }
+
+        return result;
+    }
+}

--- a/pdfdataextractor/src/main/java/com/testsigma/addons/web/ExtractPDFFileContentBasedOnFileNameUsingPassword.java
+++ b/pdfdataextractor/src/main/java/com/testsigma/addons/web/ExtractPDFFileContentBasedOnFileNameUsingPassword.java
@@ -1,0 +1,93 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.PdfDocUtilities;
+import com.testsigma.addons.web.util.PdfDocUtilitiesFactory;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+
+@Data
+@Action(
+        actionText = "PDF: Extract content from the file file-name with password password-value from the downloads and store it in runtime-variable variable-name",
+        description = "Extracts content by accessing the given file in the downloads (with password if required) and stores that content in a run time variable",
+        applicationType = ApplicationType.WEB
+)
+public class ExtractPDFFileContentBasedOnFileNameUsingPassword extends WebAction {
+
+    @TestData(reference = "file-name")
+    private com.testsigma.sdk.TestData fileName;
+
+    @TestData(reference = "password-value")
+    private com.testsigma.sdk.TestData passwordValue;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        PdfDocUtilities pdfAndDocUtilities = PdfDocUtilitiesFactory.create(driver, logger);
+
+        try {
+            logger.info("Initiated execution");
+            logger.info("File name: " + fileName.getValue().toString());
+
+            // Get the given PDF from downloads
+            File downloadedPdfFile = pdfAndDocUtilities.copyFileFromDownloads("pdf", fileName.getValue().toString());
+            logger.info("Local path: " + downloadedPdfFile.getAbsolutePath());
+
+            // Load the PDF with password
+            PDDocument document = Loader.loadPDF(downloadedPdfFile, passwordValue.getValue().toString());
+            try {
+                if (document.isEncrypted()) {
+                    logger.info("PDF was encrypted, opened successfully with the provided password.");
+                }
+
+                // Extract text
+                PDFTextStripper pdfTextStripper = new PDFTextStripper();
+                String fileContent = pdfTextStripper.getText(document);
+
+                // Store in runtime variable
+                runTimeData.setKey(runtimeVariable.getValue().toString());
+                runTimeData.setValue(fileContent);
+
+                logger.info("File content: " + fileContent);
+                setSuccessMessage("Successfully extracted the data in the file and stored in run time variable "
+                        + runTimeData.getKey() + " Value: " + fileContent);
+            } finally {
+                document.close();
+            }
+
+        } catch (RuntimeException e) {
+            logger.info("Unable to find the given file in the downloads " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to find the given file in the downloads");
+            result = Result.FAILED;
+
+        } catch (org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException e) {
+            logger.info("Invalid password for the PDF file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("The provided password is incorrect for the given PDF file");
+            result = Result.FAILED;
+
+        } catch (Exception e) {
+            logger.info(ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to read the data in the given file");
+            result = Result.FAILED;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Addon Name: PDFDataExtractor
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/TE-29278
Added support to extract content from password-protected PDFs (latest download & by file name) and store content in runtime variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an action to extract text from the latest downloaded password-protected PDF and save it into a runtime variable.
  - Added an action to extract text from a password-protected PDF by specifying its file name and save it into a runtime variable. Includes clear error handling for missing files and invalid passwords.
- Chores
  - Bumped addon version to 1.0.5.
  - Updated Lombok dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->