### PR TITLE
feat/CUS-10228-Add PressKeycodeHelper and TV remote key press for Android

### DIFF
--- a/android_tv_operations/pom.xml
+++ b/android_tv_operations/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>android_tv_operations</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/KeyUtil.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/KeyUtil.java
@@ -183,4 +183,49 @@ public class KeyUtil {
                 throw new IllegalArgumentException("Invalid key value");
         }
     }
+
+    public static String getKeyName(int keycode) {
+        switch (keycode) {
+            case 19:  return "Up";
+            case 20:  return "Down";
+            case 21:  return "Left";
+            case 22:  return "Right";
+            case 23:  return "Ok";
+            case 172: return "Guide";
+            case 256: return "Tv-contents-menu";
+            case 82:  return "Menu";
+            case 165: return "Info";
+            case 166: return "Ch+";
+            case 167: return "Ch-";
+            case 4:   return "Back";
+            case 7:   return "NUM_0";
+            case 8:   return "NUM_1";
+            case 9:   return "NUM_2";
+            case 10:  return "NUM_3";
+            case 11:  return "NUM_4";
+            case 12:  return "NUM_5";
+            case 13:  return "NUM_6";
+            case 14:  return "NUM_7";
+            case 15:  return "NUM_8";
+            case 16:  return "NUM_9";
+            case 24:  return "Volume-Up";
+            case 25:  return "Volume-Down";
+            case 85:  return "PlayPause";
+            case 89:  return "Rewind";
+            case 90:  return "Forward";
+            case 3:   return "Home";
+            case 26:  return "Power";
+            case 187: return "App-switch";
+            case 1:   return "Soft-left";
+            case 2:   return "Soft-right";
+            case 122: return "Navigate-previous";
+            case 123: return "Navigate-next";
+            case 124: return "Navigate-in";
+            case 125: return "Navigate-out";
+            case 301: return "Stem-1-Netflix";
+            case 302: return "Stem-2";
+            case 303: return "Stem-3";
+            default:  return "keycode_" + keycode;
+        }
+    }
 }

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyMultipleTimes.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyMultipleTimes.java
@@ -50,8 +50,9 @@ public class PressKeyMultipleTimes extends AndroidAction {
             int waitTime = Integer.parseInt(testData1.getValue().toString()) * 1000;
             logger.info("Wait time:" + waitTime + "milliseconds");
             int keycode = KeyUtil.getKeyCode(key.getValue().toString());
+            logger.info("Key code is: " + keycode);
             for (int i = 0; i < noOfTimes; i++) {
-                CommandExecutionHelper.executeScript(androidDriver, "mobile: pressKey", Map.of("keycode", keycode));
+                PressKeycodeHelper.pressKeyTvRemote(androidDriver, keycode);
                 logger.info("Press key event done");
                 Thread.sleep(waitTime);
             }

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyOnRemote.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeyOnRemote.java
@@ -41,7 +41,8 @@ public class PressKeyOnRemote extends AndroidAction {
             logger.info("Initiating execution");
             AndroidDriver androidDriver = (AndroidDriver) this.driver;
             int keycode = KeyUtil.getKeyCode(key.getValue().toString());
-            CommandExecutionHelper.executeScript(androidDriver, "mobile: pressKey", Map.of("keycode", keycode));
+            logger.info("Key code is: " + keycode);
+            PressKeycodeHelper.pressKeyTvRemote(androidDriver, keycode);
             setSuccessMessage("Pressed the key successfully");
         } catch (IllegalArgumentException e) {
             logger.info("Invalid key value");

--- a/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeycodeHelper.java
+++ b/android_tv_operations/src/main/java/com/testsigma/addons/android/PressKeycodeHelper.java
@@ -1,0 +1,53 @@
+package com.testsigma.addons.android;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.android.AndroidDriver;
+import org.openqa.selenium.WebDriverException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PressKeycodeHelper {
+
+    private static final String EXT_NAME = "mobile: pressKey";
+    private static final String FALLBACK_COMMAND = "pressKeycode";
+    private static final int TV_REMOTE_DELAY_MS = 2000;
+
+    private PressKeycodeHelper() {
+    }
+
+    public static void pressKeyTvRemote(AndroidDriver driver, int keycode) {
+        try {
+            Thread.sleep(TV_REMOTE_DELAY_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("TV remote key delay interrupted", e);
+        }
+        String keyName = KeyUtil.getKeyName(keycode);
+        System.out.println("Sending " + keyName + " from TV REMOTE");
+        pressKeycode(driver, keycode);
+    }
+
+    public static void pressKeycode(AndroidDriver driver, int keycode,
+                                    Integer metastate, Integer flags) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("keycode", keycode);
+        if (metastate != null) {
+            args.put("metastate", metastate);
+        }
+        if (flags != null) {
+            args.put("flags", flags);
+        }
+
+        try {
+            CommandExecutionHelper.executeScript(driver, EXT_NAME, args);
+        } catch (WebDriverException e) {
+            // Fallback for servers that do not support the "mobile: pressKey" extension
+            driver.execute(FALLBACK_COMMAND, args);
+        }
+    }
+
+    public static void pressKeycode(AndroidDriver driver, int keycode) {
+        pressKeycode(driver, keycode, null, null);
+    }
+}


### PR DESCRIPTION
# Publish this addon as public
Addon Name: Android TV Operations
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-10228
Add PressKeycodeHelper and TV remote key press for Android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.8

* **Refactor**
  * Improved Android TV remote key press handling with enhanced utility methods and fallback mechanisms for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->