### PR TITLE
feat/CUS-13159-Fix Windows file upload failure by sanitizing path separators in Testsigma upload filename

### DIFF
--- a/upload_latest_file_to_testsigma_uploads/pom.xml
+++ b/upload_latest_file_to_testsigma_uploads/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>upload_latest_file_to_testsigma_uploads</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/upload_latest_file_to_testsigma_uploads/src/main/java/com/signdesk/testsigma/addons/utils/TestsigmaUtils.java
+++ b/upload_latest_file_to_testsigma_uploads/src/main/java/com/signdesk/testsigma/addons/utils/TestsigmaUtils.java
@@ -17,6 +17,10 @@ import java.util.concurrent.TimeUnit;
 
 public class TestsigmaUtils {
 
+  /**
+   * Uploads a file to Testsigma uploads via the API and returns the raw Response.
+   * Caller is responsible for closing the response inside a try-with-resources block.
+   */
   public static Response uploadFile(String filePath, String projectId, String applicationId,
       String uploadName, String apiUrl, String apiKey) throws Exception {
 
@@ -32,7 +36,7 @@ public class TestsigmaUtils {
 
     RequestBody body = new MultipartBody.Builder()
         .setType(MultipartBody.FORM)
-        .addFormDataPart("fileContent", pathFile.getAbsolutePath(),
+            .addFormDataPart("fileContent", pathFile.getAbsolutePath().replaceAll("[/\\\\]", "_").replaceAll("^_+", ""),
             RequestBody.create(new File(pathFile.getAbsolutePath()), MediaType.parse("application/octet-stream")))
         .addFormDataPart("projectId", projectId)
         .addFormDataPart("name", uploadName)
@@ -50,10 +54,11 @@ public class TestsigmaUtils {
         .build();
 
     OkHttpClient client = new OkHttpClient().newBuilder()
-        .connectTimeout(60, TimeUnit.SECONDS)
-        .readTimeout(60, TimeUnit.SECONDS)
-        .writeTimeout(60, TimeUnit.SECONDS)
-        .build();
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .build();
+
     return client.newCall(request).execute();
   }
 

--- a/upload_latest_file_to_testsigma_uploads/src/main/java/com/signdesk/testsigma/addons/web/FileUploadByAPIAndStoreTestsigmaUploadedPath.java
+++ b/upload_latest_file_to_testsigma_uploads/src/main/java/com/signdesk/testsigma/addons/web/FileUploadByAPIAndStoreTestsigmaUploadedPath.java
@@ -10,7 +10,6 @@ import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 @Data
@@ -60,7 +59,7 @@ public class FileUploadByAPIAndStoreTestsigmaUploadedPath extends WebAction {
 			}
 
 			String uploadedPath = "testsigma-storage:/" + TestsigmaUtils.readJsonData(
-					responseBody.string(), "$.latestVersion.path", logger);
+					response.body().string(), "$.latestVersion.path", logger);
 
 			runTimeData.setKey(variableName.getValue().toString());
 			runTimeData.setValue(uploadedPath);


### PR DESCRIPTION
# Publish this addon as PUBLIC
Addon Name: Upload Latest file to Testsigma Uploads
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-13159
Fix Windows file upload failure by sanitizing path separators in Testsigma upload filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling during uploads to Testsigma for better compatibility with various file naming conventions.

* **Chores**
  * Updated package version to 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->