### PR TITLE
feat/CUS-12984-Extract text from Teams/Outlook-exported .docx files

### DIFF
--- a/docx_data_extractor/pom.xml
+++ b/docx_data_extractor/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>docx_data_extractor</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -81,6 +81,19 @@
     <build>
         <finalName>docx_data_extractor</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractDocxFileContentBasedOnFileName.java
+++ b/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractDocxFileContentBasedOnFileName.java
@@ -1,8 +1,8 @@
 package com.testsigma.addons.web;
 
-
 import com.testsigma.addons.web.utils.DocxDocUtilities;
 import com.testsigma.addons.web.utils.DocxDocUtilitiesFactory;
+import com.testsigma.addons.web.utils.WordTextExtractor;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -11,13 +11,9 @@ import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.openqa.selenium.NoSuchElementException;
 
 import java.io.File;
-import java.io.FileInputStream;
-
 
 @Data
 @Action(actionText = "DOCX: Extract content from the file file-name from the downloads and store it in runtime-variable variable-name",
@@ -34,7 +30,6 @@ public class ExtractDocxFileContentBasedOnFileName extends WebAction {
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runTimeData;
 
-
     @Override
     protected Result execute() throws NoSuchElementException {
         Result result = Result.SUCCESS;
@@ -42,16 +37,14 @@ public class ExtractDocxFileContentBasedOnFileName extends WebAction {
         try {
             logger.info("Initiated execution");
             File downloadedDocxFile = docxUtilities.copyFileFromDownloads("docx", fileName.getValue().toString());
-            FileInputStream fis = new FileInputStream(downloadedDocxFile);
-            XWPFDocument document = new XWPFDocument(fis);
-            XWPFWordExtractor extractor = new XWPFWordExtractor(document);
-            String fileContent = extractor.getText();
+            String fileContent = WordTextExtractor.extract(downloadedDocxFile, true);
 
             logger.info("Local path: " + downloadedDocxFile.getAbsolutePath());
             runTimeData.setKey(variable.getValue().toString());
             runTimeData.setValue(fileContent);
             logger.info("File content: " + fileContent);
-            setSuccessMessage("Successfully extracted the data in the file and stored in run time variable " + variable.getValue().toString() + ". " + variable.getValue().toString() + " = " + fileContent);
+            setSuccessMessage("Successfully extracted the data in the file and stored in run time variable "
+                    + variable.getValue().toString() + ". " + variable.getValue().toString() + " = " + fileContent);
         } catch (RuntimeException e) {
             logger.info("Unable to find the given file in the downloads" + ExceptionUtils.getStackTrace(e));
             setErrorMessage(e.getMessage());

--- a/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractLatestDownloadedDocxFileContent.java
+++ b/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractLatestDownloadedDocxFileContent.java
@@ -1,8 +1,8 @@
 package com.testsigma.addons.web;
 
-
 import com.testsigma.addons.web.utils.DocxDocUtilities;
 import com.testsigma.addons.web.utils.DocxDocUtilitiesFactory;
+import com.testsigma.addons.web.utils.WordTextExtractor;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -11,18 +11,16 @@ import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.openqa.selenium.NoSuchElementException;
 
 import java.io.File;
-import java.io.FileInputStream;
 
 @Data
 @Action(actionText = "DOCX: Extract content from latest file in the downloads and store it in runtime-variable variable-name",
         description = "Extracts content from the latest downloaded docx file in the downloads and stores that content in a runtime variable",
         applicationType = ApplicationType.WEB)
 public class ExtractLatestDownloadedDocxFileContent extends WebAction {
+
     @TestData(reference = "variable-name", isRuntimeVariable = true)
     private com.testsigma.sdk.TestData variable;
 
@@ -33,21 +31,17 @@ public class ExtractLatestDownloadedDocxFileContent extends WebAction {
     protected Result execute() throws NoSuchElementException {
         Result result = Result.SUCCESS;
         DocxDocUtilities docxUtilities = DocxDocUtilitiesFactory.create(driver, logger);
-        FileInputStream fis = null;
-        XWPFDocument document = null;
         try {
             logger.info("Initiated execution");
             File downloadedDocxFile = docxUtilities.copyFileFromDownloads("docx", null);
-            fis = new FileInputStream(downloadedDocxFile);
-            document = new XWPFDocument(fis);
-            XWPFWordExtractor extractor = new XWPFWordExtractor(document);
-            String fileContent = extractor.getText();
+            String fileContent = WordTextExtractor.extract(downloadedDocxFile, true);
 
             logger.info("Local path: " + downloadedDocxFile.getAbsolutePath());
             runTimeData.setKey(variable.getValue().toString());
             runTimeData.setValue(fileContent);
             logger.info("File content: " + fileContent);
-            setSuccessMessage("Successfully extracted the data in the file and stored in run time variable " + variable.getValue().toString() + ". " + variable.getValue().toString() + " = " + fileContent);
+            setSuccessMessage("Successfully extracted the data in the file and stored in run time variable "
+                    + variable.getValue().toString() + ". " + variable.getValue().toString() + " = " + fileContent);
         } catch (RuntimeException e) {
             logger.info("Unable to find the latest file in the downloads" + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to find the latest file in the downloads");
@@ -56,17 +50,6 @@ public class ExtractLatestDownloadedDocxFileContent extends WebAction {
             logger.info(ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to read the content in the given docx file");
             result = Result.FAILED;
-        } finally {
-            try {
-                if (fis != null) {
-                    fis.close();
-                }
-                if (document != null) {
-                    document.close();
-                }
-            } catch (Exception ex) {
-                logger.warn("Error closing resources: " + ex.getMessage());
-            }
         }
         return result;
     }

--- a/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractWordFileContentAtGivenPath.java
+++ b/docx_data_extractor/src/main/java/com/testsigma/addons/web/ExtractWordFileContentAtGivenPath.java
@@ -1,5 +1,6 @@
 package com.testsigma.addons.web;
 
+import com.testsigma.addons.web.utils.WordTextExtractor;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -9,14 +10,9 @@ import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.poi.hwpf.HWPFDocument;
-import org.apache.poi.hwpf.extractor.WordExtractor;
-import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.openqa.selenium.NoSuchElementException;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 
@@ -41,7 +37,6 @@ public class ExtractWordFileContentAtGivenPath extends WebAction {
         Result result = Result.SUCCESS;
         String originalFilePath = filePath_.getValue().toString();
         File wordFile = null;
-        boolean isTempFile = false;
 
         try {
             String cleanPath = originalFilePath;
@@ -63,7 +58,6 @@ public class ExtractWordFileContentAtGivenPath extends WebAction {
             if (originalFilePath.toLowerCase().startsWith("http://") || originalFilePath.toLowerCase().startsWith("https://")) {
                 String fileName = isDocx ? "input.docx" : "input.doc";
                 wordFile = urlToFileConverter(fileName, originalFilePath);
-                isTempFile = true;
             } else {
                 wordFile = new File(originalFilePath);
             }
@@ -72,19 +66,7 @@ public class ExtractWordFileContentAtGivenPath extends WebAction {
                 throw new IOException("File not found at the specified path: " + originalFilePath);
             }
 
-            String text;
-            try (FileInputStream fis = new FileInputStream(wordFile)) {
-                if (isDocx) {
-                    XWPFDocument document = new XWPFDocument(fis);
-                    XWPFWordExtractor extractor = new XWPFWordExtractor(document);
-                    text = extractor.getText();
-                } else {
-                    HWPFDocument document = new HWPFDocument(fis);
-                    WordExtractor extractor = new WordExtractor(document);
-                    text = extractor.getText();
-                }
-            }
-
+            String text = WordTextExtractor.extract(wordFile, isDocx);
             logger.debug("Extracted text: " + text);
 
             String runtimeVariableKey = runtimeVariable.getValue().toString();

--- a/docx_data_extractor/src/main/java/com/testsigma/addons/web/utils/WordTextExtractor.java
+++ b/docx_data_extractor/src/main/java/com/testsigma/addons/web/utils/WordTextExtractor.java
@@ -1,0 +1,127 @@
+package com.testsigma.addons.web.utils;
+
+import org.apache.poi.hwpf.HWPFDocument;
+import org.apache.poi.hwpf.extractor.WordExtractor;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.openxml4j.opc.PackageRelationship;
+import org.apache.poi.openxml4j.opc.PackagingURIHelper;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.xmlbeans.XmlObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WordTextExtractor {
+
+    private static final String ALT_CHUNK_REL_TYPE =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk";
+
+    public static String extract(File file, boolean isDocx) throws Exception {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            if (isDocx) {
+                try (XWPFDocument document = new XWPFDocument(fis)) {
+                    return extractDocx(document);
+                }
+            } else {
+                try (HWPFDocument document = new HWPFDocument(fis);
+                     WordExtractor extractor = new WordExtractor(document)) {
+                    return extractor.getText();
+                }
+            }
+        }
+    }
+
+    private static String extractDocx(XWPFDocument document) throws Exception {
+        // Standard XML paragraph walk (handles body, tables, text boxes, SDT)
+        StringBuilder sb = new StringBuilder();
+        XmlObject[] paras = document.getDocument().getBody().selectPath(
+                "declare namespace w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' .//w:p"
+        );
+        for (XmlObject para : paras) {
+            XmlObject[] runs = para.selectPath(
+                    "declare namespace w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' .//w:t"
+            );
+            for (XmlObject run : runs) {
+                sb.append(run.getDomNode().getTextContent());
+            }
+            sb.append("\n");
+        }
+        String text = sb.toString().trim();
+
+        // Fallback: Teams/Outlook exports embed content as an MHT altChunk with no <w:t> elements
+        if (text.isEmpty()) {
+            text = extractAltChunk(document);
+        }
+        return text;
+    }
+
+    private static String extractAltChunk(XWPFDocument document) throws Exception {
+        for (PackageRelationship rel : document.getPackagePart().getRelationships()) {
+            if (!ALT_CHUNK_REL_TYPE.equals(rel.getRelationshipType())) continue;
+            PackagePart chunkPart = document.getPackage().getPart(
+                    PackagingURIHelper.createPartName(rel.getTargetURI()));
+            if (chunkPart == null) continue;
+            try (InputStream is = chunkPart.getInputStream()) {
+                String mht = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                return stripHtml(decodeQuotedPrintable(extractHtmlFromMht(mht)));
+            }
+        }
+        return "";
+    }
+
+    private static String extractHtmlFromMht(String mht) {
+        Matcher bm = Pattern.compile("boundary=\"([^\"]+)\"").matcher(mht);
+        if (!bm.find()) return mht;
+        String boundary = bm.group(1);
+
+        String[] parts = mht.split("--" + Pattern.quote(boundary));
+        for (String part : parts) {
+            if (part.toLowerCase().contains("content-type: text/html")) {
+                int bodyStart = part.indexOf("\r\n\r\n");
+                if (bodyStart == -1) bodyStart = part.indexOf("\n\n");
+                if (bodyStart != -1) return part.substring(bodyStart).trim();
+            }
+        }
+        return mht;
+    }
+
+    private static String decodeQuotedPrintable(String qp) throws Exception {
+        qp = qp.replace("=\r\n", "").replace("=\n", "");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int i = 0;
+        while (i < qp.length()) {
+            char c = qp.charAt(i);
+            if (c == '=' && i + 2 < qp.length()) {
+                String hex = qp.substring(i + 1, i + 3);
+                try {
+                    baos.write(Integer.parseInt(hex, 16));
+                    i += 3;
+                } catch (NumberFormatException e) {
+                    baos.write((byte) c);
+                    i++;
+                }
+            } else {
+                baos.write((byte) c);
+                i++;
+            }
+        }
+        return baos.toString(StandardCharsets.UTF_8.name());
+    }
+
+    private static String stripHtml(String html) {
+        html = html.replaceAll("(?is)<style[^>]*>.*?</style>", " ");
+        html = html.replaceAll("(?is)<script[^>]*>.*?</script>", " ");
+        html = html.replaceAll("(?i)<(br|/p|/div|/h[1-6]|/li|/tr)[^>]*>", "\n");
+        html = html.replaceAll("<[^>]+>", "");
+        html = html.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+                   .replace("&nbsp;", " ").replace("&quot;", "\"").replace("&#39;", "'");
+        html = html.replaceAll("[ \\t]+", " ");
+        html = html.replaceAll("([ \\t]*\\n){3,}", "\n\n");
+        return html.trim();
+    }
+}


### PR DESCRIPTION
# Publish this addon as PUBLIC
Addon Name: Docx Data Extractor
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-12984
Extract text from Teams/Outlook-exported .docx files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for extracting text from both DOCX and legacy DOC Word document formats.

* **Bug Fixes**
  * Improved text extraction reliability from Word documents.

* **Chores**
  * Updated project version to 1.0.2.
  * Refactored internal Word document extraction handling to use a centralized utility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/testsigmahq/testsigma-addons/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->