### PR TITLE
[CUS-9787] clear cell value from csv file.

### DIFF
--- a/csv_file_update_from_upload_section/pom.xml
+++ b/csv_file_update_from_upload_section/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>csv_file_update_from_upload_section</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.17.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/DeleteRowContentFromCsv.java
+++ b/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/DeleteRowContentFromCsv.java
@@ -1,0 +1,152 @@
+package com.testsigma.addons.web;
+
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+@Data
+@Action(actionText = "clear cell value from a CSV file file-path where row is row-number and column is column-number",
+        description = "Deletes a particular cell from CSV file uses 1-based indexing for row and column numbers.",
+        applicationType = ApplicationType.WEB)
+public class DeleteRowContentFromCsv extends WebAction {
+
+    @TestData(reference = "file-path")
+    private com.testsigma.sdk.TestData filePathOrUpload;
+
+    @TestData(reference = "row-number")
+    private com.testsigma.sdk.TestData rowNumber;
+
+    @TestData(reference = "column-number")
+    private com.testsigma.sdk.TestData columnNumber;
+
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+
+        String filePathString = filePathOrUpload.getValue().toString();
+        int targetRow;
+        int targetColumn;
+        try {
+            targetRow = Integer.parseInt(rowNumber.getValue().toString());
+            targetColumn = Integer.parseInt(columnNumber.getValue().toString());
+        } catch (NumberFormatException e) {
+            setErrorMessage("Row number and Column number must be valid integers.");
+            return com.testsigma.sdk.Result.FAILED;
+        }
+
+        // Validate 1-based input (must be at least 1)
+        if (targetRow < 1 || targetColumn < 1) {
+            setErrorMessage("Row and Column numbers must be at least 1. Given: row=" + targetRow + ", column=" + targetColumn);
+            return com.testsigma.sdk.Result.FAILED;
+        }
+
+        // Store original 1-based values for user-friendly messages
+        int originalRow = targetRow;
+        int originalColumn = targetColumn;
+
+        // Convert to 0-based index (user gives 1,1 → maps to 0,0 in CSV)
+        int rowIndex = targetRow - 1;
+        int columnIndex = targetColumn - 1;
+
+
+        String csvFilePath;
+        if (filePathString.startsWith("https://") || filePathString.startsWith("http://")) {
+            File tempFile = urlToCSVFileConverter("csvFileName", filePathString);
+            csvFilePath = tempFile.getAbsolutePath();
+        } else {
+            // Use local file path directly
+            logger.info("Given is local file path...");
+            csvFilePath = filePathString;
+        }
+        logger.info("CSV File path: " + csvFilePath);
+
+        try (Reader reader = new FileReader(csvFilePath);
+             CSVReader csvReader = new CSVReader(reader)) {
+            List<String[]> rows = csvReader.readAll();
+
+            // Check row bounds using 0-based index
+            if (rowIndex >= 0 && rowIndex < rows.size()) {
+                logger.info("Accessing row " + originalRow);
+                String[] row = rows.get(rowIndex);
+
+                // Check column bounds using 0-based index
+                if (columnIndex >= 0 && columnIndex < row.length) {
+                    row[columnIndex] = "";
+
+                    // Write the modified CSV back to the same file
+                    try (CSVWriter writer = new CSVWriter(new FileWriter(csvFilePath))) {
+                        writer.writeAll(rows);
+                    } catch (IOException e) {
+                        logger.warn("Error writing to CSV file: " + ExceptionUtils.getStackTrace(e));
+                        setErrorMessage("Error writing to CSV file: " + e.getMessage());
+                        result = com.testsigma.sdk.Result.FAILED;
+                        return result;
+                    }
+
+                    logger.info("Content deleted from row " + originalRow + " and column " + originalColumn);
+                    setSuccessMessage("Content deleted from row " + originalRow + " and column " + originalColumn);
+                } else {
+                    logger.warn("Column number " + originalColumn + " is out of bounds.");
+                    setErrorMessage("Column number " + originalColumn + " is out of bounds.");
+                    result = com.testsigma.sdk.Result.FAILED;
+                }
+            } else {
+                logger.warn("Row number " + originalRow + " is out of bounds.");
+                setErrorMessage("Row number " + originalRow + " is out of bounds.");
+                result = com.testsigma.sdk.Result.FAILED;
+            }
+        } catch (IOException | CsvException e) {
+            logger.warn("Error processing CSV file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Error processing CSV file: " + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+            return result;
+        }
+        return result;
+    }
+
+    public File urlToCSVFileConverter(String fileName, String url) {
+        try {
+            logger.info("Given is URL... File name: " + fileName);
+            URL urlObject = new URL(url);
+
+            // Extract file extension if present
+            String baseName = fileName;
+            String extension = ".csv"; // default csv format
+            int lastDotIndex = fileName.lastIndexOf('.');
+            if (lastDotIndex > 0) {
+                baseName = fileName.substring(0, lastDotIndex);
+                extension = fileName.substring(lastDotIndex);
+            }
+
+            File tempFile = File.createTempFile(baseName, extension);
+            FileUtils.copyURLToFile(urlObject, tempFile);
+            logger.info("CSV file created: " + tempFile.getAbsolutePath());
+            return tempFile;
+        } catch (Exception e) {
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access or validate the CSV file. Please check the inputs.", e);
+        }
+    }
+
+}
+

