### PR TITLE
feat/CUS-10170-Added support for the latest chrome permissions

### DIFF
--- a/chrome_site_permissions/pom.xml
+++ b/chrome_site_permissions/pom.xml
@@ -6,14 +6,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>chrome_site_permissions</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.5_cloud</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.24_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>

--- a/chrome_site_permissions/src/main/java/com/testsigma/addons/mobileweb/MyFirstWebAction.java
+++ b/chrome_site_permissions/src/main/java/com/testsigma/addons/mobileweb/MyFirstWebAction.java
@@ -16,12 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Action(
-        actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
-        description = "Set chrome site settings permissions to URL.",
-        applicationType = ApplicationType.MOBILE_WEB,
-        useCustomScreenshot = false
-)
+@Action(actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value", description = "Set chrome site settings permissions to URL.", applicationType = ApplicationType.MOBILE_WEB, useCustomScreenshot = false)
 public class MyFirstWebAction extends WebAction {
 
     @TestData(reference = "Target-URL")
@@ -59,16 +54,33 @@ public class MyFirstWebAction extends WebAction {
 
             // Determine which permission selector to use
             Boolean isOldStructure = (Boolean) js.executeScript(
-                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');"
-            );
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');");
 
+            logger.info("Is old structure flag: " + isOldStructure);
+            Boolean isChrome143Structure = (Boolean) js.executeScript(
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-privacy-page-index')?.shadowRoot.querySelector('#siteSettingsSiteDetails');");
+
+            logger.info("Is Chrome 143+ structure: " + isChrome143Structure);
             String permissionSelect;
-            if (isOldStructure) {
-                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
-                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
+
+            if (isChrome143Structure) {
+                logger.info("Its Chrome 143+ Structure");
+                permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
+                        "  .shadowRoot.querySelector(\"#main\")\n" +
+                        "  .shadowRoot.querySelector(\"settings-privacy-page-index\")\n" +
+                        "  .shadowRoot.querySelector(\"#siteSettingsSiteDetails\")\n" +
+                        "  .shadowRoot.querySelector(\"site-details-permission[label='%s']\")\n" +
+                        "  .shadowRoot.querySelector(\"#permission\")";
+            } else if (isOldStructure) {
+                logger.info("Its Old Structure");
+                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot"
+                        +
+                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot"
+                        +
                         ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
                         ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
             } else {
+                logger.info("Its New Structure (pre-143)");
                 permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
                         "  .shadowRoot.querySelector(\"#main\")\n" +
                         "  .shadowRoot.querySelector(\"#privacy > settings-privacy-page-index\")\n" +
@@ -96,7 +108,7 @@ public class MyFirstWebAction extends WebAction {
         } catch (Exception error) {
             result = com.testsigma.sdk.Result.FAILED;
             logger.info("Exception: " + ExceptionUtils.getStackTrace(error));
-            setErrorMessage("Unable to change site permissions, " + ExceptionUtils.getMessage(error));
+            setErrorMessage("Unable to change site permissions: " + ExceptionUtils.getMessage(error));
             return result;
         } finally {
             driver.switchTo().window(origWindowHandle);

--- a/chrome_site_permissions/src/main/java/com/testsigma/addons/web/MyFirstWebAction.java
+++ b/chrome_site_permissions/src/main/java/com/testsigma/addons/web/MyFirstWebAction.java
@@ -16,12 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Action(
-        actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value",
-        description = "Set chrome site settings permissions to URL.",
-        applicationType = ApplicationType.WEB,
-        useCustomScreenshot = false
-)
+@Action(actionText = "Set chrome permission to URL: Target-URL , Permission Name: Permission-Name, Permission Type: Permission-Value", description = "Set chrome site settings permissions to URL.", applicationType = ApplicationType.WEB, useCustomScreenshot = false)
 public class MyFirstWebAction extends WebAction {
 
     @TestData(reference = "Target-URL")
@@ -59,16 +54,33 @@ public class MyFirstWebAction extends WebAction {
 
             // Determine which permission selector to use
             Boolean isOldStructure = (Boolean) js.executeScript(
-                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');"
-            );
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-basic-page');");
 
+            logger.info("Is old structure flag: " + isOldStructure);
+            Boolean isChrome143Structure = (Boolean) js.executeScript(
+                    "return !!document.querySelector('body > settings-ui')?.shadowRoot.querySelector('#main')?.shadowRoot.querySelector('settings-privacy-page-index')?.shadowRoot.querySelector('#siteSettingsSiteDetails');");
+
+            logger.info("Is Chrome 143+ structure: " + isChrome143Structure);
             String permissionSelect;
-            if (isOldStructure) {
-                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot" +
-                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot" +
+
+            if (isChrome143Structure) {
+                logger.info("Its Chrome 143+ Structure");
+                permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
+                        "  .shadowRoot.querySelector(\"#main\")\n" +
+                        "  .shadowRoot.querySelector(\"settings-privacy-page-index\")\n" +
+                        "  .shadowRoot.querySelector(\"#siteSettingsSiteDetails\")\n" +
+                        "  .shadowRoot.querySelector(\"site-details-permission[label='%s']\")\n" +
+                        "  .shadowRoot.querySelector(\"#permission\")";
+            } else if (isOldStructure) {
+                logger.info("Its Old Structure");
+                permissionSelect = "return document.querySelector(\"body > settings-ui\").shadowRoot.querySelector(\"#main\").shadowRoot"
+                        +
+                        ".querySelector(\"settings-basic-page\").shadowRoot.querySelector(\"#basicPage > settings-section.expanded > settings-privacy-page\").shadowRoot"
+                        +
                         ".querySelector(\"#pages > settings-subpage > site-details\").shadowRoot" +
                         ".querySelector(\"div.list-frame > site-details-permission[label='%s']\").shadowRoot.querySelector(\"#permission\")";
             } else {
+                logger.info("Its New Structure (pre-143)");
                 permissionSelect = "return document.querySelector(\"body > settings-ui\")\n" +
                         "  .shadowRoot.querySelector(\"#main\")\n" +
                         "  .shadowRoot.querySelector(\"#privacy > settings-privacy-page-index\")\n" +
@@ -96,7 +108,7 @@ public class MyFirstWebAction extends WebAction {
         } catch (Exception error) {
             result = com.testsigma.sdk.Result.FAILED;
             logger.info("Exception: " + ExceptionUtils.getStackTrace(error));
-            setErrorMessage("Unable to change site permissions, " + ExceptionUtils.getMessage(error));
+            setErrorMessage("Unable to change site permissions: " + ExceptionUtils.getMessage(error));
             return result;
         } finally {
             driver.switchTo().window(origWindowHandle);


### PR DESCRIPTION
# Publish this addon as public
Addon Name: Chrome site permissions
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-10170
Added support for the latest chrome permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chrome version detection to handle different site permissions structures across Chrome versions, including Chrome 143+ with fallback support for older versions.

* **Bug Fixes**
  * Improved error messaging for site permission changes.

* **Chores**
  * Bumped artifact version to 1.0.8 and updated SDK dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->