### PR TITLE
feat/CUS-13444-Accept HTTP 202 as successful PUT response

### DIFF
--- a/tdp_row_and_column_creator_updater/pom.xml
+++ b/tdp_row_and_column_creator_updater/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>tdp_row_and_column_creator_updater_</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/tdp_row_and_column_creator_updater/src/main/java/com/testsigma/addons/web/TdpRowColumnCreatorUpdaterAction.java
+++ b/tdp_row_and_column_creator_updater/src/main/java/com/testsigma/addons/web/TdpRowColumnCreatorUpdaterAction.java
@@ -171,7 +171,7 @@ public class TdpRowColumnCreatorUpdaterAction extends WebAction {
             logger.info("PUT Status: " + putResponse.getStatusCode());
             logger.info("PUT Body: " + putResponse.getBody().asString());
 
-            if (putResponse.getStatusCode() != 200) {
+            if (putResponse.getStatusCode() < 200 || putResponse.getStatusCode() >= 300) {
                 setErrorMessage("PUT failed: " + putResponse.getBody().asString());
                 return Result.FAILED;
             }


### PR DESCRIPTION
## Publish this addon as PUBLIC
Addon Name: TDP Row and Column Creator Updater
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-13444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP PUT request handling to recognize all successful 2xx response status codes (200-299) as valid operation outcomes, rather than limiting success validation to an exact 200 status code response.

* **Chores**
  * Updated project version to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->