--- a/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/DeleteRowContentFromCsvAndStorePath.java
+++ b/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/DeleteRowContentFromCsvAndStorePath.java
@@ -23,22 +23,22 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 @Data
-@Action(actionText = "Write row number and column number into CSV file with testdata where absolutepath is test_data and store filepath in runtime variable variable-name (It supports file from upload section)",
-        description = "Write a particular row and column into CSV file where absolutepath. Can accept local file paths or URLs for the CSV file. Stores the file path in a runtime variable.It supports file from upload section.",
+@Action(actionText = "clear cell value from CSV file test_data where row is row-number and column column-number" +
+        " and store filepath in runtime variable variable-name (It supports file from upload section)",
+        description = "Deletes content from a particular cell in CSV file using 1-based indexing for row " +
+                "and column numbers. Can accept local file paths or URLs for the CSV file." +
+                " Stores the file path in a runtime variable. It supports file from upload section.",
         applicationType = ApplicationType.WEB)
-public class WriteCsvFileandStorePath extends WebAction {
+public class DeleteRowContentFromCsvAndStorePath extends WebAction {
 
-    @TestData(reference = "row")
-    private com.testsigma.sdk.TestData row;
+    @TestData(reference = "row-number")
+    private com.testsigma.sdk.TestData rowNumber;
 
-    @TestData(reference = "column")
-    private com.testsigma.sdk.TestData column;
+    @TestData(reference = "column-number")
+    private com.testsigma.sdk.TestData columnNumber;
 
     @TestData(reference = "test_data")
     private com.testsigma.sdk.TestData filePath;
-
-    @TestData(reference = "testdata")
-    private com.testsigma.sdk.TestData testData;
 
     @TestData(reference = "variable-name", isRuntimeVariable = true)
     private com.testsigma.sdk.TestData variableName;
@@ -53,13 +53,12 @@ public class WriteCsvFileandStorePath extends WebAction {
         com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
 
         String filePathString = filePath.getValue().toString();
-        String replace = testData.getValue().toString();
-        
+
         int targetRow;
         int targetColumn;
         try {
-            targetRow = Integer.parseInt(row.getValue().toString());
-            targetColumn = Integer.parseInt(column.getValue().toString());
+            targetRow = Integer.parseInt(rowNumber.getValue().toString());
+            targetColumn = Integer.parseInt(columnNumber.getValue().toString());
         } catch (NumberFormatException e) {
             setErrorMessage("Row number and Column number must be valid integers.");
             return com.testsigma.sdk.Result.FAILED;
@@ -103,26 +102,33 @@ public class WriteCsvFileandStorePath extends WebAction {
                 int rowIndex = targetRow - 1;
                 int columnIndex = targetColumn - 1;
 
-                while (data.size() <= rowIndex) {
-                    data.add(new String[Math.max(columnIndex + 1, 0)]);
-                }
-                String[] targetRowData = data.get(rowIndex);
-                if (targetRowData.length <= columnIndex) {
-                    String[] newRow = new String[columnIndex + 1];
-                    System.arraycopy(targetRowData, 0, newRow, 0, targetRowData.length);
-                    data.set(rowIndex, newRow);
-                    targetRowData = newRow;
-                }
-                targetRowData[columnIndex] = replace;
+                // Check row bounds using 0-based index
+                if (rowIndex < data.size()) {
+                    logger.info("Accessing row " + originalRow);
+                    String[] row = data.get(rowIndex);
 
-                writer = new CSVWriter(new FileWriter(tempCsvFile), ',', CSVWriter.NO_QUOTE_CHARACTER,
-                        CSVWriter.DEFAULT_ESCAPE_CHARACTER, CSVWriter.DEFAULT_LINE_END);
-                writer.writeAll(data);
-                writer.flush();
-            } catch (IOException | CsvException e) { // Catch both exceptions
+                    // Check column bounds using 0-based index
+                    if (columnIndex < row.length) {
+                        row[columnIndex] = "";
+
+                        writer = new CSVWriter(new FileWriter(tempCsvFile), ',', CSVWriter.NO_QUOTE_CHARACTER,
+                                CSVWriter.DEFAULT_ESCAPE_CHARACTER, CSVWriter.DEFAULT_LINE_END);
+                        writer.writeAll(data);
+                        writer.flush();
+
+                        logger.info("Content deleted from row " + originalRow + " and column " + originalColumn);
+                    } else {
+                        setErrorMessage("Column number " + originalColumn + " is out of bounds. Max columns: " + row.length);
+                        return com.testsigma.sdk.Result.FAILED;
+                    }
+                } else {
+                    setErrorMessage("Row number " + originalRow + " is out of bounds. Max rows: " + data.size());
+                    return com.testsigma.sdk.Result.FAILED;
+                }
+            } catch (IOException | CsvException e) {
                 result = com.testsigma.sdk.Result.FAILED;
                 setErrorMessage("Error processing CSV file: " + e.getMessage());
-                logger.warn("Error processing CSV file: " + e); // Use logger.error for exceptions
+                logger.warn("Error processing CSV file: " + e);
                 return result;
             } finally {
                 if (csvReader != null) {
@@ -140,23 +146,24 @@ public class WriteCsvFileandStorePath extends WebAction {
                     }
                 }
             }
+
             // Copy the temp file back to the original file
             try {
                 Files.copy(tempCsvFile.toPath(), csvFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                logger.info("Successfully copied content to original file" + csvFile.getAbsolutePath());
+                logger.info("Successfully copied content to original file: " + csvFile.getAbsolutePath());
             } catch (IOException ex) {
-                logger.warn("Error copying data from temp file to original file" + ex);
+                logger.warn("Error copying data from temp file to original file: " + ex);
                 setErrorMessage("Failed to copy data from temp file to original file: " + ex.getMessage());
                 return com.testsigma.sdk.Result.FAILED;
             }
 
-            // Store the path of the new updated file
+            // Store the path of the updated file
             runTimeData.setKey(variableName.getValue().toString());
-            runTimeData.setValue(csvFile.getAbsolutePath()); // Store absolute path of the new file
+            runTimeData.setValue(csvFile.getAbsolutePath());
 
-            setSuccessMessage("Data updated successfully at row " + originalRow + ", column " + originalColumn 
-                    + " with value: " + replace + ". File path stored in runtime variable: " 
-                    + variableName.getValue().toString() + " = " + csvFile.getAbsolutePath());
+            setSuccessMessage("Content deleted from row " + originalRow + ", column " + originalColumn
+                    + ". File path stored in runtime variable: " + variableName.getValue().toString()
+                    + " = " + csvFile.getAbsolutePath());
         } catch (Exception e) {
             result = com.testsigma.sdk.Result.FAILED;
             setErrorMessage("Operation Failed: " + e.getMessage());
@@ -180,7 +187,7 @@ public class WriteCsvFileandStorePath extends WebAction {
             File tempFile = new File(filePath);
 
             // Download the file from the URL to the temporary location
-            FileUtils.copyURLToFile(new URL(pathOrUrl), tempFile, 10000, 10000); // Adding timeouts
+            FileUtils.copyURLToFile(new URL(pathOrUrl), tempFile, 10000, 10000);
             logger.info("Temp file created for URL file: " + uniqueFileName + " at path " + filePath);
 
             return tempFile;
@@ -190,3 +197,4 @@ public class WriteCsvFileandStorePath extends WebAction {
         }
     }
 }
+

--- a/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/ReadCellValueFromCsv.java
+++ b/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/ReadCellValueFromCsv.java
@@ -1,0 +1,156 @@
+package com.testsigma.addons.web;
+
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+@Data
+@Action(actionText = "Read cell value from CSV file file-path at row row-number and column column-number and" +
+        " store in variable-name",
+        description = "Reads a value from a particular cell in CSV file using 1-based indexing for row and column" +
+                " numbers and stores it in a runtime variable.",
+        applicationType = ApplicationType.WEB)
+public class ReadCellValueFromCsv extends WebAction {
+
+    @TestData(reference = "file-path")
+    private com.testsigma.sdk.TestData filePathOrUpload;
+
+    @TestData(reference = "row-number")
+    private com.testsigma.sdk.TestData rowNumber;
+
+    @TestData(reference = "column-number")
+    private com.testsigma.sdk.TestData columnNumber;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData variableName;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+
+        com.testsigma.sdk.Result result = Result.SUCCESS;
+
+        String filePathString = filePathOrUpload.getValue().toString();
+        int targetRow;
+        int targetColumn;
+        try {
+            targetRow = Integer.parseInt(rowNumber.getValue().toString());
+            targetColumn = Integer.parseInt(columnNumber.getValue().toString());
+        } catch (NumberFormatException e) {
+            setErrorMessage("Row number and Column number must be valid integers.");
+            return Result.FAILED;
+        }
+
+        // Validate 1-based input (must be at least 1)
+        if (targetRow < 1 || targetColumn < 1) {
+            setErrorMessage("Row and Column numbers must be at least 1. Given: row="
+                    + targetRow + ", column=" + targetColumn);
+            return Result.FAILED;
+        }
+
+        // Store original 1-based values for user-friendly messages
+        int originalRow = targetRow;
+        int originalColumn = targetColumn;
+
+        // Convert to 0-based index (user gives 1,1 → maps to 0,0 in CSV)
+        int rowIndex = targetRow - 1;
+        int columnIndex = targetColumn - 1;
+
+        String csvFilePath;
+        if (filePathString.startsWith("https://") || filePathString.startsWith("http://")) {
+            File tempFile = urlToCSVFileConverter("csvFileName", filePathString);
+            csvFilePath = tempFile.getAbsolutePath();
+        } else {
+            // Use local file path directly
+            logger.info("Given is local file path...");
+            csvFilePath = filePathString;
+        }
+        logger.info("CSV File path: " + csvFilePath);
+
+        try (Reader reader = new FileReader(csvFilePath);
+             CSVReader csvReader = new CSVReader(reader)) {
+            List<String[]> rows = csvReader.readAll();
+
+            // Check row bounds using 0-based index
+            if (rowIndex < rows.size()) {
+                logger.info("Accessing row " + originalRow);
+                String[] row = rows.get(rowIndex);
+
+                // Check column bounds using 0-based index
+                if (columnIndex < row.length) {
+                    String cellValue = row[columnIndex];
+
+                    // Store the cell value in the runtime variable
+                    runTimeData.setKey(variableName.getValue().toString());
+                    runTimeData.setValue(cellValue);
+
+                    logger.info("Cell value '" + cellValue + "' read from row " + originalRow +
+                            " and column " + originalColumn);
+                    setSuccessMessage("Cell value '" + cellValue + "' read from row " + originalRow +
+                            " and column " + originalColumn
+                            + ". Stored in variable: " + variableName.getValue().toString());
+                } else {
+                    logger.warn("Column number " + originalColumn + " is out of bounds.");
+                    setErrorMessage("Column number " + originalColumn + " is out of bounds.");
+                    result = Result.FAILED;
+                }
+            } else {
+                logger.warn("Row number " + originalRow + " is out of bounds.");
+                setErrorMessage("Row number " + originalRow + " is out of bounds.");
+                result = Result.FAILED;
+            }
+        } catch (IOException | CsvException e) {
+            logger.warn("Error processing CSV file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Error processing CSV file: " + e.getMessage());
+            result = Result.FAILED;
+            return result;
+        }
+        return result;
+    }
+
+    public File urlToCSVFileConverter(String fileName, String url) {
+        try {
+            logger.info("Given is URL... File name: " + fileName);
+            URL urlObject = new URL(url);
+
+            // Extract file extension if present
+            String baseName = fileName;
+            String extension = ".csv"; // default csv format
+            int lastDotIndex = fileName.lastIndexOf('.');
+            if (lastDotIndex > 0) {
+                baseName = fileName.substring(0, lastDotIndex);
+                extension = fileName.substring(lastDotIndex);
+            }
+
+            File tempFile = File.createTempFile(baseName, extension);
+            FileUtils.copyURLToFile(urlObject, tempFile);
+            logger.info("CSV file created: " + tempFile.getAbsolutePath());
+            return tempFile;
+        } catch (Exception e) {
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access or validate the CSV file. Please check the inputs.", e);
+        }
+    }
+}
+

--- a/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/WriteCellValueInCsv.java
+++ b/csv_file_update_from_upload_section/src/main/java/com/testsigma/addons/web/WriteCellValueInCsv.java
@@ -1,0 +1,153 @@
+package com.testsigma.addons.web;
+
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+@Data
+@Action(actionText = "Write value test-data into a cell in CSV file file-path at row row-number and column column-number",
+        description = "Writes a value to a particular cell in CSV file using 1-based indexing for row and column numbers.",
+        applicationType = ApplicationType.WEB)
+public class WriteCellValueInCsv extends WebAction {
+
+    @TestData(reference = "file-path")
+    private com.testsigma.sdk.TestData filePathOrUpload;
+
+    @TestData(reference = "row-number")
+    private com.testsigma.sdk.TestData rowNumber;
+
+    @TestData(reference = "column-number")
+    private com.testsigma.sdk.TestData columnNumber;
+
+    @TestData(reference = "test-data")
+    private com.testsigma.sdk.TestData cellValue;
+
+    @Override
+    public com.testsigma.sdk.Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+
+        String filePathString = filePathOrUpload.getValue().toString();
+        String valueToWrite = cellValue.getValue().toString();
+        int targetRow;
+        int targetColumn;
+        try {
+            targetRow = Integer.parseInt(rowNumber.getValue().toString());
+            targetColumn = Integer.parseInt(columnNumber.getValue().toString());
+        } catch (NumberFormatException e) {
+            setErrorMessage("Row number and Column number must be valid integers.");
+            return com.testsigma.sdk.Result.FAILED;
+        }
+
+        // Validate 1-based input (must be at least 1)
+        if (targetRow < 1 || targetColumn < 1) {
+            setErrorMessage("Row and Column numbers must be at least 1. Given: row=" + targetRow + ", column=" + targetColumn);
+            return com.testsigma.sdk.Result.FAILED;
+        }
+
+        // Store original 1-based values for user-friendly messages
+        int originalRow = targetRow;
+        int originalColumn = targetColumn;
+
+        // Convert to 0-based index (user gives 1,1 → maps to 0,0 in CSV)
+        int rowIndex = targetRow - 1;
+        int columnIndex = targetColumn - 1;
+
+        String csvFilePath;
+        if (filePathString.startsWith("https://") || filePathString.startsWith("http://")) {
+            File tempFile = urlToCSVFileConverter("csvFileName", filePathString);
+            csvFilePath = tempFile.getAbsolutePath();
+        } else {
+            // Use local file path directly
+            logger.info("Given is local file path...");
+            csvFilePath = filePathString;
+        }
+        logger.info("CSV File path: " + csvFilePath);
+
+        try (Reader reader = new FileReader(csvFilePath);
+             CSVReader csvReader = new CSVReader(reader)) {
+            List<String[]> rows = csvReader.readAll();
+
+            // Check row bounds using 0-based index
+            if (rowIndex >= 0 && rowIndex < rows.size()) {
+                logger.info("Accessing row " + originalRow);
+                String[] row = rows.get(rowIndex);
+
+                // Check column bounds using 0-based index
+                if (columnIndex >= 0 && columnIndex < row.length) {
+                    row[columnIndex] = valueToWrite;
+
+                    // Write the modified CSV back to the same file
+                    try (CSVWriter writer = new CSVWriter(new FileWriter(csvFilePath))) {
+                        writer.writeAll(rows);
+                    } catch (IOException e) {
+                        logger.warn("Error writing to CSV file: " + ExceptionUtils.getStackTrace(e));
+                        setErrorMessage("Error writing to CSV file: " + e.getMessage());
+                        result = com.testsigma.sdk.Result.FAILED;
+                        return result;
+                    }
+
+                    logger.info("Value '" + valueToWrite + "' written to row " + originalRow + " and column " + originalColumn);
+                    setSuccessMessage("Value '" + valueToWrite + "' written to row " + originalRow + " and column " + originalColumn);
+                } else {
+                    logger.warn("Column number " + originalColumn + " is out of bounds.");
+                    setErrorMessage("Column number " + originalColumn + " is out of bounds.");
+                    result = com.testsigma.sdk.Result.FAILED;
+                }
+            } else {
+                logger.warn("Row number " + originalRow + " is out of bounds.");
+                setErrorMessage("Row number " + originalRow + " is out of bounds.");
+                result = com.testsigma.sdk.Result.FAILED;
+            }
+        } catch (IOException | CsvException e) {
+            logger.warn("Error processing CSV file: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Error processing CSV file: " + e.getMessage());
+            result = com.testsigma.sdk.Result.FAILED;
+            return result;
+        }
+        return result;
+    }
+
+    public File urlToCSVFileConverter(String fileName, String url) {
+        try {
+            logger.info("Given is URL... File name: " + fileName);
+            URL urlObject = new URL(url);
+
+            // Extract file extension if present
+            String baseName = fileName;
+            String extension = ".csv"; // default csv format
+            int lastDotIndex = fileName.lastIndexOf('.');
+            if (lastDotIndex > 0) {
+                baseName = fileName.substring(0, lastDotIndex);
+                extension = fileName.substring(lastDotIndex);
+            }
+
+            File tempFile = File.createTempFile(baseName, extension);
+            FileUtils.copyURLToFile(urlObject, tempFile);
+            logger.info("CSV file created: " + tempFile.getAbsolutePath());
+            return tempFile;
+        } catch (Exception e) {
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access or validate the CSV file. Please check the inputs.", e);
+        }
+    }
+}


### PR DESCRIPTION

# please review this addon and publish as PUBLIC

Addon name : csv_file_update_from_upload_section
Addon accont: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira: https://testsigma.atlassian.net/browse/CUS-9787


# fix 
Added 4 New Nlps, 2 Nlp's to clear cell value at given index, 1 Nlp to write contents in a cell, 1 Nlp to read the contents
Updated existing class to use 1-based indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV cell deletion action (delete value at specified row/column).
  * Added CSV cell deletion with updated file path storage.
  * Added CSV cell value reader action (retrieve and store in variable).
  * Added CSV cell value writer action (update cell content).
  * Added support for both local files and HTTP(S) URLs across all CSV operations.

* **Chores**
  * Updated project version to 1.0.5.
  * Updated commons-lang3 dependency to 3.17.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->