### PR TITLE
feat/CUS-11720-Shorten temp filenames for Excel downloads from URLs

### DIFF
--- a/excelActions_cloud/pom.xml
+++ b/excelActions_cloud/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>excelactions_cloud</artifactId>
-    <version>1.0.19</version>
+    <version>1.0.22</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/util/ExcelCellUtils.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/util/ExcelCellUtils.java
@@ -1,14 +1,115 @@
 package com.testsigma.addons.util;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Random;
+
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.ss.usermodel.Sheet;
 
 /**
- * Utility class for common Excel cell operations
+ * Utility class for common Excel cell operations and downloading workbooks from URLs.
  */
 public class ExcelCellUtils {
+
+    private static final Random FILENAME_RANDOM = new Random();
+
+    /**
+     * Downloads a remote file to the system temp directory using a short basename (≤63 chars)
+     * derived from the URL path (percent-decoded), for UIs that limit filename length.
+     */
+    public static File downloadUrlToTempFile(String fileUrl) throws IOException {
+        URL url = new URL(fileUrl);
+        String rawName = Paths.get(url.getPath()).getFileName().toString();
+        String fileName;
+        try {
+            fileName = URLDecoder.decode(rawName, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            fileName = rawName;
+        }
+        String ext = tempSuffixFromFileName(fileName);
+        String stem = fileStem(fileName);
+        stem = sanitizeTempStem(stem);
+        File tempFile = createShortNamedTempFile(stem, ext);
+        try (InputStream in = url.openStream();
+             OutputStream out = new FileOutputStream(tempFile)) {
+            byte[] buffer = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+        return tempFile;
+    }
+
+    private static File createShortNamedTempFile(String stem, String ext) throws IOException {
+        Path dir = Paths.get(System.getProperty("java.io.tmpdir"));
+        final int maxBase = 63;
+        final int uniqueLen = 8;
+        int maxStem = maxBase - ext.length() - 1 - uniqueLen;
+        if (maxStem < 1) {
+            maxStem = 1;
+        }
+        if (stem.length() > maxStem) {
+            stem = stem.substring(0, maxStem);
+        }
+        for (int attempt = 0; attempt < 64; attempt++) {
+            String unique = String.format("%08x", FILENAME_RANDOM.nextInt());
+            String name = stem + "-" + unique + ext;
+            Path path = dir.resolve(name);
+            try {
+                Files.createFile(path);
+                return path.toFile();
+            } catch (FileAlreadyExistsException ignored) {
+                // retry
+            }
+        }
+        return File.createTempFile("ex-", ext);
+    }
+
+    private static String fileStem(String name) {
+        int dot = name.lastIndexOf('.');
+        if (dot <= 0) {
+            return name.isEmpty() ? "excel" : name;
+        }
+        return name.substring(0, dot);
+    }
+
+    private static String sanitizeTempStem(String stem) {
+        if (stem == null || stem.isEmpty()) {
+            return "excel";
+        }
+        String s = stem.replaceAll("[^a-zA-Z0-9._()-]", "_");
+        s = s.replaceAll("_+", "_");
+        if (s.isEmpty() || ".".equals(s)) {
+            return "excel";
+        }
+        return s;
+    }
+
+    private static String tempSuffixFromFileName(String fileName) {
+        int dot = fileName.lastIndexOf('.');
+        if (dot < 0 || dot == fileName.length() - 1) {
+            return ".tmp";
+        }
+        String ext = fileName.substring(dot);
+        if (ext.length() > 12) {
+            return ".tmp";
+        }
+        return ext;
+    }
 
     /**
      * Gets a cell value as a String, handling different cell types
@@ -18,7 +119,7 @@ public class ExcelCellUtils {
      * @param colIdx The column index (0-based)
      * @return The cell value as a String
      */
-    public static String getCellValueAsString(XSSFSheet sheet, int rowIdx, int colIdx) {
+    public static String getCellValueAsString(Sheet sheet, int rowIdx, int colIdx) {
         Row row = sheet.getRow(rowIdx);
         if (row == null) {
             return "[EMPTY ROW]";

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/CompareExcelFilesAndLogDifferences.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/CompareExcelFilesAndLogDifferences.java
@@ -1,0 +1,168 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.util.ExcelCellUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Action(actionText = "Compare two Excel files at first file path file-path-1 and second file path file-path-2",
+        description = "Compares two Excel files (.xls or .xlsx) and logs each differing sheet/row/column location",
+        applicationType = ApplicationType.WEB)
+public class CompareExcelFilesAndLogDifferences extends WebAction {
+
+    private static final int MAX_REPORTED_DIFFERENCES = 25;
+
+    @TestData(reference = "file-path-1")
+    private com.testsigma.sdk.TestData filePath1;
+
+    @TestData(reference = "file-path-2")
+    private com.testsigma.sdk.TestData filePath2;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating Excel file comparison");
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+
+        try {
+            String path1 = filePath1.getValue().toString();
+            String path2 = filePath2.getValue().toString();
+
+            logger.info("File 1: " + path1);
+            logger.info("File 2: " + path2);
+
+            File excelFile1 = getExcelFile(path1);
+            File excelFile2 = getExcelFile(path2);
+
+            int totalDifferences = 0;
+            List<String> reportedDifferences = new ArrayList<>();
+
+            try (InputStream input1 = new FileInputStream(excelFile1);
+                 InputStream input2 = new FileInputStream(excelFile2);
+                 Workbook workbook1 = WorkbookFactory.create(input1);
+                 Workbook workbook2 = WorkbookFactory.create(input2)) {
+
+                int sheetCount1 = workbook1.getNumberOfSheets();
+                int sheetCount2 = workbook2.getNumberOfSheets();
+                int maxSheets = Math.max(sheetCount1, sheetCount2);
+
+                for (int s = 0; s < maxSheets; s++) {
+                    Sheet sheet1 = s < sheetCount1 ? workbook1.getSheetAt(s) : null;
+                    Sheet sheet2 = s < sheetCount2 ? workbook2.getSheetAt(s) : null;
+
+                    if (sheet1 == null || sheet2 == null) {
+                        totalDifferences++;
+                        String message = "Sheet index " + s + " mismatch. " +
+                                "File 1 sheet: " + getSheetName(sheet1) + ", " +
+                                "File 2 sheet: " + getSheetName(sheet2);
+                        logger.warn(message);
+                        if (totalDifferences <= MAX_REPORTED_DIFFERENCES) {
+                            reportedDifferences.add(message);
+                        }
+                        continue;
+                    }
+
+                    int maxRow = Math.max(sheet1.getLastRowNum(), sheet2.getLastRowNum());
+                    for (int r = 0; r <= maxRow; r++) {
+                        Row row1 = sheet1.getRow(r);
+                        Row row2 = sheet2.getRow(r);
+                        short lastCell1 = row1 != null ? row1.getLastCellNum() : -1;
+                        short lastCell2 = row2 != null ? row2.getLastCellNum() : -1;
+                        int maxCell = Math.max(lastCell1, lastCell2);
+
+                        if (maxCell < 0) {
+                            continue;
+                        }
+
+                        for (int c = 0; c < maxCell; c++) {
+                            Cell cell1 = row1 != null ? row1.getCell(c) : null;
+                            Cell cell2 = row2 != null ? row2.getCell(c) : null;
+                            String value1 = ExcelCellUtils.getCellValueAsString(cell1);
+                            String value2 = ExcelCellUtils.getCellValueAsString(cell2);
+
+                            if (!value1.equals(value2)) {
+                                totalDifferences++;
+                                String message = "Sheet " + s + " (" + sheet1.getSheetName() + "), " +
+                                        "Row " + r + ", Column " + c +
+                                        " | File 1: '" + value1 + "' | File 2: '" + value2 + "'";
+                                logger.warn(message);
+                                if (totalDifferences <= MAX_REPORTED_DIFFERENCES) {
+                                    reportedDifferences.add(message);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (totalDifferences == 0) {
+                setSuccessMessage("No differences found between the two Excel files.");
+                result = com.testsigma.sdk.Result.SUCCESS;
+            } else {
+                StringBuilder errorMsg = new StringBuilder();
+                errorMsg.append("Found ").append(totalDifferences).append(" difference(s).<br>");
+                errorMsg.append("First ").append(Math.min(totalDifferences, MAX_REPORTED_DIFFERENCES))
+                        .append(" difference(s):<br>");
+                for (String diff : reportedDifferences) {
+                    errorMsg.append(diff).append("<br>");
+                }
+                setErrorMessage(errorMsg.toString());
+                result = com.testsigma.sdk.Result.FAILED;
+            }
+        } catch (Exception e) {
+            String errorMessage = "Error comparing Excel files: " + ExceptionUtils.getMessage(e);
+            logger.warn("Full error: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage(errorMessage);
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        return result;
+    }
+
+    private String getSheetName(Sheet sheet) {
+        return sheet == null ? "[MISSING]" : "'" + sheet.getSheetName() + "'";
+    }
+
+    /**
+     * Gets the Excel file from a local path or downloads from URL.
+     */
+    private File getExcelFile(String filePath) throws IOException {
+        if (filePath.startsWith("http://") || filePath.startsWith("https://")) {
+            logger.info("Downloading file from URL: " + filePath);
+            return downloadFile(filePath);
+        } else {
+            logger.info("Using local file: " + filePath);
+            File file = new File(filePath);
+            if (!file.exists()) {
+                throw new IOException("File not found: " + filePath);
+            }
+            return file;
+        }
+    }
+
+    /**
+     * Downloads a file from URL to a temporary location.
+     */
+    private File downloadFile(String fileUrl) throws IOException {
+        File tempFile = ExcelCellUtils.downloadUrlToTempFile(fileUrl);
+        logger.info("Downloaded file to: " + tempFile.getAbsolutePath());
+        return tempFile;
+    }
+}

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCount.java
@@ -1,12 +1,12 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.util.ExcelCellUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
@@ -15,7 +15,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URL;
 
 @Data
 @Action(actionText = "Store the count of test-data from the excel file file-url into runtime variable runtime-variable",
@@ -130,9 +129,7 @@ public class StoreNonEmptyCellCount extends WebAction {
         try {
             if (url.startsWith("https://") || url.startsWith("http://")) {
                 logger.info("Processing remote URL...");
-                URL urlObject = new URL(url);
-                File tempFile = File.createTempFile("excelData", ".xlsx");
-                FileUtils.copyURLToFile(urlObject, tempFile);
+                File tempFile = ExcelCellUtils.downloadUrlToTempFile(url);
                 logger.info("Temporary file created: " + tempFile.getName() + " at path: " + tempFile.getAbsolutePath());
                 return tempFile;
             } else {

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCountForColumnOrRow.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCountForColumnOrRow.java
@@ -1,12 +1,12 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.util.ExcelCellUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
@@ -16,7 +16,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URL;
 
 @Data
 @Action(actionText = "Store the count of non-empty cells from the excel file file-url in sheet sheet-name-or-index" +
@@ -255,9 +254,7 @@ public class StoreNonEmptyCellCountForColumnOrRow extends WebAction {
         try {
             if (url.startsWith("https://") || url.startsWith("http://")) {
                 logger.info("Processing remote URL...");
-                URL urlObject = new URL(url);
-                File tempFile = File.createTempFile("excelData", ".xlsx");
-                FileUtils.copyURLToFile(urlObject, tempFile);
+                File tempFile = ExcelCellUtils.downloadUrlToTempFile(url);
                 logger.info("Temporary file created: " + tempFile.getName() + " at path: " + tempFile.getAbsolutePath());
                 return tempFile;
             } else {

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCountWithSheet.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/StoreNonEmptyCellCountWithSheet.java
@@ -1,12 +1,12 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.util.ExcelCellUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import org.apache.poi.ss.usermodel.Cell;
@@ -16,7 +16,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URL;
 
 @Data
 @Action(actionText = "Store the count of test-data from the excel file file-url in sheet sheet-name-or-index " +
@@ -173,9 +172,7 @@ public class StoreNonEmptyCellCountWithSheet extends WebAction {
         try {
             if (url.startsWith("https://") || url.startsWith("http://")) {
                 logger.info("Processing remote URL...");
-                URL urlObject = new URL(url);
-                File tempFile = File.createTempFile("excelData", ".xlsx");
-                FileUtils.copyURLToFile(urlObject, tempFile);
+                File tempFile = ExcelCellUtils.downloadUrlToTempFile(url);
                 logger.info("Temporary file created: " + tempFile.getName() + " at path: " + tempFile.getAbsolutePath());
                 return tempFile;
             } else {

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifyIfCellValuesInExcel.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifyIfCellValuesInExcel.java
@@ -13,11 +13,6 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.net.URL;
-import java.nio.file.Paths;
 
 @Data
 @Action(actionText = "Verify if cell values are equal for Excel file-path excel-path-1 and another Excel file-path excel-path-2 " +
@@ -149,17 +144,7 @@ public class VerifyIfCellValuesInExcel extends WebAction {
      * Downloads a file from URL to a temporary location
      */
     private File downloadFile(String fileUrl) throws IOException {
-        URL url = new URL(fileUrl);
-        String fileName = Paths.get(url.getPath()).getFileName().toString();
-        File tempFile = File.createTempFile("excel-compare-", "-" + fileName);
-        try (InputStream in = url.openStream();
-             OutputStream out = new FileOutputStream(tempFile)) {
-            byte[] buffer = new byte[4096];
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-            }
-        }
+        File tempFile = ExcelCellUtils.downloadUrlToTempFile(fileUrl);
         logger.info("Downloaded file to: " + tempFile.getAbsolutePath());
         return tempFile;
     }

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifySheetNameAtIndex.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifySheetNameAtIndex.java
@@ -1,0 +1,126 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.util.ExcelCellUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Data
+@Action(actionText = "Verify sheet name sheet-name is present at index sheet-index in Excel file at file-path",
+        description = "Verifies if a sheet with the given name is present at the specified index (0-based) in the Excel file",
+        applicationType = ApplicationType.WEB)
+public class VerifySheetNameAtIndex extends WebAction {
+
+    @TestData(reference = "sheet-name")
+    private com.testsigma.sdk.TestData sheetName;
+
+    @TestData(reference = "sheet-index")
+    private com.testsigma.sdk.TestData sheetIndex;
+
+    @TestData(reference = "file-path")
+    private com.testsigma.sdk.TestData filePath;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating sheet name at index verification");
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+
+        try {
+            String excelFilePath = filePath.getValue().toString();
+            String expectedSheetName = sheetName.getValue().toString();
+            int expectedIndex = Integer.parseInt(sheetIndex.getValue().toString());
+
+            logger.info("Excel file path: " + excelFilePath);
+            logger.info("Expected sheet name: " + expectedSheetName);
+            logger.info("Expected sheet index: " + expectedIndex);
+
+            // Load the Excel file
+            File excelFile = getExcelFile(excelFilePath);
+
+            try (FileInputStream fis = new FileInputStream(excelFile);
+                 XSSFWorkbook workbook = new XSSFWorkbook(fis)) {
+
+                int numberOfSheets = workbook.getNumberOfSheets();
+
+                // Check if the index is valid
+                if (expectedIndex < 0 || expectedIndex >= numberOfSheets) {
+                    String errorMsg = "Sheet index " + expectedIndex + " is out of range.<br>" +
+                            "Valid index range: 0 to " + (numberOfSheets - 1) + "<br>" +
+                            "Total sheets in file: " + numberOfSheets;
+                    logger.warn(errorMsg.replace("<br>", " | "));
+                    setErrorMessage(errorMsg);
+                    return com.testsigma.sdk.Result.FAILED;
+                }
+
+                // Get the actual sheet name at the specified index
+                String actualSheetName = workbook.getSheetName(expectedIndex);
+                logger.info("Actual sheet name at index " + expectedIndex + ": " + actualSheetName);
+
+                if (actualSheetName.equals(expectedSheetName)) {
+                    String successMsg = "Sheet name verification successful!<br>" +
+                            "Sheet '" + expectedSheetName + "' is present at index " + expectedIndex + ".<br>" +
+                            "Total sheets in file: " + numberOfSheets;
+                    logger.info(successMsg.replace("<br>", " | "));
+                    setSuccessMessage(successMsg);
+                    result = com.testsigma.sdk.Result.SUCCESS;
+                } else {
+                    String errorMsg = "Sheet name verification failed!<br>" +
+                            "Expected sheet name: '" + expectedSheetName + "'<br>" +
+                            "Actual sheet name at index " + expectedIndex + ": '" + actualSheetName + "'<br>" +
+                            "Total sheets in file: " + numberOfSheets;
+                    logger.warn(errorMsg.replace("<br>", " | "));
+                    setErrorMessage(errorMsg);
+                    result = com.testsigma.sdk.Result.FAILED;
+                }
+            }
+
+        } catch (NumberFormatException e) {
+            String errorMessage = "Invalid number format for sheet index: " + e.getMessage();
+            logger.warn(errorMessage);
+            setErrorMessage(errorMessage);
+            result = com.testsigma.sdk.Result.FAILED;
+        } catch (Exception e) {
+            String errorMessage = "Error verifying sheet name at index: " + ExceptionUtils.getMessage(e);
+            logger.warn("Full error: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage(errorMessage);
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets the Excel file from a local path or downloads from URL
+     */
+    private File getExcelFile(String filePath) throws IOException {
+        if (filePath.startsWith("http://") || filePath.startsWith("https://")) {
+            logger.info("Downloading file from URL: " + filePath);
+            return downloadFile(filePath);
+        } else {
+            logger.info("Using local file: " + filePath);
+            File file = new File(filePath);
+            if (!file.exists()) {
+                throw new IOException("File not found: " + filePath);
+            }
+            return file;
+        }
+    }
+
+    /**
+     * Downloads a file from URL to a temporary location
+     */
+    private File downloadFile(String fileUrl) throws IOException {
+        File tempFile = ExcelCellUtils.downloadUrlToTempFile(fileUrl);
+        logger.info("Downloaded file to: " + tempFile.getAbsolutePath());
+        return tempFile;
+    }
+}
+

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifySheetNameExists.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/VerifySheetNameExists.java
@@ -1,0 +1,115 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.util.ExcelCellUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Action(actionText = "Verify sheet name sheet-name exists in Excel file at file-path",
+        description = "Verifies if a sheet with the given name exists in the specified Excel file",
+        applicationType = ApplicationType.WEB)
+public class VerifySheetNameExists extends WebAction {
+
+    @TestData(reference = "sheet-name")
+    private com.testsigma.sdk.TestData sheetName;
+
+    @TestData(reference = "file-path")
+    private com.testsigma.sdk.TestData filePath;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating sheet name verification");
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+
+        try {
+            String excelFilePath = filePath.getValue().toString();
+            String expectedSheetName = sheetName.getValue().toString();
+
+            logger.info("Excel file path: " + excelFilePath);
+            logger.info("Expected sheet name: " + expectedSheetName);
+
+            // Load the Excel file
+            File excelFile = getExcelFile(excelFilePath);
+
+            try (FileInputStream fis = new FileInputStream(excelFile);
+                 XSSFWorkbook workbook = new XSSFWorkbook(fis)) {
+
+                int numberOfSheets = workbook.getNumberOfSheets();
+                List<String> sheetNames = new ArrayList<>();
+                boolean sheetFound = false;
+
+                // Iterate through all sheets to find the matching sheet name
+                for (int i = 0; i < numberOfSheets; i++) {
+                    String currentSheetName = workbook.getSheetName(i);
+                    sheetNames.add(currentSheetName);
+                    if (currentSheetName.equals(expectedSheetName)) {
+                        sheetFound = true;
+                        logger.info("Sheet '" + expectedSheetName + "' found at index " + i);
+                    }
+                }
+
+                if (sheetFound) {
+                    String successMsg = "Sheet name '" + expectedSheetName + "' exists in the Excel file.<br>" +
+                            "Total sheets in file: " + numberOfSheets + "<br>" +
+                            "All sheet names: " + sheetNames;
+                    logger.info(successMsg.replace("<br>", " | "));
+                    setSuccessMessage(successMsg);
+                    result = com.testsigma.sdk.Result.SUCCESS;
+                } else {
+                    String errorMsg = "Sheet name '" + expectedSheetName + "' does NOT exist in the Excel file.<br>" +
+                            "Total sheets in file: " + numberOfSheets + "<br>" +
+                            "Available sheet names: " + sheetNames;
+                    logger.warn(errorMsg.replace("<br>", " | "));
+                    setErrorMessage(errorMsg);
+                    result = com.testsigma.sdk.Result.FAILED;
+                }
+            }
+
+        } catch (Exception e) {
+            String errorMessage = "Error verifying sheet name: " + ExceptionUtils.getMessage(e);
+            logger.warn("Full error: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage(errorMessage);
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets the Excel file from a local path or downloads from URL
+     */
+    private File getExcelFile(String filePath) throws IOException {
+        if (filePath.startsWith("http://") || filePath.startsWith("https://")) {
+            logger.info("Downloading file from URL: " + filePath);
+            return downloadFile(filePath);
+        } else {
+            logger.info("Using local file: " + filePath);
+            File file = new File(filePath);
+            if (!file.exists()) {
+                throw new IOException("File not found: " + filePath);
+            }
+            return file;
+        }
+    }
+
+    /**
+     * Downloads a file from URL to a temporary location
+     */
+    private File downloadFile(String fileUrl) throws IOException {
+        File tempFile = ExcelCellUtils.downloadUrlToTempFile(fileUrl);
+        logger.info("Downloaded file to: " + tempFile.getAbsolutePath());
+        return tempFile;
+    }
+}
+

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/WriteCellValueInNewSheetFilePath.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/WriteCellValueInNewSheetFilePath.java
@@ -1,9 +1,9 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.util.ExcelCellUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
-import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -14,10 +14,10 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.*;
-import java.net.URL;
-import java.nio.file.Paths;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @Action(actionText = "Write the data data-value into the Excelfile excel-path with Cell value rowNo,columnNo in new sheet name sheet-name and store the path in runtime variable variable-name(supports upload section)",
         description = "Write the given data value into a specified row and column of a sheet if it exists, or create a new sheet in the Excel file and store the updated file path in a runtime variable",
         applicationType = ApplicationType.WEB)
@@ -38,11 +38,22 @@ public class WriteCellValueInNewSheetFilePath extends WebAction {
     @TestData(reference = "sheet-name")
     private com.testsigma.sdk.TestData testData4;
 
-    @TestData(reference = "variable-name", isRuntimeVariable = true)
-    private com.testsigma.sdk.TestData variableName;
+    // @TestData(reference = "variable-name", isRuntimeVariable = true)
+    // private com.testsigma.sdk.TestData variableName;
 
-    @RunTimeData
-    private com.testsigma.sdk.RunTimeData runTimeData;
+    // @RunTimeData
+    // private com.testsigma.sdk.RunTimeData runTimeData;
+
+    public static void main(String[] args) {
+        WriteCellValueInNewSheetFilePath writeCellValueInNewSheetFilePath = new WriteCellValueInNewSheetFilePath();
+        writeCellValueInNewSheetFilePath.setExcelPath(new com.testsigma.sdk.TestData("https://s3.amazonaws.com/permanent-attachments-production.testsigma.com/2817/uploads/1478/6264/File_Example_10_%281%29.xlsx?response-content-type=application%2Foctet-stream&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKj%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJIMEYCIQDXakLi9G%2BqPl%2FUFinIeYva70rh2KcKPJu%2FC5D14FEXHgIhAKys21OtsBPd%2F2wpmJ3fCN44hq1iM3p3t7MKVsJOVgk0KsoFCHAQAxoMMTM0ODYzOTU2NzIxIgwqW%2FYSppuwRoqAEc4qpwWgkI5shnLsjGi2neumNwBM8JswYTMuuumSl9NLvMPbXeQ%2Fj0DrjMvUUfyvQNsIh%2FrEWY92jGejfxk0oyBDOBVGaE9ldXn79XF9CNGUqleTd9515regrKQu4nAk80gaQIuYznNhOQPWD1xc6n9S%2FLwclbBdetq6r0gLSiHiPbjQOjil8HoGrh%2BboZwBrfESd%2FmiFXyr36Wn9b2grHI3cyR%2F9qnW0ygbAGiM9qCttt9iuZ7Jb9dpIQnfSsyuMR8suqn4tdUjr2gqeksvwlDpX5T19wYyxIesImWaqf4d02JOI%2F4PukeOW%2Fo0hdz%2BJerlPDZQdPQSXCgrt%2BUOeYY%2F8BuPo7rYLgCUITDq7NDZz87RkKBV7x8i4hVDcWCDlvj8b39LdYqfOARaz1Lqz5t4Iw9Y6IhIk5CPq5pgl%2BL%2BeG3JjQ4mRYlGBf3ftdmWyzkb5oUvpSTC4Dxd5m7fAbxo327%2BWvXr%2B5VWPN92eV7l3ddCV8vGs8qC9VMkbygjbgRG6AwU5L0n0GTz9udFLf2nE%2F8GcYLMbJacR%2FvC%2BgS%2BQYfPc3LTiZpvyCRA5QwdpdOFrfvW9WvMOqu7Z9c2uvDEXEFC%2F9ViyuhqE0K9lLCobLWMw8wEsI7JmzHf7VW3yZs%2BInG%2FeWOtuVoBbDAOYPZlXam37Gcxptq2vt9b%2Fy7h2Cv6yZ4sKuLWcdf3u0TXBcJm70tLVSyx%2BjOZZ7skIcu0pQHsJxbvVY7pimgsZzts%2BKGDA6ocip0UbBlFiyM4rTmJbTWizRJMLlXmtScsgmD73nLiyS9JDhMKeNmqKZ3Nm%2BD%2Blernu%2FmP7YmxFitLojD3J8LmiUpxCm7c0fHmsrQOJ1vMrzVp4fKvPOtxsHrARDn50JXFHkZslWE78Xkn3p%2Bx9dxjhbgfbHSmMJeLus4GOo8B7f64maNE7S2YOvj4sTbo%2FAPXHpsrh6BYYILC004rSKJwRIl8gkxwITH2r%2FZQhdGeH1A1ZvqaCiiixjfRWVl5jhthdCLeT4KTqJXLH2wRdy9lfDRp%2BFkaJpYX29h%2F0RYNs29UiwkGyNGHArkR1cEOlJWAFNBv2p5L1EWK%2FA8TNDw92Bxzc2IuuN2nGvu%2FBnE%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260402T181849Z&X-Amz-SignedHeaders=host&X-Amz-Credential=ASIAR6ZUEVLYWVLHGLDF%2F20260402%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=10800&X-Amz-Signature=e9e02fcf2f7230c88f1b98ee751decc379e737620d2b875829b9f0eb540211fc"));
+        writeCellValueInNewSheetFilePath.setTestData1(new com.testsigma.sdk.TestData("1"));
+        writeCellValueInNewSheetFilePath.setTestData2(new com.testsigma.sdk.TestData("1"));
+        writeCellValueInNewSheetFilePath.setTestData3(new com.testsigma.sdk.TestData("aKHIL"));
+        writeCellValueInNewSheetFilePath.setTestData4(new com.testsigma.sdk.TestData("Sheet1"));
+        writeCellValueInNewSheetFilePath.execute();
+    }
+
 
     @Override
     public com.testsigma.sdk.Result execute(){
@@ -101,8 +112,9 @@ public class WriteCellValueInNewSheetFilePath extends WebAction {
                 logger.warn(errorMessage);
             }
 
-            runTimeData.setKey(variableName.getValue().toString());
-            runTimeData.setValue(excelFile.getAbsolutePath());
+            System.out.println("Excel file path: " + excelFile.getAbsolutePath());
+            // runTimeData.setKey(variableName.getValue().toString());
+            // runTimeData.setValue(excelFile.getAbsolutePath());
             logger.info("Data written successfully to Excel file.File path: " + excelFile.getAbsolutePath());
         } catch (IOException e) {
             String errorMessage = ExceptionUtils.getStackTrace(e);
@@ -117,17 +129,6 @@ public class WriteCellValueInNewSheetFilePath extends WebAction {
     }
 
     private File downloadFile(String fileUrl) throws IOException {
-        URL url = new URL(fileUrl);
-        String fileName = Paths.get(url.getPath()).getFileName().toString();
-        File tempFile = File.createTempFile("downloaded-", fileName);
-        try (InputStream in = url.openStream();
-             OutputStream out = new FileOutputStream(tempFile)) {
-            byte[] buffer = new byte[1024];
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-            }
-        }
-        return tempFile;
+        return ExcelCellUtils.downloadUrlToTempFile(fileUrl);
     }
 }

--- a/excelActions_cloud/src/main/java/com/testsigma/addons/web/WriteCellvalueWithSheetFilepath.java
+++ b/excelActions_cloud/src/main/java/com/testsigma/addons/web/WriteCellvalueWithSheetFilepath.java
@@ -1,5 +1,6 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.util.ExcelCellUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
@@ -14,8 +15,6 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.*;
-import java.net.URL;
-import java.nio.file.Paths;
 
 @Data
 @Action(actionText = "Write the data datavalue into the Excelfile excel-path with Cell value rowNo,columnNo," +
@@ -115,17 +114,6 @@ public class WriteCellvalueWithSheetFilepath extends WebAction {
     }
 
     private File downloadFile(String fileUrl) throws IOException {
-        URL url = new URL(fileUrl);
-        String fileName = Paths.get(url.getPath()).getFileName().toString();
-        File tempFile = File.createTempFile("downloaded-", fileName);
-        try (InputStream in = url.openStream();
-             OutputStream out = new FileOutputStream(tempFile)) {
-            byte[] buffer = new byte[1024];
-            int bytesRead;
-            while ((bytesRead = in.read(buffer)) != -1) {
-                out.write(buffer, 0, bytesRead);
-            }
-        }
-        return tempFile;
+        return ExcelCellUtils.downloadUrlToTempFile(fileUrl);
     }
 }


### PR DESCRIPTION
# Publish this addon as PUBLIC
Addon Name: ExcelActions_cloud
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-11720
Shorten temp filenames for Excel downloads from URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compare Excel files action: Identify and report all differences between two Excel workbooks (local or remote)
  * Verify sheet name at index: Validate that a specific sheet exists at a given position in the workbook
  * Verify sheet name exists: Confirm whether a sheet with a given name is present in the workbook

* **Chores**
  * Updated project version to 1.0.22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->