### PR TITLE
feat/CUS-8412-Corrected endIndex usage in GetSubStringFromStartIndexToEndIndex

### DIFF
--- a/string_data_generators/pom.xml
+++ b/string_data_generators/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>string_data_generators</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.9</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/string_data_generators/src/main/java/com/testsigma/addons/string_utils/generators/GetSubStringFromStartIndexToEndIndex.java
+++ b/string_data_generators/src/main/java/com/testsigma/addons/string_utils/generators/GetSubStringFromStartIndexToEndIndex.java
@@ -20,7 +20,7 @@ public class GetSubStringFromStartIndexToEndIndex extends TestDataFunction {
     public TestData generate() throws Exception {
         String actualString = string.getValue().toString();
         int fromIndex = Integer.valueOf(startIndex.getValue().toString());
-        int tillIndex = Integer.valueOf(startIndex.getValue().toString());
+        int tillIndex = Integer.valueOf(endIndex.getValue().toString());
         String substring = actualString.substring(fromIndex, tillIndex);
         return new TestData(substring);
     }


### PR DESCRIPTION
# Publish this addon as public
Addon Name: String Data Generators
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/30397/addons
Jira : https://testsigma.atlassian.net/browse/CUS-8412
Corrected endIndex usage in GetSubStringFromStartIndexToEndIndex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed substring extraction to correctly apply the specified end boundary instead of incorrectly using the start boundary.

* **Chores**
  * Updated project version to 1.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->