### PR TITLE
[CUS-12130] updated add-on to store filename/path/extension

### DIFF
--- a/get_latest_downloaded_file_path/pom.xml
+++ b/get_latest_downloaded_file_path/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>get_latest_downloaded_file_path</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFileName.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFileName.java
@@ -1,0 +1,103 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.Utilities;
+import com.testsigma.addons.web.util.UtilitiesFactory;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Action(actionText = "Get latest downloaded content and store in runtime variable variable-name",
+        description = "Retrieves the local path of the most recently downloaded file from the browser" +
+                " (Chrome/Edge) and stores it in a runtime variable.",
+        applicationType = ApplicationType.WEB)
+public class GetLatestDownloadedFileName extends WebAction {
+
+    @TestData(reference = "content", allowedValues = {"file-name", "file-path", "file-name-with-extension", "file-extension"})
+    private com.testsigma.sdk.TestData content;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        Utilities utilities = UtilitiesFactory.create(driver, logger);
+        String originalWindowHandle = driver.getWindowHandle();
+        try {
+            logger.info("Initiated execution");
+            String contentType = content.getValue().toString().trim().toLowerCase();
+
+            String storedValue;
+            if ("file-path".equals(contentType)) {
+                // Copy the file locally and return the temp file path
+                File localFile = utilities.copyFileFromDownloads();
+                logger.info("Local file path: " + localFile.getAbsolutePath());
+                storedValue = localFile.getAbsolutePath();
+            } else {
+                // For name/extension, read the original file name from the downloads page
+                // without copying the entire file
+                ((JavascriptExecutor) driver).executeScript("window.open('about:blank','_blank');");
+                List<String> tabs = new ArrayList<>(driver.getWindowHandles());
+                driver.switchTo().window(tabs.get(tabs.size() - 1));
+                try {
+                    if (!utilities.isFileDownloaded()) {
+                        throw new RuntimeException("File is still downloading.");
+                    }
+                    String originalPath = utilities.getDownloadedFileLocalPath();
+                    logger.info("Original downloaded file path: " + originalPath);
+
+                    int lastSep = Math.max(originalPath.lastIndexOf('/'), originalPath.lastIndexOf('\\'));
+                    String originalFileName = lastSep >= 0 ? originalPath.substring(lastSep + 1) : originalPath;
+                    int dotIndex = originalFileName.lastIndexOf('.');
+
+                    switch (contentType) {
+                        case "file-name":
+                            storedValue = dotIndex > 0 ? originalFileName.substring(0, dotIndex) : originalFileName;
+                            break;
+                        case "file-name-with-extension":
+                            storedValue = originalFileName;
+                            break;
+                        case "file-extension":
+                            storedValue = dotIndex > 0 ? originalFileName.substring(dotIndex + 1) : "";
+                            break;
+                        default:
+                            storedValue = originalFileName;
+                            break;
+                    }
+                } finally {
+                    driver.close();
+                    driver.switchTo().window(originalWindowHandle);
+                }
+            }
+
+            runTimeData.setKey(runtimeVariable.getValue().toString());
+            runTimeData.setValue(storedValue);
+            setSuccessMessage("Successfully stored the latest downloaded " + contentType + " in the runtime variable. "
+                    + runtimeVariable.getValue().toString() + " = " + storedValue);
+        } catch (Exception e) {
+            logger.info("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Exception Occurred while extracting the latest downloaded file content. Exception: "
+                    + ExceptionUtils.getMessage(e));
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+}

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/VerifyIfTheLatestFileType.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/VerifyIfTheLatestFileType.java
@@ -1,0 +1,87 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.Utilities;
+import com.testsigma.addons.web.util.UtilitiesFactory;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.nio.file.Files;
+
+@Data
+@Action(actionText = "Verify if the latest downloaded file type is expected-file-type",
+        description = "Verifies that the most recently downloaded file has the expected file type/extension",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class VerifyIfTheLatestFileType extends WebAction {
+
+    @TestData(reference = "expected-file-type", allowedValues = {"pdf", "png", "jpg", "jpeg", "csv", "zip", "xlsx", "docx", "txt"})
+    private com.testsigma.sdk.TestData testData;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+
+        String currentWindowHandle = driver.getWindowHandle();
+        try {
+            String expectedFileType = testData.getValue().toString().trim().toLowerCase().replaceAll("^\\.", "");
+            logger.info("Expected file type: " + expectedFileType);
+
+            String expectedMimeType;
+            switch (expectedFileType) {
+                case "pdf":  expectedMimeType = "application/pdf"; break;
+                case "png":  expectedMimeType = "image/png"; break;
+                case "jpg":
+                case "jpeg": expectedMimeType = "image/jpeg"; break;
+                case "csv":  expectedMimeType = "text/csv"; break;
+                case "zip":  expectedMimeType = "application/zip"; break;
+                case "xlsx": expectedMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"; break;
+                case "docx": expectedMimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"; break;
+                case "txt":  expectedMimeType = "text/plain"; break;
+                default:
+                    setErrorMessage("Unsupported file type: '" + expectedFileType + "'. Supported types: pdf, png, jpg, jpeg, csv, zip, xlsx, docx, txt");
+                    return Result.FAILED;
+            }
+            logger.info("Expected MIME type: " + expectedMimeType);
+
+            Utilities utilities = UtilitiesFactory.create(driver, logger);
+            File localFile = utilities.copyFileFromDownloads();
+            logger.info("Local temp file: " + localFile.getAbsolutePath());
+
+            String actualFileType;
+            try {
+                actualFileType = Files.probeContentType(localFile.toPath());
+            } finally {
+                localFile.delete();
+            }
+
+            if (actualFileType == null) {
+                setErrorMessage("Could not determine file type of downloaded file: " + localFile.getName());
+                return Result.FAILED;
+            }
+            logger.info("Actual file type: " + actualFileType);
+
+            if (actualFileType.equals(expectedMimeType)) {
+                setSuccessMessage("Verified: the latest downloaded file type is '" + expectedFileType + "' as expected.");
+            } else {
+                setErrorMessage("File type mismatch: expected '" + expectedFileType + "' but found '" + actualFileType + "'.");
+                result = Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Error while verifying file type: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Error while verifying file type: " + e.getMessage());
+            result = Result.FAILED;
+        } finally {
+            driver.switchTo().window(currentWindowHandle);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION

# please review this addon and publish as PUBLIC

Addon name : get_latest_downloaded_file_path
Addon accont: https://jarvis.testsigma.com/ui/tenants/3072/addons
Jira: https://testsigma.atlassian.net/browse/CUS-12130


# fix 
added 2 NLP's 
1. to get the actual file name/path/extension
2. to verify the file content using mime type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve the most recently downloaded file's full path, filename, or extension directly from the browser to incorporate in your automated tests and workflows.
  * Verify the file type of the most recently downloaded file by validating its MIME type against an expected file type value.

* **Chores**
  * Updated version to 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->