### PR TITLE
feat/TE-29497-Added support for Chrome 140 site permission

### DIFF
--- a/chrome_site_permissions/pom.xml
+++ b/chrome_site_permissions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>chrome_site_permissions</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -17,7 +17,7 @@
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
     </properties>
 
@@ -55,18 +55,23 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.14.1</version>
+            <version>4.33.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>9.0.0</version>
+            <version>9.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
         </dependency>
 
     </dependencies>

--- a/chrome_site_permissions/src/main/java/com/testsigma/addons/mobileweb/MyFirstWebAction.java
+++ b/chrome_site_permissions/src/main/java/com/testsigma/addons/mobileweb/MyFirstWebAction.java
@@ -16,82 +16,93 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Action(actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
+@Action(
+        actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
         description = "Set chrome site settings permissions to URL.",
         applicationType = ApplicationType.MOBILE_WEB,
-        useCustomScreenshot = false)
+        useCustomScreenshot = false
+)
 public class MyFirstWebAction extends WebAction {
 
-  @TestData(reference = "Target-URL")
-  private com.testsigma.sdk.TestData targetUrl;
+    @TestData(reference = "Target-URL")
+    private com.testsigma.sdk.TestData targetUrl;
 
-  @TestData(reference = "Permission-Name")
-  private com.testsigma.sdk.TestData permissionName;
+    @TestData(reference = "Permission-Name")
+    private com.testsigma.sdk.TestData permissionName;
 
-  @TestData(reference = "Permission-Value")
-  private com.testsigma.sdk.TestData permissionValue;
+    @TestData(reference = "Permission-Value")
+    private com.testsigma.sdk.TestData permissionValue;
 
-  public static void main(String... a){
-  /*  MyFirstWebAction action = new MyFirstWebAction();
-    action.setTargetUrl(new com.testsigma.sdk.TestData("https://www.facebook.com"));
-    action.setPermissionName(new com.testsigma.sdk.TestData("Microphone"));
-    action.setPermissionValue(new com.testsigma.sdk.TestData("Allow"));
-    WebDriverManager.chromedriver().setup();
-    ChromeOptions options = new ChromeOptions();
-    RemoteWebDriver driver = new ChromeDriver(options);
-    action.setDriver(driver);
-    action.execute();
-*/
-  }
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        String origWindowHandle = driver.getWindowHandle();
+        List<String> origWindowsList = new ArrayList<>(driver.getWindowHandles());
 
-  @Override
-  public com.testsigma.sdk.Result execute() throws NoSuchElementException {
-    //Your Awesome code starts here
-    com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
-    String origWindowHandle = driver.getWindowHandle();
-    List<String> origwindowsList = new ArrayList<>(driver.getWindowHandles());
+        logger.info("Initiating execution");
 
-    logger.info("Initiating execution");
-    String permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
-            ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
-            ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
-            ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
-    permissionSelect = String.format(permissionSelect, permissionName.getValue().toString());
-    logger.info("Permission query:"+permissionSelect);
+        try {
+            JavascriptExecutor js = (JavascriptExecutor) driver;
 
-    try {
+            // Open Chrome site settings in a new tab
+            logger.info("Opening chrome settings in new tab");
+            String chromeSettingsUrl = "chrome://settings/content/siteDetails?site=" + targetUrl.getValue().toString();
+            driver.switchTo().newWindow(WindowType.TAB);
+            String newTab = driver.getWindowHandles()
+                    .stream()
+                    .filter(handle -> !origWindowsList.contains(handle))
+                    .findFirst()
+                    .get();
+            driver.switchTo().window(newTab);
+            driver.get(chromeSettingsUrl);
+            Thread.sleep(5000);
 
-      JavascriptExecutor js = (JavascriptExecutor) driver;
-      logger.info("Opening chrome settings in new tab");
-      String chromeSettingsUrl = "chrome://settings/content/siteDetails?site="+targetUrl.getValue().toString();
-      driver.switchTo().newWindow(WindowType.TAB);
-      String newTab = driver.getWindowHandles()
-              .stream()
-              .filter(handle -> !origwindowsList.contains(handle))
-              .findFirst()
-              .get();
-      driver.switchTo().window(newTab);
+            // Determine which permission selector to use
+            Boolean isOldStructure = (Boolean) js.executeScript(
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');"
+            );
 
-      logger.info("Opening new tab");
+            String permissionSelect;
+            if (isOldStructure) {
+                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
+                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
+                        ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
+                        ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
+            } else {
+                permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
+                        "  .shadowRoot.querySelector(\"#main\")\n" +
+                        "  .shadowRoot.querySelector(\"#privacy > settings-privacy-page-index\")\n" +
+                        "  .shadowRoot.querySelector(\"#old\")\n" +
+                        "  .shadowRoot.querySelector(\"#basicPage > settings-section > settings-privacy-page\")\n" +
+                        "  .shadowRoot.querySelector(\"#pages > settings-subpage > site-details\")\n" +
+                        "  .shadowRoot.querySelector(\"div.list-frame > site-details-permission[label='%s']\")\n" +
+                        "  .shadowRoot.querySelector(\"#permission\")";
+            }
 
-        driver.get(chromeSettingsUrl);
-        Thread.sleep(5000);
-        logger.info("Finding permission type element:"+permissionName.getValue().toString());
-        WebElement elem = (WebElement) js.executeScript(permissionSelect);
-        Select select = new Select(elem);
-        logger.info("Selecting permission type:"+permissionValue.getValue().toString());
-        select.selectByVisibleText(permissionValue.getValue().toString());
-        Thread.sleep(3000);
-        logger.info("Permisssion successfully set");
-    } catch (Exception error) {
-      result = com.testsigma.sdk.Result.FAILED;
-      logger.info("Exception: "+ ExceptionUtils.getStackTrace(error));
-      setErrorMessage("Unable to change site permissions,"+error.getMessage());
-      return result;
-    }finally {
-      driver.switchTo().window(origWindowHandle);
+            // Format the query with the permission name
+            permissionSelect = String.format(permissionSelect, permissionName.getValue().toString());
+            logger.info("Permission query: " + permissionSelect);
+
+            // Find the element and set the permission
+            logger.info("Finding permission type element: " + permissionName.getValue().toString());
+            WebElement elem = (WebElement) js.executeScript(permissionSelect);
+            Select select = new Select(elem);
+            logger.info("Selecting permission type: " + permissionValue.getValue().toString());
+            select.selectByVisibleText(permissionValue.getValue().toString());
+            Thread.sleep(3000);
+
+            logger.info("Permission successfully set");
+
+        } catch (Exception error) {
+            result = com.testsigma.sdk.Result.FAILED;
+            logger.info("Exception: " + ExceptionUtils.getStackTrace(error));
+            setErrorMessage("Unable to change site permissions, " + ExceptionUtils.getMessage(error));
+            return result;
+        } finally {
+            driver.switchTo().window(origWindowHandle);
+        }
+
+        setSuccessMessage("Site permissions changed successfully");
+        return result;
     }
-    setSuccessMessage("Site permissions changed successfully");
-    return result;
-  }
 }

