### PR TITLE
feat/TP-5059-Flatten PDF AcroForm fields before sending to Anthropic

### DIFF
--- a/ai_based_action/pom.xml
+++ b/ai_based_action/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>ai_based_action</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.24</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends AndroidAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
@@ -98,9 +99,15 @@ public class StoreAiOutputFromFile extends AndroidAction {
 
     private File resolveFile(String path, Set<File> tempFiles) throws Exception {
         if (path.startsWith("http://") || path.startsWith("https://")) {
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            // Strip query string BEFORE extracting filename/extension
+            String pathOnly = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+            String fileName = pathOnly.substring(pathOnly.lastIndexOf('/') + 1);
+            // URL-decode the filename (handles %2B, %28, etc.)
+            fileName = java.net.URLDecoder.decode(fileName, "UTF-8");
+
             String ext  = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.')) : ".tmp";
             String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : "ai_file";
+
             File tmp = File.createTempFile(base, ext);
             try (InputStream in = new URL(path).openStream()) {
                 Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends AndroidAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_android_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_ANDROID, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_ANDROID, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyIfPdfsAreSimilar.java
@@ -106,7 +106,8 @@ public class VerifyIfPdfsAreSimilar extends AndroidAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContent.java
@@ -54,7 +54,8 @@ public class VerifyImageContent extends AndroidAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_android_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_ANDROID, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_ANDROID, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContentIfStep.java
@@ -1,9 +1,12 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.android;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
 import com.testsigma.addons.util.ScreenshotUtils;
-import com.testsigma.sdk.*;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.StepActionType;
+import com.testsigma.sdk.AndroidAction;
 import com.testsigma.sdk.annotation.AI;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
@@ -19,13 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.ANDROID,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends AndroidAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +42,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (Android): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +56,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContentWithScroll.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/android/VerifyImageContentWithScroll.java
@@ -81,7 +81,8 @@ public class VerifyImageContentWithScroll extends AndroidAction {
 
             // Send all 3 screenshots to AI
             List<File> screenshotFiles = Arrays.asList(screenshot1File, screenshot2File, screenshot3File);
-            String aiResponse = AiActionUtils.invokeAiWithFiles(ai, screenshotFiles, AiActionUtils.VERIFY_SCROLL_PROMPT_ANDROID, query, logger);
+            String aiResponse = AiActionUtils.invokeAiWithFiles(ai, screenshotFiles, AiActionUtils.VERIFY_SCROLL_PROMPT_ANDROID, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/ClickOnImageUsingAi.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/ClickOnImageUsingAi.java
@@ -25,12 +25,13 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 
 @Data
 @Action(actionText = "Ai: Click on Image/text matching prompt prompt-describing-image",
-        description = "Locate and tap a UI element on an iOS device using a single AI call. " +
-                "AI reports the image dimensions it analyzed; coordinates are scaled back to device space automatically. " +
-                "Fails if the element is not found.",
+        description = "Locate and tap a UI element on an iOS device using two AI passes: " +
+                "Pass 1 locates the element; Pass 2 verifies the green-dot tap location and " +
+                "corrects it if needed. Fails if the element is not found.",
         displayName = "Ai: Click on Image/text matching prompt",
         applicationType = ApplicationType.IOS,
         useCustomScreenshot = true)
@@ -45,10 +46,57 @@ public class ClickOnImageUsingAi extends IOSAction {
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
 
+    // ── Iteration-2 prompt ────────────────────────────────────────────────────
+    // Build order: PART1 + query + PART2_COORDS + tapX + ", " + tapY + PART2_STEPS
+    private static final String VERIFY_PROMPT_PART1 =
+            "You are given two screenshots of the same iOS screen, attached in order:\n" +
+            "  1. CLEAN IMAGE (first attachment) — the original, unaltered screenshot with no overlays.\n" +
+            "  2. ANNOTATED IMAGE (second attachment) — the same screenshot with two overlays " +
+            "added by an automated tool (NOT part of the original UI):\n" +
+            "       • GREEN DOT — the exact intended tap point proposed by a first AI pass.\n" +
+            "       • MAGENTA ARROW — points from the left toward the green dot " +
+            "(arrowhead stops ~20 px to the left of the dot) to indicate the tap location.\n\n" +
+            "Use the clean image to understand the UI. " +
+            "Use the annotated image to find the green dot via the arrow, then evaluate it.\n\n" +
+            "The element we are trying to tap is described as: \"";
+
+    private static final String VERIFY_PROMPT_PART2_COORDS =
+            "\"\n\nThe green dot is currently placed at pixel coordinates (";
+
+    // %d %d → captureW, captureH injected at runtime so AI uses exact dimensions
+    private static final String VERIFY_PROMPT_STEPS_FMT =
+            "The screenshot dimensions are exactly %d × %d pixels (width × height).\n\n" +
+            "STEP 1 — Image dimensions:\n" +
+            "  The exact pixel dimensions are already stated above. " +
+            "Use those values verbatim as \"imageWidth\" and \"imageHeight\" in your output — do NOT guess or remeasure.\n\n" +
+            "STEP 2 — Follow the arrow to the green dot:\n" +
+            "  In the annotated image, the magenta arrow points at the green dot at the " +
+            "coordinates given above. Cross-reference with the clean image to identify " +
+            "exactly which UI element the green dot is sitting on.\n" +
+            "  • Is the green dot on the CORRECT target element described by the query?\n" +
+            "  • Is it at a good tappable position — center of the element, " +
+            "not on a border, gap, or neighboring element?\n" +
+            "  Set \"accurate\": true only if BOTH conditions are met.\n\n" +
+            "STEP 3 — Return the best tap location:\n" +
+            "  Always return the most precise (click_x, click_y) for the target element.\n" +
+            "  • Green dot IS correct → confirm it, return the same or very close coordinates.\n" +
+            "  • Green dot is wrong or slightly off → return the corrected center of the " +
+            "actual target element.\n" +
+            "  The returned point MUST land at the visual center of the target's tappable " +
+            "area and must NOT fall on any adjacent or neighboring element.\n" +
+            "  In the \"reason\" field, state which element the dot is on, whether it was " +
+            "correct, and if corrected — by how many pixels it moved (dx, dy).\n\n" +
+            "OUTPUT FORMAT — strict JSON only, no markdown, no explanation:\n" +
+            "{\"accurate\": <bool>, " +
+            "\"click_x\": <int>, \"click_y\": <int>, " +
+            "\"imageWidth\": <int>, \"imageHeight\": <int>, " +
+            "\"reason\": \"<element the dot is on; accurate or corrected; if corrected: dx=N dy=N>\"}";
+
     @Override
     public Result execute() {
         logger.info("=== ClickOnImageUsingAi (iOS): Starting ===");
         File screenshotFile     = null;
+        File annotatedJpegFile  = null;
         File finalAnnotatedFile = null;
 
         try {
@@ -63,37 +111,41 @@ public class ClickOnImageUsingAi extends IOSAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_ios_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.LOCATE_PROMPT_IOS, query, logger);
+            // ──────────────────────────────────────────────────────────────────────
+            // ITERATION 1 — Locate the element in the clean screenshot
+            // ──────────────────────────────────────────────────────────────────────
+            logger.info("[Iteration 1] Locating element...");
+            String aiResponse1 = AiActionUtils.invokeAiAnthropicFirst(
+                    ai, screenshotFile, AiActionUtils.LOCATE_PROMPT_IOS, query, logger);
+            JsonNode node1 = AiActionUtils.parseAiJson(aiResponse1, logger);
 
-            JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
-            if (responseNode == null) {
+            if (node1 == null) {
                 setErrorMessage("Failed to get image response from AI (contact support)");
                 finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_click_failed");
                 ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
                 return Result.FAILED;
             }
 
-            boolean found = responseNode.path("found").asBoolean(false);
-            if (!found) {
-                String reason = responseNode.path("description").asText("element not found");
+            if (!node1.path("found").asBoolean(false)) {
+                String reason = node1.path("description").asText("element not found");
                 finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_click_failed");
                 ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
                 setErrorMessage("AI could not locate '" + query + "': " + reason);
                 return Result.FAILED;
             }
 
-            int aiX1        = responseNode.path("x1").asInt(0);
-            int aiY1        = responseNode.path("y1").asInt(0);
-            int aiX2        = responseNode.path("x2").asInt(0);
-            int aiY2        = responseNode.path("y2").asInt(0);
-            int imageWidth  = responseNode.path("imageWidth").asInt(0);
-            int imageHeight = responseNode.path("imageHeight").asInt(0);
-            int confidence  = responseNode.path("confidence").asInt(50);
-            String description = responseNode.path("description").asText("");
+            int aiX1        = node1.path("x1").asInt(0);
+            int aiY1        = node1.path("y1").asInt(0);
+            int aiX2        = node1.path("x2").asInt(0);
+            int aiY2        = node1.path("y2").asInt(0);
+            int imageWidth  = node1.path("imageWidth").asInt(0);
+            int imageHeight = node1.path("imageHeight").asInt(0);
+            int conf1       = node1.path("confidence").asInt(50);
+            String desc1    = node1.path("description").asText("");
 
             logger.info(String.format(
-                    "AI result — bbox: (%d,%d)-(%d,%d) | AI image dims: %dx%d | confidence: %d | desc: '%s'",
-                    aiX1, aiY1, aiX2, aiY2, imageWidth, imageHeight, confidence, description));
+                    "[Iteration 1] AI result — bbox: (%d,%d)-(%d,%d) | AI image dims: %dx%d | confidence: %d | desc: '%s'",
+                    aiX1, aiY1, aiX2, aiY2, imageWidth, imageHeight, conf1, desc1));
 
             if (imageWidth <= 0 || imageHeight <= 0) {
                 setErrorMessage(String.format(
@@ -108,37 +160,94 @@ public class ClickOnImageUsingAi extends IOSAction {
             int tapX = (cap[0] + cap[2]) / 2;
             int tapY = (cap[1] + cap[3]) / 2;
             logger.info(String.format(
-                    "Device bbox: (%d,%d)-(%d,%d)  tap: (%d,%d)",
+                    "[Iteration 1] Device bbox: (%d,%d)-(%d,%d)  tap: (%d,%d)",
                     cap[0], cap[1], cap[2], cap[3], tapX, tapY));
 
-            BufferedImage annotated = AiActionUtils.drawHighlight(
+            BufferedImage annotated1 = AiActionUtils.drawHighlight(
                     pageCapture, cap[0], cap[1], cap[2], cap[3], tapX, tapY, Color.MAGENTA);
-            finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(annotated, "ai_click_elem_result");
+            annotatedJpegFile = AiActionUtils.captureAsJpeg(annotated1, "ai_ios_annotated", logger);
+
+            /*// ──────────────────────────────────────────────────────────────────────
+            // ITERATION 2 — Verify the GREEN DOT in the annotated screenshot
+            // ──────────────────────────────────────────────────────────────────────
+            logger.info(String.format(
+                    "[Iteration 2] Verifying green-dot at physical (%d,%d)...", tapX, tapY));
+            String verifyPrompt = VERIFY_PROMPT_PART1 + query
+                    + VERIFY_PROMPT_PART2_COORDS
+                    + tapX + ", " + tapY + ") in this image.\n\n"
+                    + String.format(VERIFY_PROMPT_STEPS_FMT, captureW, captureH);
+            String aiResponse2 = AiActionUtils.invokeAiWithFilesAnthropicFirst(
+                    ai, List.of(screenshotFile, annotatedJpegFile), verifyPrompt, "", logger);
+            JsonNode node2 = AiActionUtils.parseAiJson(aiResponse2, logger);
+
+            String finalDesc = desc1;
+            int    finalConf = conf1;
+
+            if (node2 != null) {
+                boolean accurate = node2.path("accurate").asBoolean(true);
+                int     rawX     = node2.path("click_x").asInt(0);
+                int     rawY     = node2.path("click_y").asInt(0);
+                int     imgW2    = node2.path("imageWidth").asInt(0);
+                int     imgH2    = node2.path("imageHeight").asInt(0);
+                String  reason   = node2.path("reason").asText("");
+
+                if (rawX > 0 && rawY > 0 && imgW2 > 0 && imgH2 > 0) {
+                    double sx2    = (double) captureW / imgW2;
+                    double sy2    = (double) captureH / imgH2;
+                    int prevX     = tapX;
+                    int prevY     = tapY;
+                    tapX = (int) Math.round(rawX * sx2);
+                    tapY = (int) Math.round(rawY * sy2);
+                    int dx = tapX - prevX;
+                    int dy = tapY - prevY;
+                    boolean corrected = Math.abs(dx) > 2 || Math.abs(dy) > 2;
+                    finalDesc = reason;
+
+                    logger.info(String.format(
+                            "[Iteration 2] accurate: %b | corrected: %b | " +
+                            "dot was (%d,%d) → corrected to (%d,%d) | delta: dx=%d dy=%d | reason: '%s'",
+                            accurate, corrected, prevX, prevY, tapX, tapY, dx, dy, reason));
+                } else {
+                    logger.info("[Iteration 2] Invalid coordinates in response — using Iteration 1 result.");
+                }
+            } else {
+                logger.info("[Iteration 2] No usable result — using Iteration 1 coordinates.");
+            }*/
+
+            // Upload the final annotated image: green dot at the definitive tap location
+            BufferedImage finalAnnotated = AiActionUtils.drawHighlight(
+                    pageCapture, cap[0], cap[1], cap[2], cap[3], tapX, tapY, Color.MAGENTA);
+            finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(finalAnnotated, "ai_click_elem_result");
             ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
-            IOSDriver iosDriver = (IOSDriver) driver;
 
             // Screenshot is in physical pixels; PointerInput expects logical points (UIKit).
             // Derive the pixel ratio from the driver's logical window size.
+            IOSDriver iosDriver = (IOSDriver) driver;
             Dimension windowSize = iosDriver.manage().window().getSize();
             int logicalTapX = (int) Math.round((double) tapX * windowSize.width  / captureW);
             int logicalTapY = (int) Math.round((double) tapY * windowSize.height / captureH);
             logger.info(String.format(
                     "Tapping at physical (%d,%d) → logical (%d,%d)  window=%dx%d  confidence=%d",
                     tapX, tapY, logicalTapX, logicalTapY,
-                    windowSize.width, windowSize.height, confidence));
+                    windowSize.width, windowSize.height, conf1));
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                // ignore
+            }
 
             PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
             Sequence tap = new Sequence(finger, 0);
             tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), logicalTapX, logicalTapY));
             tap.addAction(finger.createPointerDown(0));
-            tap.addAction(new Pause(finger, Duration.ofMillis(100)));
+            tap.addAction(new Pause(finger, Duration.ofMillis(500)));
             tap.addAction(finger.createPointerUp(0));
             ((Interactive) iosDriver).perform(Collections.singletonList(tap));
 
             setSuccessMessage(String.format(
                     "Successfully tapped '%s' at logical (%d,%d) | physical (%d,%d) | bbox (%d,%d)-(%d,%d) | confidence=%d | %s",
                     query, logicalTapX, logicalTapY, tapX, tapY,
-                    cap[0], cap[1], cap[2], cap[3], confidence, description));
+                    cap[0], cap[1], cap[2], cap[3], conf1, desc1));
             return Result.SUCCESS;
 
         } catch (Exception e) {
@@ -147,6 +256,7 @@ public class ClickOnImageUsingAi extends IOSAction {
             return Result.FAILED;
         } finally {
             AiActionUtils.deleteQuietly(screenshotFile);
+            AiActionUtils.deleteQuietly(annotatedJpegFile);
             AiActionUtils.deleteQuietly(finalAnnotatedFile);
         }
     }

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends IOSAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
@@ -98,9 +99,15 @@ public class StoreAiOutputFromFile extends IOSAction {
 
     private File resolveFile(String path, Set<File> tempFiles) throws Exception {
         if (path.startsWith("http://") || path.startsWith("https://")) {
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            // Strip query string BEFORE extracting filename/extension
+            String pathOnly = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+            String fileName = pathOnly.substring(pathOnly.lastIndexOf('/') + 1);
+            // URL-decode the filename (handles %2B, %28, etc.)
+            fileName = java.net.URLDecoder.decode(fileName, "UTF-8");
+
             String ext  = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.')) : ".tmp";
             String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : "ai_file";
+
             File tmp = File.createTempFile(base, ext);
             try (InputStream in = new URL(path).openStream()) {
                 Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends IOSAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_ios_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_IOS, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_IOS, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyIfPdfsAreSimilar.java
@@ -107,7 +107,8 @@ public class VerifyIfPdfsAreSimilar extends IOSAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContent.java
@@ -54,7 +54,8 @@ public class VerifyImageContent extends IOSAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_ios_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_IOS, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_IOS, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContentIfStep.java
@@ -1,9 +1,12 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.ios;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
 import com.testsigma.addons.util.ScreenshotUtils;
-import com.testsigma.sdk.*;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.StepActionType;
+import com.testsigma.sdk.IOSAction;
 import com.testsigma.sdk.annotation.AI;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
@@ -19,13 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.IOS,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends IOSAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +42,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (iOS): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +56,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContentWithScroll.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/VerifyImageContentWithScroll.java
@@ -83,7 +83,8 @@ public class VerifyImageContentWithScroll extends IOSAction {
 
             // Send all 3 screenshots to AI
             List<File> screenshotFiles = Arrays.asList(screenshot1File, screenshot2File, screenshot3File);
-            String aiResponse = AiActionUtils.invokeAiWithFiles(ai, screenshotFiles, AiActionUtils.VERIFY_SCROLL_PROMPT_IOS, query, logger);
+            String aiResponse = AiActionUtils.invokeAiWithFiles(ai, screenshotFiles, AiActionUtils.VERIFY_SCROLL_PROMPT_IOS, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends WebAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
@@ -98,9 +99,15 @@ public class StoreAiOutputFromFile extends WebAction {
 
     private File resolveFile(String path, Set<File> tempFiles) throws Exception {
         if (path.startsWith("http://") || path.startsWith("https://")) {
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            // Strip query string BEFORE extracting filename/extension
+            String pathOnly = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+            String fileName = pathOnly.substring(pathOnly.lastIndexOf('/') + 1);
+            // URL-decode the filename (handles %2B, %28, etc.)
+            fileName = java.net.URLDecoder.decode(fileName, "UTF-8");
+
             String ext  = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.')) : ".tmp";
             String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : "ai_file";
+
             File tmp = File.createTempFile(base, ext);
             try (InputStream in = new URL(path).openStream()) {
                 Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/StoreOutputFromAiPrompt.java
@@ -65,7 +65,8 @@ public class StoreOutputFromAiPrompt extends WebAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_mobileweb_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_MOBILE_WEB, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_MOBILE_WEB, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyIfPdfsAreSimilar.java
@@ -105,7 +105,8 @@ public class VerifyIfPdfsAreSimilar extends WebAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyImageContent.java
@@ -54,7 +54,8 @@ public class VerifyImageContent extends WebAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_mobileweb_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_MOBILE_WEB, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_MOBILE_WEB, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/VerifyImageContentIfStep.java
@@ -1,9 +1,12 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.mobileWeb;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
 import com.testsigma.addons.util.ScreenshotUtils;
-import com.testsigma.sdk.*;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.StepActionType;
+import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.AI;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
@@ -19,13 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.MOBILE_WEB,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends WebAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +42,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (Mobile Web): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +56,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/salesforce/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/salesforce/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends SalesforceAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
@@ -98,9 +99,15 @@ public class StoreAiOutputFromFile extends SalesforceAction {
 
     private File resolveFile(String path, Set<File> tempFiles) throws Exception {
         if (path.startsWith("http://") || path.startsWith("https://")) {
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            // Strip query string BEFORE extracting filename/extension
+            String pathOnly = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+            String fileName = pathOnly.substring(pathOnly.lastIndexOf('/') + 1);
+            // URL-decode the filename (handles %2B, %28, etc.)
+            fileName = java.net.URLDecoder.decode(fileName, "UTF-8");
+
             String ext  = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.')) : ".tmp";
             String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : "ai_file";
+
             File tmp = File.createTempFile(base, ext);
             try (InputStream in = new URL(path).openStream()) {
                 Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/ai_based_action/src/main/java/com/testsigma/addons/salesforce/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/salesforce/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends SalesforceAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_SALESFORCE, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_SALESFORCE, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/salesforce/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/salesforce/VerifyIfPdfsAreSimilar.java
@@ -106,7 +106,8 @@ public class VerifyIfPdfsAreSimilar extends SalesforceAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/salesforce/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/salesforce/VerifyImageContentIfStep.java
@@ -3,7 +3,10 @@ package com.testsigma.addons.salesforce;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
 import com.testsigma.addons.util.ScreenshotUtils;
-import com.testsigma.sdk.*;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.StepActionType;
+import com.testsigma.sdk.SalesforceAction;
 import com.testsigma.sdk.annotation.AI;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
@@ -19,13 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
         applicationType = ApplicationType.Salesforce,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends SalesforceAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +42,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (Salesforce): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +56,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/util/AiActionUtils.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/util/AiActionUtils.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.testsigma.sdk.AI;
 import com.testsigma.sdk.AIRequest;
 import com.testsigma.sdk.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 
@@ -13,15 +16,28 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 public class AiActionUtils {
 
+    /** Used for click / locate actions (Vertex AI). */
     public static final String AI_MODEL = "anthropic.claude-opus-4-6";
+
+    /** Used for verify and store (data extraction) actions (Anthropic direct). */
+    public static final String AI_MODEL_ANTHROPIC = "claude-opus-4-8";
 
     private static final String CUSTOM_INSTRUCTIONS =
             "<custom_instructions>\n" +
             "{\n" +
             "  \"provider\": \"vertex-ai\",\n" +
+            "  \"image_detail\": \"high\"\n" +
+            "}\n" +
+            "</custom_instructions>";
+
+    private static final String CUSTOM_INSTRUCTIONS_ANTHROPIC =
+            "<custom_instructions>\n" +
+            "{\n" +
+            "  \"provider\": \"anthropic\",\n" +
             "  \"image_detail\": \"high\"\n" +
             "}\n" +
             "</custom_instructions>";
@@ -337,21 +353,75 @@ public class AiActionUtils {
         return invokeAiWithFiles(ai, List.of(screenshotFile), basePrompt, query, logger);
     }
 
+    /** Builds the full AI prompt and invokes the AI service with a single screenshot (Anthropic-direct first). */
+    public static String invokeAiAnthropicFirst(AI ai, File screenshotFile,
+                                                 String basePrompt, String query,
+                                                 Logger logger) throws Exception {
+        return invokeAiWithFilesAnthropicFirst(ai, List.of(screenshotFile), basePrompt, query, logger);
+    }
+
     /**
-     * Variant that sends multiple files in one request — used for two-image verification
-     * where Screenshot A (clean) and Screenshot B (annotated) are attached together.
+     * Same as invokeAiWithFiles but with model priority reversed:
+     * tries AI_MODEL_ANTHROPIC (anthropic direct) first, falls back to AI_MODEL (vertex-ai).
+     */
+    public static String invokeAiWithFilesAnthropicFirst(AI ai, List<File> files,
+                                                          String basePrompt, String query,
+                                                          Logger logger) throws Exception {
+        // Primary: anthropic direct
+        AIRequest primary = new AIRequest();
+        primary.setPrompt(basePrompt + query + CUSTOM_INSTRUCTIONS_ANTHROPIC);
+        primary.setModel(AI_MODEL_ANTHROPIC);
+        primary.setFiles(files);
+        logger.info("Sending AI request with model=" + AI_MODEL_ANTHROPIC + ", files=" + files.size() + "...");
+        String response = ai.invokeAI(primary);
+        logger.info("AI response: " + response);
+
+        if (isBlankOrEmptyJson(response)) {
+            // Fallback: vertex-ai
+            logger.info("Primary model returned empty response, falling back to model=" + AI_MODEL);
+            AIRequest fallback = new AIRequest();
+            fallback.setPrompt(basePrompt + query + CUSTOM_INSTRUCTIONS);
+            fallback.setModel(AI_MODEL);
+            fallback.setFiles(files);
+            response = ai.invokeAI(fallback);
+            logger.info("Fallback AI response: " + response);
+        }
+        return response;
+    }
+
+    /**
+     * Sends multiple files in one request. Tries AI_MODEL (vertex-ai) first;
+     * if the response is null or empty falls back to AI_MODEL_ANTHROPIC (anthropic direct).
      */
     public static String invokeAiWithFiles(AI ai, List<File> files,
                                             String basePrompt, String query,
                                             Logger logger) throws Exception {
-        AIRequest aiRequest = new AIRequest();
-        aiRequest.setPrompt(basePrompt + query + CUSTOM_INSTRUCTIONS);
-        aiRequest.setModel(AI_MODEL);
-        aiRequest.setFiles(files);
-        logger.info("Sending AI request with " + files.size() + " file(s)...");
-        String response = ai.invokeAI(aiRequest);
+        // Primary: vertex-ai
+        AIRequest primary = new AIRequest();
+        primary.setPrompt(basePrompt + query + CUSTOM_INSTRUCTIONS);
+        primary.setModel(AI_MODEL);
+        primary.setFiles(files);
+        logger.info("Sending AI request with model=" + AI_MODEL + ", files=" + files.size() + "...");
+        String response = ai.invokeAI(primary);
         logger.info("AI response: " + response);
+
+        if (isBlankOrEmptyJson(response)) {
+            // Fallback: anthropic direct
+            logger.info("Primary model returned empty response, falling back to model=" + AI_MODEL_ANTHROPIC);
+            AIRequest fallback = new AIRequest();
+            fallback.setPrompt(basePrompt + query + CUSTOM_INSTRUCTIONS_ANTHROPIC);
+            fallback.setModel(AI_MODEL_ANTHROPIC);
+            fallback.setFiles(files);
+            response = ai.invokeAI(fallback);
+            logger.info("Fallback AI response: " + response);
+        }
         return response;
+    }
+
+    private static boolean isBlankOrEmptyJson(String response) {
+        if (response == null || response.isBlank()) return true;
+        String trimmed = response.trim();
+        return trimmed.isEmpty() || trimmed.equals("{}") || trimmed.equals("null");
     }
 
     /** Strips markdown fences and extracts the first JSON object from an AI response. */
@@ -497,6 +567,39 @@ public class AiActionUtils {
         g.drawImage(src, 0, 0, null);
         g.dispose();
         return rgb;
+    }
+
+    /**
+     * If the file is a PDF, flattens its AcroForm fields so that widget values stored only in
+     * /V (but without an appearance stream /AP) are baked into visible page content before the
+     * file is sent to Anthropic. Anthropic's renderer relies on appearance streams; without this
+     * step, form fields whose /AP is empty appear blank even though the data exists in /V.
+     *
+     * Non-PDF files are returned unchanged. The flattened PDF is written to a temp file added to
+     * tempFiles so it is cleaned up by the caller's finally block.
+     */
+    public static File flattenPdf(File file, Set<File> tempFiles, Logger logger) {
+        String name = file.getName().toLowerCase();
+        if (!name.endsWith(".pdf")) {
+            return file;
+        }
+        try {
+            try (PDDocument doc = Loader.loadPDF(file)) {
+                PDAcroForm form = doc.getDocumentCatalog().getAcroForm();
+                if (form != null && !form.getFields().isEmpty()) {
+                    form.flatten();
+                    logger.info("PDF AcroForm flattened: " + file.getName());
+                }
+                File flat = File.createTempFile("flat_", ".pdf");
+                doc.save(flat);
+                tempFiles.add(flat);
+                logger.info("Flattened PDF written to: " + flat.getAbsolutePath());
+                return flat;
+            }
+        } catch (Exception e) {
+            logger.info("PDF flatten failed (using original): " + e.getMessage());
+            return file;
+        }
     }
 
     public static void deleteQuietly(File file) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/StoreAiOutputFromFile.java
@@ -52,10 +52,11 @@ public class StoreAiOutputFromFile extends WebAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
@@ -97,9 +98,15 @@ public class StoreAiOutputFromFile extends WebAction {
 
     private File resolveFile(String path, Set<File> tempFiles) throws Exception {
         if (path.startsWith("http://") || path.startsWith("https://")) {
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
+            // Strip query string BEFORE extracting filename/extension
+            String pathOnly = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+            String fileName = pathOnly.substring(pathOnly.lastIndexOf('/') + 1);
+            // URL-decode the filename (handles %2B, %28, etc.)
+            fileName = java.net.URLDecoder.decode(fileName, "UTF-8");
+
             String ext  = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.')) : ".tmp";
             String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : "ai_file";
+
             File tmp = File.createTempFile(base, ext);
             try (InputStream in = new URL(path).openStream()) {
                 Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends WebAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_WEB, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_WEB, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyIfPdfIsSimilarAtGivenPage.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyIfPdfIsSimilarAtGivenPage.java
@@ -122,14 +122,7 @@ public class VerifyIfPdfIsSimilarAtGivenPage extends WebAction {
             try {
                 List<File> files = Arrays.asList(baseJpeg, actualJpeg);
 
-                AIRequest aiRequest = new AIRequest();
-                aiRequest.setPrompt(AiActionUtils.COMPARE_PDF_PROMPT + prompt + "\n" +
-                        "<custom_instructions>\n{\n  \"provider\": \"vertex-ai\",\n  \"image_detail\": \"high\"\n}\n</custom_instructions>");
-                aiRequest.setModel(AiActionUtils.AI_MODEL);
-                aiRequest.setFiles(files);
-                logger.info("Sending AI request for page " + page + " with " + files.size() + " file(s)...");
-                String aiResponse = ai.invokeAI(aiRequest);
-                logger.info("AI response: " + aiResponse);
+                String aiResponse = AiActionUtils.invokeAiWithFiles(ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
 
                 JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                 if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyIfPdfsAreSimilar.java
@@ -103,7 +103,8 @@ public class VerifyIfPdfsAreSimilar extends WebAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyImageContent.java
@@ -55,7 +55,8 @@ public class VerifyImageContent extends WebAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyImageContentIfStep.java
@@ -1,4 +1,4 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
@@ -19,13 +19,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.WEB,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends WebAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +39,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContent (Web): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +53,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyPdfSimilarityInWhileLoop.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/web/VerifyPdfSimilarityInWhileLoop.java
@@ -147,14 +147,7 @@ public class VerifyPdfSimilarityInWhileLoop extends WebAction {
             try {
                 List<File> files = Arrays.asList(baseJpeg, actualJpeg);
 
-                AIRequest aiRequest = new AIRequest();
-                aiRequest.setPrompt(AiActionUtils.COMPARE_PDF_PROMPT + prompt +
-                        "\n<custom_instructions>\n{\n  \"provider\": \"vertex-ai\",\n  \"image_detail\": \"high\"\n}\n</custom_instructions>");
-                aiRequest.setModel(AiActionUtils.AI_MODEL);
-                aiRequest.setFiles(files);
-                logger.info("Sending AI request for page " + pageNum + " with " + files.size() + " file(s)...");
-                String aiResponse = ai.invokeAI(aiRequest);
-                logger.info("AI response: " + aiResponse);
+                String aiResponse = AiActionUtils.invokeAiWithFiles(ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
 
                 JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                 if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windows/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windows/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends WindowsAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windows/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windows/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends WindowsAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_windows_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_DESKTOP, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_DESKTOP, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyIfPdfsAreSimilar.java
@@ -106,7 +106,8 @@ public class VerifyIfPdfsAreSimilar extends WindowsAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyImageContent.java
@@ -54,7 +54,8 @@ public class VerifyImageContent extends WindowsAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_win_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_DESKTOP, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_DESKTOP, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windows/VerifyImageContentIfStep.java
@@ -1,9 +1,12 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.windows;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
 import com.testsigma.addons.util.ScreenshotUtils;
-import com.testsigma.sdk.*;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.StepActionType;
+import com.testsigma.sdk.WindowsAction;
 import com.testsigma.sdk.annotation.AI;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
@@ -19,13 +22,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the web page and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.WINDOWS,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends WindowsAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +42,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (Windows): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -52,9 +56,9 @@ public class VerifyImageContent extends SalesforceAction {
             int captureH = pageCapture.getHeight();
             logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_web_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_WEB, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);

--- a/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/StoreAiOutputFromFile.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/StoreAiOutputFromFile.java
@@ -53,10 +53,11 @@ public class StoreAiOutputFromFile extends WindowsAdvancedAction {
             String variableName = runtimeVariable.getValue().toString();
             logger.info("Prompt: " + prompt + " | File: " + path + " | Variable: " + variableName);
 
-            File file = resolveFile(path, tempFiles);
+            File file = AiActionUtils.flattenPdf(resolveFile(path, tempFiles), tempFiles, logger);
 
             String aiResponse = AiActionUtils.invokeAiWithFiles(
-                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt, logger);
+                    ai, Collections.singletonList(file), AiActionUtils.EXTRACT_FROM_FILE_PROMPT, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/StoreOutputFromAiPrompt.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/StoreOutputFromAiPrompt.java
@@ -62,7 +62,8 @@ public class StoreOutputFromAiPrompt extends WindowsAdvancedAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_windowsadvanced_store_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_DESKTOP, prompt, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.STORE_PROMPT_DESKTOP, prompt,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyIfPdfsAreSimilar.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyIfPdfsAreSimilar.java
@@ -106,7 +106,8 @@ public class VerifyIfPdfsAreSimilar extends WindowsAdvancedAction {
                 try {
                     List<File> files = Arrays.asList(baseJpeg, actualJpeg);
                     String aiResponse = AiActionUtils.invokeAiWithFiles(
-                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt, logger);
+                            ai, files, AiActionUtils.COMPARE_PDF_PROMPT, prompt,
+                    logger);
 
                     JsonNode node = AiActionUtils.parseAiJson(aiResponse, logger);
                     if (node == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyImageContent.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyImageContent.java
@@ -65,7 +65,8 @@ public class VerifyImageContent extends WindowsAdvancedAction {
 
             screenshotFile = AiActionUtils.captureAsJpeg(desktopCapture, "ai_desktop_verify_capture", logger);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_DESKTOP, query, logger);
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_DESKTOP, query,
+                    logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {

--- a/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyImageContentIfStep.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/windowsAdvanced/VerifyImageContentIfStep.java
@@ -1,4 +1,4 @@
-package com.testsigma.addons.salesforce;
+package com.testsigma.addons.windowsAdvanced;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.testsigma.addons.util.AiActionUtils;
@@ -9,23 +9,22 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.TestStepResult;
 import lombok.Data;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 
 @Data
-@Action(actionText = "Ai: Verify page contains verification-query",
-        description = "Capture a screenshot of the Salesforce page and ask AI to verify whether the described " +
-                "content or condition is present. The step passes if AI confirms the query; fails otherwise.",
-        displayName = "Ai: Verify page contains",
-        applicationType = ApplicationType.Salesforce,
+@Action(actionText = "Ai: Verify if the page has content matching prompt verification-query",
+        description = "Capture a screenshot of the desktop and ask AI to verify whether the described " +
+                "content or condition is present. The step passes if AI confirms the query; fails otherwise. " +
+                "Use natural language to describe what you expect to see.",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        actionType = StepActionType.IF_CONDITION,
         useCustomScreenshot = true)
-public class VerifyImageContent extends SalesforceAction {
+public class VerifyImageContentIfStep extends WindowsAdvancedAction {
 
     @TestData(reference = "verification-query")
     private com.testsigma.sdk.TestData verificationQuery;
@@ -38,7 +37,7 @@ public class VerifyImageContent extends SalesforceAction {
 
     @Override
     public Result execute() {
-        logger.info("=== VerifyImageContent (Salesforce): Starting ===");
+        logger.info("=== VerifyImageContentIfStep (WindowsAdvanced): Starting ===");
         File screenshotFile     = null;
         File finalAnnotatedFile = null;
 
@@ -46,21 +45,31 @@ public class VerifyImageContent extends SalesforceAction {
             String query = verificationQuery.getValue().toString();
             logger.info("Verification query: " + query);
 
-            byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-            BufferedImage pageCapture = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
-            int captureW = pageCapture.getWidth();
-            int captureH = pageCapture.getHeight();
-            logger.info("Viewport screenshot size: " + captureW + "x" + captureH);
+            Dimension logicalScreen = Toolkit.getDefaultToolkit().getScreenSize();
+            int logicalScreenW = logicalScreen.width;
+            int logicalScreenH = logicalScreen.height;
+            logger.info("Logical screen size (Toolkit): " + logicalScreenW + "x" + logicalScreenH);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_salesforce_verify_capture", logger);
+            Robot robot = new Robot();
+            BufferedImage desktopCapture = robot.createScreenCapture(new Rectangle(logicalScreen));
+            int captureW = desktopCapture.getWidth();
+            int captureH = desktopCapture.getHeight();
+            logger.info("Robot desktop capture size (physical px): " + captureW + "x" + captureH);
 
-            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_SALESFORCE, query,
+            double displayScaleX = (double) captureW / logicalScreen.width;
+            double displayScaleY = (double) captureH / logicalScreen.height;
+            logger.info(String.format(
+                    "Display scale (capture / logical): %.4fx%.4f", displayScaleX, displayScaleY));
+
+            screenshotFile = AiActionUtils.captureAsJpeg(desktopCapture, "ai_desktop_verify_capture", logger);
+
+            String aiResponse = AiActionUtils.invokeAi(ai, screenshotFile, AiActionUtils.VERIFY_PROMPT_DESKTOP, query,
                     logger);
 
             JsonNode responseNode = AiActionUtils.parseAiJson(aiResponse, logger);
             if (responseNode == null) {
                 setErrorMessage("Failed to get verification response from AI (contact support)");
-                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_verify_failed");
+                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(desktopCapture, "ai_verify_failed");
                 ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
                 return Result.FAILED;
             }
@@ -84,10 +93,10 @@ public class VerifyImageContent extends SalesforceAction {
                 int capCX = (cap[0] + cap[2]) / 2;
                 int capCY = (cap[1] + cap[3]) / 2;
                 BufferedImage annotated = AiActionUtils.drawHighlight(
-                        pageCapture, cap[0], cap[1], cap[2], cap[3], capCX, capCY, Color.GREEN);
+                        desktopCapture, cap[0], cap[1], cap[2], cap[3], capCX, capCY, Color.GREEN);
                 finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(annotated, "ai_verify_passed");
             } else {
-                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_verify_result");
+                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(desktopCapture, "ai_verify_result");
             }
             ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
 
@@ -104,7 +113,7 @@ public class VerifyImageContent extends SalesforceAction {
             }
 
         } catch (Exception e) {
-            logger.info("Exception: " + e.getMessage());
+            logger.info("Exception: " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Failed to verify using AI. Error: " + e.getMessage());
             return Result.FAILED;
         } finally {


### PR DESCRIPTION
## Publish this addon as PUBLIC
Addon Name: Ai based action
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/TP-5059

## Summary
- PDF AcroForm widget values stored in `/V` but with an empty `/AP` (appearance stream) appear blank when Anthropic's native PDF renderer processes them, because the renderer relies on appearance streams to display field values visually.
- Added `AiActionUtils.flattenPdf()` which uses PDFBox's `PDAcroForm.flatten()` to bake field values into visible page content before sending the file to Anthropic.
- Applied to all 7 `StoreAiOutputFromFile` platform variants (web, android, iOS, mobileWeb, salesforce, windows, windowsAdvanced).

## Root cause
Anthropic's PDF renderer renders appearance streams (`/AP`). When a form field has a value in `/V` but an empty `/AP`, the field looks blank — Claude correctly reports it as empty even though the data exists in the PDF's structure.

## Fix
`AiActionUtils.flattenPdf(file, tempFiles, logger)`:
- No-op for non-PDF files
- Opens the PDF via `Loader.loadPDF()` (PDFBox 3.x API)
- Calls `form.flatten()` only when the form has fields
- Saves to a temp file registered in `tempFiles` for cleanup
- Falls back to the original file on any error (safe degradation)

## Test plan
- [ ] Upload a PDF with AcroForm fields that have values in `/V` but empty `/AP` and verify Claude now extracts the correct values
- [ ] Verify non-PDF files (images, docx) pass through unchanged
- [ ] Verify PDFs without AcroForm fields pass through unchanged
- [ ] Confirm temp files are cleaned up after execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered image verification conditional steps across all supported platforms.
  * Introduced automatic fallback to Anthropic AI when primary model response is unavailable.
  * Added PDF flattening support for improved file processing in AI operations.

* **Bug Fixes**
  * Improved URL handling to correctly process files with query parameters and encoded characters.

* **Chores**
  * Version updated to 1.0.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->