### PR TITLE
feat/CUS-10228-Fix Android TV key press (mobile: pressKey + keycode)

### DIFF
--- a/android_tv_operations/pom.xml
+++ b/android_tv_operations/pom.xml
@@ -6,18 +6,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>android_tv_operations</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.6_cloud</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.24_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
     </properties>
 
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.14.1</version>
+            <version>4.33.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>9.0.0</version>
+            <version>9.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.17.0</version>
         </dependency>
 
     </dependencies>

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/KeyUtil.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/KeyUtil.java
@@ -3,7 +3,7 @@ package com.testsigma.addons.android;
 import io.appium.java_client.android.nativekey.AndroidKey;
 
 public class KeyUtil {
-    
+
     public static AndroidKey getKey(String value) {
         AndroidKey androidKey;
         switch (value) {
@@ -130,5 +130,57 @@ public class KeyUtil {
         }
 
         return androidKey;
+    }
+
+    /**
+     * Returns Android KeyEvent keycode (int) for the given key name.
+     * Use with pressKeyCode(keycode) for reliable key injection on Android TV
+     * (works for Down, Menu and other keys where pressKey(KeyEvent) may fail).
+     * Keycodes match android.view.KeyEvent constants.
+     */
+    public static int getKeyCode(String value) {
+        switch (value) {
+            case "Up": return 19;           // KEYCODE_DPAD_UP
+            case "Down": return 20;          // KEYCODE_DPAD_DOWN
+            case "Left": return 21;          // KEYCODE_DPAD_LEFT
+            case "Right": return 22;         // KEYCODE_DPAD_RIGHT
+            case "Ok": return 23;            // KEYCODE_DPAD_CENTER
+            case "Guide": return 172;        // KEYCODE_TV_GUIDE
+            case "Tv-contents-menu": return 256; // KEYCODE_TV_CONTENTS_MENU
+            case "Menu": return 82;          // KEYCODE_MENU
+            case "Info": return 165;         // KEYCODE_INFO
+            case "Ch+": return 166;          // KEYCODE_CHANNEL_UP
+            case "Ch-": return 167;          // KEYCODE_CHANNEL_DOWN
+            case "Back": return 4;           // KEYCODE_BACK
+            case "NUM_0": return 7;          // KEYCODE_0
+            case "NUM_1": return 8;          // KEYCODE_1
+            case "NUM_2": return 9;          // KEYCODE_2
+            case "NUM_3": return 10;         // KEYCODE_3
+            case "NUM_4": return 11;         // KEYCODE_4
+            case "NUM_5": return 12;         // KEYCODE_5
+            case "NUM_6": return 13;        // KEYCODE_6
+            case "NUM_7": return 14;        // KEYCODE_7
+            case "NUM_8": return 15;        // KEYCODE_8
+            case "NUM_9": return 16;        // KEYCODE_9
+            case "Volume-Up": return 24;     // KEYCODE_VOLUME_UP
+            case "Volume-Down": return 25;  // KEYCODE_VOLUME_DOWN
+            case "PlayPause": return 85;    // KEYCODE_MEDIA_PLAY_PAUSE
+            case "Rewind": return 89;       // KEYCODE_MEDIA_REWIND
+            case "Forward": return 90;      // KEYCODE_MEDIA_FAST_FORWARD
+            case "Home": return 3;          // KEYCODE_HOME
+            case "Power": return 26;        // KEYCODE_POWER
+            case "App-switch": return 187;  // KEYCODE_APP_SWITCH
+            case "Soft-left": return 1;     // KEYCODE_SOFT_LEFT
+            case "Soft-right": return 2;    // KEYCODE_SOFT_RIGHT
+            case "Navigate-previous": return 122; // KEYCODE_NAVIGATE_PREVIOUS
+            case "Navigate-next": return 123;     // KEYCODE_NAVIGATE_NEXT
+            case "Navigate-in": return 124;      // KEYCODE_NAVIGATE_IN
+            case "Navigate-out": return 125;     // KEYCODE_NAVIGATE_OUT
+            case "Stem-1-Netflix": return 301;   // KEYCODE_STEM_1
+            case "Stem-2": return 302;           // KEYCODE_STEM_2
+            case "Stem-3": return 303;           // KEYCODE_STEM_3
+            default:
+                throw new IllegalArgumentException("Invalid key value");
+        }
     }
 }

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/LongPressKeyOnRemote.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/LongPressKeyOnRemote.java
@@ -23,7 +23,9 @@ public class LongPressKeyOnRemote extends AndroidAction {
             reference = "key-value",
             allowedValues =
                     {
-                            "Ok"
+                            "Ok","Up","Down","Left","Right",
+                            "Rewind","Forward","Ch+","Ch-",
+                            "Volume-Up","Volume-Down"
                     }
     )
     private com.testsigma.sdk.TestData key;

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyMultipleTimes.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyMultipleTimes.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.nativekey.AndroidKey;
-import io.appium.java_client.android.nativekey.KeyEvent;
 import lombok.Data;
+
+import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 
@@ -44,13 +45,13 @@ public class PressKeyMultipleTimes extends AndroidAction {
         Result result = Result.SUCCESS;
         try {
             logger.info("Initiating execution");
-            AndroidDriver androidDriver = (AndroidDriver)this.driver;
+            AndroidDriver androidDriver = (AndroidDriver) this.driver;
             int noOfTimes = Integer.parseInt(testData.getValue().toString());
             int waitTime = Integer.parseInt(testData1.getValue().toString()) * 1000;
             logger.info("Wait time:" + waitTime + "milliseconds");
-            AndroidKey androidKey = KeyUtil.getKey(key.getValue().toString());
+            int keycode = KeyUtil.getKeyCode(key.getValue().toString());
             for (int i = 0; i < noOfTimes; i++) {
-                androidDriver.pressKey(new KeyEvent(androidKey));
+                CommandExecutionHelper.executeScript(androidDriver, "mobile: pressKey", Map.of("keycode", keycode));
                 logger.info("Press key event done");
                 Thread.sleep(waitTime);
             }

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyOnRemote.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyOnRemote.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.nativekey.AndroidKey;
-import io.appium.java_client.android.nativekey.KeyEvent;
 import lombok.Data;
+
+import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 
@@ -19,18 +20,18 @@ import org.openqa.selenium.NoSuchElementException;
 public class PressKeyOnRemote extends AndroidAction {
 
     @TestData(
-                reference = "key-value",
-                allowedValues =
+            reference = "key-value",
+            allowedValues =
                     {
-                        "Up", "Down", "Left", "Right", "Guide", "Tv-contents-menu",
-                        "Menu", "Info", "Ch+", "Ch-", "Back", "Ok",
-                        "NUM_0", "NUM_1", "NUM_2", "NUM_3", "NUM_4", "NUM_5",
-                        "NUM_6", "NUM_7", "NUM_8", "NUM_9", "Volume-Up", "Volume-Down",
-                        "PlayPause", "Rewind", "Forward", "Home", "Power", "App-switch",
-                        "Soft-left", "Soft-right", "Navigate-previous", "Navigate-next", "Navigate-in", "Navigate-out",
-                        "Stem-1-Netflix", "Stem-2", "Stem-3"
+                            "Up", "Down", "Left", "Right", "Guide", "Tv-contents-menu",
+                            "Menu", "Info", "Ch+", "Ch-", "Back", "Ok",
+                            "NUM_0", "NUM_1", "NUM_2", "NUM_3", "NUM_4", "NUM_5",
+                            "NUM_6", "NUM_7", "NUM_8", "NUM_9", "Volume-Up", "Volume-Down",
+                            "PlayPause", "Rewind", "Forward", "Home", "Power", "App-switch",
+                            "Soft-left", "Soft-right", "Navigate-previous", "Navigate-next", "Navigate-in", "Navigate-out",
+                            "Stem-1-Netflix", "Stem-2", "Stem-3"
                     }
-             )
+    )
     private com.testsigma.sdk.TestData key;
 
     @Override
@@ -38,9 +39,9 @@ public class PressKeyOnRemote extends AndroidAction {
         Result result = Result.SUCCESS;
         try {
             logger.info("Initiating execution");
-            AndroidDriver androidDriver = (AndroidDriver)this.driver;
-            AndroidKey androidKey = KeyUtil.getKey(key.getValue().toString());
-            androidDriver.pressKey(new KeyEvent(androidKey));
+            AndroidDriver androidDriver = (AndroidDriver) this.driver;
+            int keycode = KeyUtil.getKeyCode(key.getValue().toString());
+            CommandExecutionHelper.executeScript(androidDriver, "mobile: pressKey", Map.of("keycode", keycode));
             setSuccessMessage("Pressed the key successfully");
         } catch (IllegalArgumentException e) {
             logger.info("Invalid key value");


### PR DESCRIPTION
# Publish this addon as public
Addon Name: Android TV Operations
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-10228
Fix Android TV key press (mobile: pressKey + keycode)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded remote control key support: long-press operations now support additional keys including Up, Down, Left, Right, Rewind, Forward, Channel +/-, and Volume +/-

* **Chores**
  * Released version 1.0.7
  * Updated core dependencies including Selenium WebDriver and Appium client for improved compatibility and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->