--- a/chrome_site_permissions/src/main/java/com/testsigma/addons/web/MyFirstWebAction.java
+++ b/chrome_site_permissions/src/main/java/com/testsigma/addons/web/MyFirstWebAction.java
@@ -16,82 +16,93 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Action(actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
+@Action(
+        actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
         description = "Set chrome site settings permissions to URL.",
         applicationType = ApplicationType.WEB,
-        useCustomScreenshot = false)
+        useCustomScreenshot = false
+)
 public class MyFirstWebAction extends WebAction {
 
-  @TestData(reference = "Target-URL")
-  private com.testsigma.sdk.TestData targetUrl;
+    @TestData(reference = "Target-URL")
+    private com.testsigma.sdk.TestData targetUrl;
 
-  @TestData(reference = "Permission-Name")
-  private com.testsigma.sdk.TestData permissionName;
+    @TestData(reference = "Permission-Name")
+    private com.testsigma.sdk.TestData permissionName;
 
-  @TestData(reference = "Permission-Value")
-  private com.testsigma.sdk.TestData permissionValue;
+    @TestData(reference = "Permission-Value")
+    private com.testsigma.sdk.TestData permissionValue;
 
-  public static void main(String... a){
-  /*  MyFirstWebAction action = new MyFirstWebAction();
-    action.setTargetUrl(new com.testsigma.sdk.TestData("https://www.facebook.com"));
-    action.setPermissionName(new com.testsigma.sdk.TestData("Microphone"));
-    action.setPermissionValue(new com.testsigma.sdk.TestData("Allow"));
-    WebDriverManager.chromedriver().setup();
-    ChromeOptions options = new ChromeOptions();
-    RemoteWebDriver driver = new ChromeDriver(options);
-    action.setDriver(driver);
-    action.execute();
-*/
-  }
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        String origWindowHandle = driver.getWindowHandle();
+        List<String> origWindowsList = new ArrayList<>(driver.getWindowHandles());
 
-  @Override
-  public com.testsigma.sdk.Result execute() throws NoSuchElementException {
-    //Your Awesome code starts here
-    com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
-    String origWindowHandle = driver.getWindowHandle();
-    List<String> origwindowsList = new ArrayList<>(driver.getWindowHandles());
+        logger.info("Initiating execution");
 
-    logger.info("Initiating execution");
-    String permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
-            ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
-            ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
-            ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
-    permissionSelect = String.format(permissionSelect, permissionName.getValue().toString());
-    logger.info("Permission query:"+permissionSelect);
+        try {
+            JavascriptExecutor js = (JavascriptExecutor) driver;
 
-    try {
+            // Open Chrome site settings in a new tab
+            logger.info("Opening chrome settings in new tab");
+            String chromeSettingsUrl = "chrome://settings/content/siteDetails?site=" + targetUrl.getValue().toString();
+            driver.switchTo().newWindow(WindowType.TAB);
+            String newTab = driver.getWindowHandles()
+                    .stream()
+                    .filter(handle -> !origWindowsList.contains(handle))
+                    .findFirst()
+                    .get();
+            driver.switchTo().window(newTab);
+            driver.get(chromeSettingsUrl);
+            Thread.sleep(5000);
 
-      JavascriptExecutor js = (JavascriptExecutor) driver;
-      logger.info("Opening chrome settings in new tab");
-      String chromeSettingsUrl = "chrome://settings/content/siteDetails?site="+targetUrl.getValue().toString();
-      driver.switchTo().newWindow(WindowType.TAB);
-      String newTab = driver.getWindowHandles()
-              .stream()
-              .filter(handle -> !origwindowsList.contains(handle))
-              .findFirst()
-              .get();
-      driver.switchTo().window(newTab);
+            // Determine which permission selector to use
+            Boolean isOldStructure = (Boolean) js.executeScript(
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');"
+            );
 
-      logger.info("Opening new tab");
+            String permissionSelect;
+            if (isOldStructure) {
+                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
+                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
+                        ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
+                        ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
+            } else {
+                permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
+                        "  .shadowRoot.querySelector(\"#main\")\n" +
+                        "  .shadowRoot.querySelector(\"#privacy > settings-privacy-page-index\")\n" +
+                        "  .shadowRoot.querySelector(\"#old\")\n" +
+                        "  .shadowRoot.querySelector(\"#basicPage > settings-section > settings-privacy-page\")\n" +
+                        "  .shadowRoot.querySelector(\"#pages > settings-subpage > site-details\")\n" +
+                        "  .shadowRoot.querySelector(\"div.list-frame > site-details-permission[label='%s']\")\n" +
+                        "  .shadowRoot.querySelector(\"#permission\")";
+            }
 
-        driver.get(chromeSettingsUrl);
-        Thread.sleep(5000);
-        logger.info("Finding permission type element:"+permissionName.getValue().toString());
-        WebElement elem = (WebElement) js.executeScript(permissionSelect);
-        Select select = new Select(elem);
-        logger.info("Selecting permission type:"+permissionValue.getValue().toString());
-        select.selectByVisibleText(permissionValue.getValue().toString());
-        Thread.sleep(3000);
-        logger.info("Permisssion successfully set");
-    } catch (Exception error) {
-      result = com.testsigma.sdk.Result.FAILED;
-      logger.info("Exception: "+ ExceptionUtils.getStackTrace(error));
-      setErrorMessage("Unable to change site permissions,"+error.getMessage());
-      return result;
-    }finally {
-      driver.switchTo().window(origWindowHandle);
+            // Format the query with the permission name
+            permissionSelect = String.format(permissionSelect, permissionName.getValue().toString());
+            logger.info("Permission query: " + permissionSelect);
+
+            // Find the element and set the permission
+            logger.info("Finding permission type element: " + permissionName.getValue().toString());
+            WebElement elem = (WebElement) js.executeScript(permissionSelect);
+            Select select = new Select(elem);
+            logger.info("Selecting permission type: " + permissionValue.getValue().toString());
+            select.selectByVisibleText(permissionValue.getValue().toString());
+            Thread.sleep(3000);
+
+            logger.info("Permission successfully set");
+
+        } catch (Exception error) {
+            result = com.testsigma.sdk.Result.FAILED;
+            logger.info("Exception: " + ExceptionUtils.getStackTrace(error));
+            setErrorMessage("Unable to change site permissions, " + ExceptionUtils.getMessage(error));
+            return result;
+        } finally {
+            driver.switchTo().window(origWindowHandle);
+        }
+
+        setSuccessMessage("Site permissions changed successfully");
+        return result;
     }
-    setSuccessMessage("Site permissions changed successfully");
-    return result;
-  }
 }


### PR DESCRIPTION
Addon Name: Chrome site permissions
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/TE-29497
Added support for Chrome 140 site permission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved Chrome compatibility: action now works across old and new Chrome Settings layouts when updating site permissions.
- Bug Fixes
  - More reliable tab handling and restoration after actions.
  - Clearer success and error messages for easier troubleshooting.
- Chores
  - Version bump to 1.0.5.
  - Dependency updates: Lombok, Selenium, Appium.
  - Added Apache Commons Lang dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->