### PR TITLE
[CUS-9542] removed deprecated methods.

### DIFF
--- a/ocr_actions/pom.xml
+++ b/ocr_actions/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>ocr_actions</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTesting.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTesting.java
@@ -1,15 +1,16 @@
 package com.testsigma.addons.android;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.io.*;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
 
 import com.testsigma.sdk.AndroidAction;
 import com.testsigma.sdk.ApplicationType;
@@ -20,10 +21,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data
@@ -107,7 +105,12 @@ public class OCRTesting extends AndroidAction {
         logger.info("Clicking on X coordinate: " + x + "\n");
         logger.info("Clicking on Y coordinate: " + y + "\n");
         
-        TouchAction action = new TouchAction((PerformsTouchActions) (AndroidDriver)this.driver);
-        action.tap(PointOption.point(x, y)).perform();
+        // Using W3C Actions API instead of deprecated TouchAction
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+        Sequence tap = new Sequence(finger, 1);
+        tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+        ((AndroidDriver) this.driver).perform(Arrays.asList(tap));
     }
 }

--- a/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingStore.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingStore.java
@@ -5,11 +5,8 @@ import java.util.List;
 import java.io.*;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 import com.testsigma.sdk.AndroidAction;
 import com.testsigma.sdk.ApplicationType;
@@ -21,10 +18,7 @@ import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data

--- a/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingdo.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingdo.java
@@ -1,13 +1,16 @@
 package com.testsigma.addons.android;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
 
 import com.testsigma.sdk.AndroidAction;
 import com.testsigma.sdk.ApplicationType;
@@ -18,11 +21,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data
@@ -93,7 +92,12 @@ public class OCRTestingdo extends AndroidAction{
         logger.info("Clicking on X coordinate: " + x + "\n");
         logger.info("Clicking on Y coordinate: " + y + "\n");
         
-        TouchAction action = new TouchAction((PerformsTouchActions) (AndroidDriver)this.driver);
-        action.tap(PointOption.point(x, y)).perform();
+        // Using W3C Actions API instead of deprecated TouchAction
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+        Sequence tap = new Sequence(finger, 1);
+        tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+        ((AndroidDriver) this.driver).perform(Arrays.asList(tap));
     }
 }

--- a/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingmouse.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/android/OCRTestingmouse.java
@@ -1,16 +1,16 @@
 package com.testsigma.addons.android;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.io.*;
 import java.time.Duration;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
 
 import com.testsigma.sdk.AndroidAction;
 import com.testsigma.sdk.ApplicationType;
@@ -21,13 +21,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.touch.TapOptions;
-import io.appium.java_client.touch.WaitOptions;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data
@@ -109,12 +103,16 @@ public class OCRTestingmouse extends AndroidAction {
 		logger.info("Clicking on X coordinate: " + x + "\n");
 		logger.info("Clicking on Y coordinate: " + y + "\n");
 		
-		TouchAction action = new TouchAction((PerformsTouchActions) (AndroidDriver)this.driver);
+		// Using W3C Actions API instead of deprecated TouchAction
+		PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+		Sequence tap = new Sequence(finger, 1);
 		logger.info("Pressing X coordinate: " + x + "\n");
-		PointOption point = PointOption.point(x, y);
 		logger.info("Pressing Y coordinate: " + y + "\n");
-        // Perform the move and tap action
-        action.moveTo(point).tap(point).perform();
+		// Perform the move and tap action
+		tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+		tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+		tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+		((AndroidDriver) this.driver).perform(Arrays.asList(tap));
 		logger.info("Successfully pressed X and y coordinate: " + x + "\n" + y + "\n");
 	}
 }

--- a/ocr_actions/src/main/java/com/testsigma/addons/ios/OCRTesting.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/ios/OCRTesting.java
@@ -1,13 +1,16 @@
 package com.testsigma.addons.ios;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.io.*;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
 
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.IOSAction;
@@ -18,11 +21,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
-import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data
@@ -102,10 +101,12 @@ public class OCRTesting extends IOSAction {
         logger.info("Clicking on X coordinate: " + x + "\n");
         logger.info("Clicking on Y coordinate: " + y + "\n");
         
-        TouchAction action = new TouchAction((IOSDriver)this.driver);
-        action.tap(PointOption.point(x,y)).perform();
-        
-       // TouchAction action = new TouchAction((PerformsTouchActions) (IOSDriver)this.driver);
-       // action.tap(PointOption.point(x, y)).perform();
+        // Using W3C Actions API instead of deprecated TouchAction
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+        Sequence tap = new Sequence(finger, 1);
+        tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+        ((IOSDriver) this.driver).perform(Arrays.asList(tap));
     }
 }

--- a/ocr_actions/src/main/java/com/testsigma/addons/ios/OCRTestingdo.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/ios/OCRTestingdo.java
@@ -1,13 +1,16 @@
 package com.testsigma.addons.ios;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
 
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.IOSAction;
@@ -18,11 +21,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
-import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data
@@ -89,10 +88,12 @@ public class OCRTestingdo extends IOSAction{
 		logger.info("Clicking on X coordinate: " + x + "\n");
 		logger.info("Clicking on Y coordinate: " + y + "\n");
 		
-		TouchAction action = new TouchAction((IOSDriver)this.driver);
-	    action.tap(PointOption.point(x,y)).perform();
-
-		//TouchAction action = new TouchAction((PerformsTouchActions) (IOSDriver)this.driver);
-		//action.tap(PointOption.point(x, y)).perform();
+		// Using W3C Actions API instead of deprecated TouchAction
+		PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+		Sequence tap = new Sequence(finger, 1);
+		tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+		tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+		tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+		((IOSDriver) this.driver).perform(Arrays.asList(tap));
 	}
 }

--- a/ocr_actions/src/main/java/com/testsigma/addons/web/OCRTestingdo.java
+++ b/ocr_actions/src/main/java/com/testsigma/addons/web/OCRTestingdo.java
@@ -18,10 +18,6 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.OCR;
 import com.testsigma.sdk.annotation.TestData;
 
-import io.appium.java_client.PerformsTouchActions;
-import io.appium.java_client.TouchAction;
-import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
 
 @Data


### PR DESCRIPTION

# please review this addon and publish as PUBLIC

Addon name : ocr_actions
Addon accont: https://jarvis.testsigma.com/ui/tenants/3072/addons
Jira: https://testsigma.atlassian.net/browse/CUS-9542


# fix 
used W3C Actions API instead of deprecated TouchAction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated touch interaction implementation across Android, iOS, and web OCR testing modules.
  * Removed unused imports and dependencies.

* **Chores**
  * Version bumped to 1.1.9.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->