### PR TITLE
feat/CUS-13327-Store device name with multi-cloud support for Android and iOS

### DIFF
--- a/store_device_name/pom.xml
+++ b/store_device_name/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>store_device_name</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/store_device_name/src/main/java/com/testsigma/addons/android/StoreDeviceName.java
+++ b/store_device_name/src/main/java/com/testsigma/addons/android/StoreDeviceName.java
@@ -34,10 +34,8 @@ public class StoreDeviceName extends AndroidAction {
     private com.testsigma.sdk.RunTimeData runtimeData;
 
     private static final String SAUCE_LABS_DEVICE_FIELD_NAME = "testobject_device_name";
-    private static final String LAMBDA_TEST_DEVICE_FIELD_NAME = "deviceName";
     private static final String BROWSER_STACK_DEVICE_FIELD_NAME = "device";
     private static final String DEVICE_FIELD_IN_DESIRED_CAPS = "deviceName";
-
     private static final String DESIRED_CAPABILITY_NAME = "desired";
 
     @Override
@@ -49,7 +47,10 @@ public class StoreDeviceName extends AndroidAction {
         try {
             AndroidDriver driver = (AndroidDriver) this.driver;
             Capabilities capabilities = driver.getCapabilities();
-            String environmentType = getEnvironmentType();
+
+            String environmentType = getEnvironmentType(capabilities);
+            logger.info("Environment type: " + environmentType);
+
             if (!environmentType.equals("error")) {
                 switch (environmentType) {
                     case "saucelabs":
@@ -73,11 +74,26 @@ public class StoreDeviceName extends AndroidAction {
                 return Result.FAILED;
             }
 
-            // Store in runtime variable
+            logger.info("Device name before version append: " + fullDeviceName);
+
+            // Append Android platform version — prefer desired.platformVersion (configured target)
+            // over appium:platformVersion (what Appium reports back, may differ for beta OS)
+            // Skip if the name already contains "Android" (e.g. SauceLabs testobject_device_name)
+            if (fullDeviceName != null && !fullDeviceName.toLowerCase().contains("android")) {
+                Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
+                String platformVersion = desiredCaps != null ? String.valueOf(desiredCaps.get("platformVersion")) : null;
+                if (platformVersion == null || platformVersion.equals("null") || platformVersion.isEmpty()) {
+                    platformVersion = (String) capabilities.getCapability("appium:platformVersion");
+                }
+                logger.info("Platform version: " + platformVersion);
+                if (platformVersion != null && !platformVersion.isEmpty()) {
+                    fullDeviceName = fullDeviceName + " Android v" + platformVersion;
+                }
+            }
+
             if (fullDeviceName != null) {
                 runtimeData.setValue(fullDeviceName);
                 runtimeData.setKey(var.getValue().toString());
-
                 setSuccessMessage("Successfully stored deviceName '" + fullDeviceName + "' in runtime variable: " + runtimeData.getKey());
                 logger.info("Stored 'deviceName' : '" + fullDeviceName + "' into runtime variable: " + runtimeData.getKey());
             } else {
@@ -96,51 +112,67 @@ public class StoreDeviceName extends AndroidAction {
         return result;
     }
 
-    private String getEnvironmentType() {
+    private String getEnvironmentType(Capabilities capabilities) {
         RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
-        String remoteAddress;
-        String environmentType = null;
         try {
             Object commandExecutor = remoteDriver.getCommandExecutor();
+            String remoteAddress;
             if (commandExecutor instanceof AppiumCommandExecutor) {
-                AppiumCommandExecutor appiumExecutor = (AppiumCommandExecutor) commandExecutor;
-                remoteAddress = appiumExecutor.getAddressOfRemoteServer().toString();
+                remoteAddress = ((AppiumCommandExecutor) commandExecutor).getAddressOfRemoteServer().toString();
             } else {
                 remoteAddress = "unknown";
             }
 
-            if (remoteAddress.toLowerCase().contains("lambdatest")) {
-                environmentType = "lambdatest";
-            } else if (remoteAddress.toLowerCase().contains("browserstack")) {
-                environmentType = "browserstack";
-            } else if (remoteAddress.toLowerCase().contains("saucelabs")) {
-                environmentType = "saucelabs";
-            } else {
-                environmentType = "local";
+            // Primary: check remote URL (direct connections to cloud providers)
+            String lowerAddress = remoteAddress.toLowerCase();
+            if (lowerAddress.contains("lambdatest")) {
+                return "lambdatest";
+            } else if (lowerAddress.contains("browserstack")) {
+                return "browserstack";
+            } else if (lowerAddress.contains("saucelabs")) {
+                return "saucelabs";
             }
+
+            // Secondary: check session ID prefix (when routed through Testsigma's proxy)
+            String sessionId = remoteDriver.getSessionId().toString();
+            if (sessionId.toLowerCase().startsWith("lt:")) {
+                return "lambdatest";
+            } else if (sessionId.toLowerCase().startsWith("sl:")) {
+                return "saucelabs";
+            } else if (sessionId.toLowerCase().startsWith("bs:")) {
+                return "browserstack";
+            }
+
+            // Tertiary: check chromedriver executable path in capabilities
+            String chromedriverExec = (String) capabilities.getCapability("appium:chromedriverExecutable");
+            if (chromedriverExec != null && chromedriverExec.toLowerCase().contains("browserstack")) {
+                return "browserstack";
+            }
+
+            return "local";
         } catch (Exception e) {
-            logger.info("Exception: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Exception in getEnvironmentType: " + ExceptionUtils.getStackTrace(e));
             return "error";
         }
-
-        return environmentType;
     }
 
     private String getLambdaTestDeviceName(Capabilities capabilities) {
-        String deviceManufacturer = (String) capabilities.getCapability("appium:deviceManufacturer");
-
-        // Make deviceManufacturer value first letter capital
-        if (deviceManufacturer != null && !deviceManufacturer.isEmpty()) {
-            deviceManufacturer = StringUtils.capitalize(deviceManufacturer);
-        }
-
         Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
         String deviceName = desiredCaps != null ? (String) desiredCaps.get(DEVICE_FIELD_IN_DESIRED_CAPS) : null;
 
-        if (deviceManufacturer != null && deviceName != null) {
-            return deviceManufacturer + " " + deviceName;
+        if (deviceName == null || deviceName.isEmpty()) {
+            deviceName = (String) capabilities.getCapability("appium:deviceName");
         }
-        return null;
+
+        // Prepend manufacturer only if not already present (e.g. "Pixel 10 Pro" needs "Google", "OnePlus 11" does not)
+        if (deviceName != null && !deviceName.isEmpty()) {
+            String manufacturer = StringUtils.capitalize((String) capabilities.getCapability("appium:deviceManufacturer"));
+            if (manufacturer != null && !manufacturer.isEmpty()
+                    && !deviceName.toLowerCase().startsWith(manufacturer.toLowerCase())) {
+                deviceName = manufacturer + " " + deviceName;
+            }
+        }
+        return deviceName;
     }
 
     private String getBrowserStackDeviceName() throws ParseException {
@@ -155,7 +187,11 @@ public class StoreDeviceName extends AndroidAction {
     }
 
     private String getDeviceNameFromDriverDesiredCaps(Capabilities capabilities) {
-        Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
-        return desiredCaps != null ? (String) desiredCaps.get(DEVICE_FIELD_IN_DESIRED_CAPS) : null;
+        String manufacturer = StringUtils.capitalize((String) capabilities.getCapability("appium:deviceManufacturer"));
+        String model = (String) capabilities.getCapability("appium:deviceModel");
+        if (manufacturer != null && !manufacturer.isEmpty() && model != null && !model.isEmpty()) {
+            return manufacturer + " " + model;
+        }
+        return null;
     }
 }

--- a/store_device_name/src/main/java/com/testsigma/addons/ios/StoreDeviceName.java
+++ b/store_device_name/src/main/java/com/testsigma/addons/ios/StoreDeviceName.java
@@ -10,14 +10,18 @@ import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.AppiumCommandExecutor;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 
 @Data
-@Action(actionText = "Store the device name in the runtime variable variable-name",
+@Action(actionText = "Testing v1 Store the device name in the runtime variable variable-name",
         description = "Retrieves the device name and stores it in the runtime variable.",
         applicationType = ApplicationType.IOS)
 public class StoreDeviceName extends IOSAction {
@@ -29,10 +33,8 @@ public class StoreDeviceName extends IOSAction {
     private com.testsigma.sdk.RunTimeData runtimeData;
 
     private static final String SAUCE_LABS_DEVICE_FIELD_NAME = "testobject_device_name";
-    private static final String LAMBDA_TEST_DEVICE_FIELD_NAME = "deviceName";
-    private static final String BROWSER_STACK_DEVICE_FIELD_NAME = "deviceName";
+    private static final String BROWSER_STACK_DEVICE_FIELD_NAME = "device";
     private static final String DEVICE_FIELD_IN_DESIRED_CAPS = "deviceName";
-
     private static final String DESIRED_CAPABILITY_NAME = "desired";
 
     @Override
@@ -44,14 +46,17 @@ public class StoreDeviceName extends IOSAction {
         try {
             IOSDriver driver = (IOSDriver) this.driver;
             Capabilities capabilities = driver.getCapabilities();
-            String environmentType = getEnvironmentType();
+
+            String environmentType = getEnvironmentType(capabilities);
+            logger.info("Environment type: " + environmentType);
+
             if (!environmentType.equals("error")) {
                 switch (environmentType) {
                     case "saucelabs":
                         fullDeviceName = getSauceLabsDeviceName(capabilities);
                         break;
                     case "browserstack":
-                        fullDeviceName = getBrowserStackDeviceName(capabilities);
+                        fullDeviceName = getBrowserStackDeviceName();
                         break;
                     case "lambdatest":
                         fullDeviceName = getLambdaTestDeviceName(capabilities);
@@ -64,18 +69,32 @@ public class StoreDeviceName extends IOSAction {
                         return Result.FAILED;
                 }
             } else {
-                logger.info("Not able to determine the environment (cloud or local).");
                 setErrorMessage("Not able to determine the environment (cloud or local).");
                 return Result.FAILED;
             }
 
-            // Store in runtime variable
+            logger.info("Device name before version append: " + fullDeviceName);
+
+            // Append iOS version — prefer desired.platformVersion (configured target)
+            // over appium:platformVersion (what Appium reports back, may differ for beta OS)
+            // Skip if the name already contains "iOS" (e.g. SauceLabs testobject_device_name)
+            if (fullDeviceName != null && !fullDeviceName.toLowerCase().contains("ios")) {
+                Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
+                String platformVersion = desiredCaps != null ? String.valueOf(desiredCaps.get("platformVersion")) : null;
+                if (platformVersion == null || platformVersion.equals("null") || platformVersion.isEmpty()) {
+                    platformVersion = (String) capabilities.getCapability("appium:platformVersion");
+                }
+                logger.info("Platform version: " + platformVersion);
+                if (platformVersion != null && !platformVersion.isEmpty()) {
+                    fullDeviceName = fullDeviceName + " iOS v" + platformVersion;
+                }
+            }
+
             if (fullDeviceName != null) {
                 runtimeData.setValue(fullDeviceName);
                 runtimeData.setKey(var.getValue().toString());
-
                 setSuccessMessage("Successfully stored device name '" + fullDeviceName + "' in runtime variable: " + runtimeData.getKey());
-                logger.info("Stored 'device name' : '" + fullDeviceName + "' into runtime variable: " + runtimeData.getKey());
+                logger.info("Stored 'deviceName' : '" + fullDeviceName + "' into runtime variable: " + runtimeData.getKey());
             } else {
                 result = Result.FAILED;
                 setErrorMessage("Failed to retrieve device name.");
@@ -92,42 +111,73 @@ public class StoreDeviceName extends IOSAction {
         return result;
     }
 
-    private String getEnvironmentType() {
+    private String getEnvironmentType(Capabilities capabilities) {
         RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
-        String remoteAddress;
-        String environmentType = null;
         try {
             Object commandExecutor = remoteDriver.getCommandExecutor();
+            String remoteAddress;
             if (commandExecutor instanceof AppiumCommandExecutor) {
-                AppiumCommandExecutor appiumExecutor = (AppiumCommandExecutor) commandExecutor;
-                remoteAddress = appiumExecutor.getAddressOfRemoteServer().toString();
+                remoteAddress = ((AppiumCommandExecutor) commandExecutor).getAddressOfRemoteServer().toString();
             } else {
                 remoteAddress = "unknown";
             }
 
-            if (remoteAddress.toLowerCase().contains("lambdatest")) {
-                environmentType = "lambdatest";
-            } else if (remoteAddress.toLowerCase().contains("browserstack")) {
-                environmentType = "browserstack";
-            } else if (remoteAddress.toLowerCase().contains("saucelabs")) {
-                environmentType = "saucelabs";
-            } else {
-                environmentType = "local";
+            // Primary: check remote URL (direct connections to cloud providers)
+            String lowerAddress = remoteAddress.toLowerCase();
+            if (lowerAddress.contains("lambdatest")) {
+                return "lambdatest";
+            } else if (lowerAddress.contains("browserstack")) {
+                return "browserstack";
+            } else if (lowerAddress.contains("saucelabs")) {
+                return "saucelabs";
             }
+
+            // Secondary: check session ID prefix (when routed through Testsigma's proxy)
+            String sessionId = remoteDriver.getSessionId().toString();
+            if (sessionId.toLowerCase().startsWith("lt:")) {
+                return "lambdatest";
+            } else if (sessionId.toLowerCase().startsWith("sl:")) {
+                return "saucelabs";
+            } else if (sessionId.toLowerCase().startsWith("bs:")) {
+                return "browserstack";
+            }
+
+            // Tertiary: check BrowserStack-specific capability paths (iOS uses bootstrapPath, Android uses chromedriverExecutable)
+            String chromedriverExec = (String) capabilities.getCapability("appium:chromedriverExecutable");
+            String bootstrapPath = (String) capabilities.getCapability("appium:bootstrapPath");
+            if ((chromedriverExec != null && chromedriverExec.toLowerCase().contains("browserstack"))
+                    || (bootstrapPath != null && bootstrapPath.toLowerCase().contains("browserstack"))) {
+                return "browserstack";
+            }
+
+            return "local";
         } catch (Exception e) {
-            logger.info("Exception: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Exception in getEnvironmentType: " + ExceptionUtils.getStackTrace(e));
             return "error";
         }
-
-        return environmentType;
     }
 
     private String getLambdaTestDeviceName(Capabilities capabilities) {
-        return (String) capabilities.getCapability(LAMBDA_TEST_DEVICE_FIELD_NAME);
+        Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
+        String deviceName = desiredCaps != null ? (String) desiredCaps.get(DEVICE_FIELD_IN_DESIRED_CAPS) : null;
+
+        // LambdaTest iOS may not expose a 'desired' wrapper — fall back to appium:deviceName
+        if (deviceName == null || deviceName.isEmpty()) {
+            deviceName = (String) capabilities.getCapability("appium:deviceName");
+        }
+        return deviceName;
     }
 
-    private String getBrowserStackDeviceName(Capabilities capabilities) {
-        return (String) capabilities.getCapability(BROWSER_STACK_DEVICE_FIELD_NAME);
+    private String getBrowserStackDeviceName() throws ParseException {
+        JavascriptExecutor jse = (JavascriptExecutor) driver;
+        Object response = jse.executeScript("browserstack_executor: {\"action\": \"getSessionDetails\"}");
+        JSONObject json = (JSONObject) new JSONParser().parse((String) response);
+        String deviceName = (String) json.get(BROWSER_STACK_DEVICE_FIELD_NAME);
+        String osVersion = (String) json.get("os_version");
+        if (deviceName != null && osVersion != null && !osVersion.isEmpty()) {
+            return deviceName + " iOS v" + osVersion;
+        }
+        return deviceName;
     }
 
     private String getSauceLabsDeviceName(Capabilities capabilities) {
@@ -136,6 +186,10 @@ public class StoreDeviceName extends IOSAction {
 
     private String getDeviceNameFromDriverDesiredCaps(Capabilities capabilities) {
         Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
-        return desiredCaps != null ? (String) desiredCaps.get(DEVICE_FIELD_IN_DESIRED_CAPS) : null;
+        String deviceName = desiredCaps != null ? (String) desiredCaps.get(DEVICE_FIELD_IN_DESIRED_CAPS) : null;
+        if (deviceName == null || deviceName.isEmpty()) {
+            deviceName = (String) capabilities.getCapability("appium:deviceName");
+        }
+        return deviceName;
     }
 }


### PR DESCRIPTION
## Publish this addon as PUBLIC
Addon Name: Store device name
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-13327
Store device name with multi-cloud support for Android and iOS

## Summary
- Detects cloud lab (BrowserStack, LambdaTest, SauceLabs) via session ID prefix (`bs:`, `lt:`, `sl:`) and capability path fallbacks, fixing detection when sessions route through Testsigma's proxy
- Appends Android/iOS platform version to the device name, preferring `desired.platformVersion` over `appium:platformVersion` so beta OS versions are reported correctly
- Fixes device name resolution per lab: BrowserStack uses JS executor session details, LambdaTest uses `desired.deviceName` with manufacturer prefix, SauceLabs uses `testobject_device_name` as-is

## Test plan
- [ ] BrowserStack Android — verified: `Samsung Galaxy S26 Android v16`
- [ ] BrowserStack iOS — verified: `iPhone 17 Pro Max iOS v26.0`
- [ ] LambdaTest Android — verified: `OnePlus 11 Android v15`, `Google Pixel 10 Pro Android v17`
- [ ] LambdaTest iOS — verified: `iPhone 17 Pro Max iOS v27`
- [ ] SauceLabs Android — verified: `Google Pixel 9 - Android 17 Beta`
- [ ] SauceLabs iOS — verified: `iPhone 16 Pro Max iOS26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device name detection and retrieval for Android and iOS with improved fallback logic for multiple execution environments.

* **Chores**
  * Updated project version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->