### PR TITLE
feat/CUS-10103-Fix tap action by replacing deprecated TouchAction with W3C Actions

### DIFF
--- a/tap_the_second_character_in_the_element/pom.xml
+++ b/tap_the_second_character_in_the_element/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>tap_the_second_character_in_the_element</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.14.1</version>
+            <version>4.33.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>9.0.0</version>
+            <version>9.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.17.0</version>
         </dependency>
 
 

--- a/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/android/TapSecondCharacter.java
+++ b/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/android/TapSecondCharacter.java
@@ -11,6 +11,11 @@ import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
+
+import java.time.Duration;
+import java.util.Collections;
 
 @Data
 @Action(actionText = "Tap the second character in the element element-locator",
@@ -39,13 +44,18 @@ public class TapSecondCharacter extends AndroidAction {
         int y_offset = elementTop + (int)(elementHeight * 0.2);
         int x_offset = elementLeft + (int)(elementWidth * 0.1);
 
-        TouchAction touchAction = new TouchAction(androidDriver);
-        touchAction.tap(PointOption.point(x_offset, y_offset)).perform();
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+        Sequence tap = new Sequence(finger, 1);
+        tap.addAction(finger.createPointerMove(Duration.ZERO,PointerInput.Origin.viewport(), x_offset, y_offset));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+
+        androidDriver.perform(Collections.singletonList(tap));
         setSuccessMessage("Successfully tapped the second character in the element");
       } catch (Exception e) {
         result = com.testsigma.sdk.Result.FAILED;
         logger.warn("Failed to tap the second character in the element " + ExceptionUtils.getStackTrace(e));
-        setErrorMessage("Failed to tap the second character in the element: " + ExceptionUtils.getStackTrace(e));
+        setErrorMessage("Failed to tap the second character in the element: " + ExceptionUtils.getMessage(e));
       }
     }else{
       result = com.testsigma.sdk.Result.FAILED;

--- a/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/ios/TapSecondCharacter.java
+++ b/tap_the_second_character_in_the_element/src/main/java/com/testsigma/addons/ios/TapSecondCharacter.java
@@ -8,8 +8,14 @@ import io.appium.java_client.TouchAction;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.touch.offset.PointOption;
 import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
+
+import java.time.Duration;
+import java.util.Collections;
 
 @Data
 @Action(actionText = "Tap the second character in the element element-locator",
@@ -38,13 +44,18 @@ public class TapSecondCharacter extends IOSAction {
         int y_offset = elementTop + (int)(elementHeight * 0.2);
         int x_offset = elementLeft + (int)(elementWidth * 0.1);
 
-        TouchAction touchAction = new TouchAction(iosDriver);
-        touchAction.tap(PointOption.point(x_offset, y_offset)).perform();
+        PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+        Sequence tap = new Sequence(finger, 1);
+        tap.addAction(finger.createPointerMove(Duration.ZERO,PointerInput.Origin.viewport(), x_offset, y_offset));
+        tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+
+        iosDriver.perform(Collections.singletonList(tap));
         setSuccessMessage("Successfully tapped the second character in the element");
       } catch (Exception e) {
         result = com.testsigma.sdk.Result.FAILED;
-        logger.warn("Failed to tap the second character in the element" + e);
-        setErrorMessage("Failed to tap the second character in the element: " + e.getMessage());
+        logger.warn("Failed to tap the second character in the element" + ExceptionUtils.getStackTrace(e));
+        setErrorMessage("Failed to tap the second character in the element: " + ExceptionUtils.getMessage(e));
       }
     }else{
       result = com.testsigma.sdk.Result.FAILED;


### PR DESCRIPTION
# Publish this addon as public
Addon Name: Tap the second character in the element
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-10103
Fix tap action by replacing deprecated TouchAction with W3C Actions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released v1.0.4 with dependency updates: Selenium Java to 4.33.0, Appium Java Client to 9.4.0, Commons Lang to 3.17.0.

* **Bug Fixes**
  * Improved tap interaction mechanism for Android and iOS platforms.
  * Enhanced error reporting and logging for better troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->