### PR TITLE
feat/CUS-10170-Added support for chrome 141v

### DIFF
--- a/mock_geo_location/pom.xml
+++ b/mock_geo_location/pom.xml
@@ -6,14 +6,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>mock_geo_location</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.20_cloud_beta</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.24_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
@@ -48,13 +48,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.33.0</version>
+            <version>4.37.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>9.0.0</version>
+            <version>9.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/mock_geo_location/src/main/java/com/testsigma/addons/web/MockGeoLocationAction.java
+++ b/mock_geo_location/src/main/java/com/testsigma/addons/web/MockGeoLocationAction.java
@@ -9,13 +9,12 @@ import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.devtools.Command;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
+import org.openqa.selenium.devtools.v141.emulation.Emulation;
 import org.openqa.selenium.remote.Augmenter;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 
 @Data
 @Action(
@@ -69,7 +68,7 @@ public class MockGeoLocationAction extends WebAction {
 
       // Enhance the driver to support DevTools
       logger.info("Augmenting driver to support DevTools...");
-      WebDriver driver1 = driver;
+      WebDriver driver1 = this.driver;
       driver1 = new Augmenter().augment(driver1);
 
       // Initialize DevTools and create a session
@@ -78,12 +77,17 @@ public class MockGeoLocationAction extends WebAction {
       devTool.createSessionIfThereIsNotOne();
       logger.info("DevTools session successfully created.");
 
-      Map<String, Object> coordinates = new HashMap<>();
-      coordinates.put("latitude", latitude);
-      coordinates.put("longitude", longitude);
-      coordinates.put("accuracy", accuracy);
-
-      devTool.send(new Command<>("Emulation.setGeolocationOverride", coordinates));
+      devTool.send(
+              Emulation.setGeolocationOverride(
+                      Optional.of(latitude),
+                      Optional.of(longitude),
+                      Optional.of(accuracy),
+                      Optional.empty(),
+                      Optional.empty(),
+                      Optional.empty(),
+                      Optional.empty()
+              )
+      );
 
       logger.info("Geolocation override applied successfully.");
     } catch (Exception e) {


### PR DESCRIPTION
# Publish this addon as public
Addon Name: Mock Geo Location
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Addon ticket: https://testsigma.atlassian.net/browse/CUS-10170
Added support for chrome 141v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mock_geo_location version to 1.0.11
  * Upgraded Selenium Java to 4.37.0 and Appium Java Client to 9.4.0
  * Updated SDK version to 1.2.24_cloud

* **Refactor**
  * Improved geolocation override implementation for better stability and type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->