### PR TITLE
feat/CUS-13486-Add store row count action and standardize error handling across all platforms

### DIFF
--- a/iterating_through_columns_in_tdps/pom.xml
+++ b/iterating_through_columns_in_tdps/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>iterating_through_columns_in_tdps</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.10</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/AddColumnToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP with the specified default value for all rows.",
         applicationType = ApplicationType.ANDROID,
@@ -42,8 +43,9 @@ public class AddColumnToTDP extends AndroidAction {
             setSuccessMessage("Successfully added new column <b>" + colName + "</b> with default value <b>" + defValue + "</b> to all rows in TDP");
             return Result.SUCCESS;
         } catch (Exception e) {
-            logger.info("Error occurred while adding column to TDP: " + e.getMessage());
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while adding column to TDP: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/AddNewRowToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters.",
         applicationType = ApplicationType.ANDROID,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class AddNewRowToTDP extends AndroidAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/CopyTDPDetails.java
@@ -1,0 +1,47 @@
+package com.testsigma.addons.android;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Action(actionText = "Copy all rows from reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Copies all rows from a reference TDP into a target TDP. Appends every row from the reference TDP to the target TDP, preserving row names and data.",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends AndroidAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetEntireRowFromTDP.java
@@ -7,10 +7,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.ANDROID,
@@ -48,8 +49,9 @@ public class GetEntireRowFromTDP extends AndroidAction {
             logger.info("Successfully retrieved and stored data for iteration: " + setName);
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            logger.warn("Error occurred while processing TDP data: " + e.getMessage());
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.warn("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPColumncount.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.ANDROID,
@@ -41,8 +42,9 @@ public class GetTDPColumncount extends AndroidAction {
             logger.info("Total column count: " + totalColumnCount);
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            logger.info("Error occurred while getting total column count of TDP: " + e.getMessage());
-            setErrorMessage("Error occurred while getting total column count: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total column count of TDP: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Error occurred while getting total column count: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPRowcount.java
@@ -1,0 +1,46 @@
+package com.testsigma.addons.android;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends AndroidAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.android.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/GetTDPValue.java
@@ -8,10 +8,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -51,7 +52,7 @@ public class GetTDPValue extends AndroidAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
         description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
         applicationType = ApplicationType.ANDROID,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class SetTDpIteratorToZero extends AndroidAction {
             setSuccessMessage("Set TDP iterator TDP_ITERATOR_KEY_NAME to 0");
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/StoreNextColumnTdpValue.java
@@ -8,11 +8,12 @@ import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestCaseResult;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.ArrayList;
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP for the given set name using iterator",
         applicationType = ApplicationType.ANDROID,
@@ -72,15 +73,16 @@ public class StoreNextColumnTdpValue extends AndroidAction {
                 iteratorRuntimeData.setValue(String.valueOf(iteratorValue));
                 iteratorRuntimeData.setKey("TDP_ITERATOR_KEY_NAME");
             } catch (NumberFormatException e) {
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            logger.warn("Error occurred while processing TDP data: " + e.getMessage());
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.warn("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.android;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.AndroidAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.ANDROID,
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends AndroidAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/android/UpdateTDPValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP.",
         applicationType = ApplicationType.ANDROID,
@@ -46,8 +47,9 @@ public class UpdateTDPValue extends AndroidAction {
             setSuccessMessage("Successfully updated parameter <b>" + paramName + "</b> to <b>" + paramValue + "</b> in set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            logger.info("Error occurred while updating TDP value: " + e.getMessage());
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP value: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/AddColumnToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP with the specified default value for all rows.",
         applicationType = ApplicationType.IOS,
@@ -40,7 +41,7 @@ public class AddColumnToTDP extends IOSAction {
             setSuccessMessage("Successfully added new column <b>" + colName + "</b> with default value <b>" + defValue + "</b> to all rows in TDP");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/AddNewRowToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters.",
         applicationType = ApplicationType.IOS,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class AddNewRowToTDP extends IOSAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/CopyTDPDetails.java
@@ -1,0 +1,47 @@
+package com.testsigma.addons.ios;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.IOSAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Action(actionText = "Copy all rows from reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Copies all rows from a reference TDP into a target TDP. Appends every row from the reference TDP to the target TDP, preserving row names and data.",
+        applicationType = ApplicationType.IOS,
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends IOSAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetEntireRowFromTDP.java
@@ -7,10 +7,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.IOS,
@@ -47,7 +48,7 @@ public class GetEntireRowFromTDP extends IOSAction {
             runTimeData.setKey(testData4.getValue().toString());
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPColumncount.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.IOS,
@@ -40,7 +41,7 @@ public class GetTDPColumncount extends IOSAction {
             runTimeData.setValue(String.valueOf(totalColumnCount));
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while getting total column count: " + e.getMessage());
+            setErrorMessage("Error occurred while getting total column count: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPRowcount.java
@@ -1,0 +1,46 @@
+package com.testsigma.addons.ios;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.IOSAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.IOS,
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends IOSAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.ios.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/GetTDPValue.java
@@ -8,10 +8,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -51,7 +52,7 @@ public class GetTDPValue extends IOSAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
         description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
         applicationType = ApplicationType.IOS,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class SetTDpIteratorToZero extends IOSAction {
             setSuccessMessage("Set TDP iterator TDP_ITERATOR_KEY_NAME to 0");
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/StoreNextColumnTdpValue.java
@@ -8,11 +8,12 @@ import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestCaseResult;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.ArrayList;
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP for the given set name using iterator",
         applicationType = ApplicationType.IOS,
@@ -72,14 +73,14 @@ public class StoreNextColumnTdpValue extends IOSAction {
                 iteratorRuntimeData.setValue(String.valueOf(iteratorValue));
                 iteratorRuntimeData.setKey("TDP_ITERATOR_KEY_NAME");
             } catch (NumberFormatException e) {
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.ios;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.IOSAction;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.IOS,
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends IOSAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/ios/UpdateTDPValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP.",
         applicationType = ApplicationType.IOS,
@@ -44,7 +45,7 @@ public class UpdateTDPValue extends IOSAction {
             setSuccessMessage("Successfully updated parameter <b>" + paramName + "</b> to <b>" + paramValue + "</b> in set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/AddColumnToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP with the specified default value for all rows.",
         applicationType = ApplicationType.MOBILE_WEB,
@@ -37,7 +38,7 @@ public class AddColumnToTDP extends WebAction {
             setSuccessMessage("Successfully added new column <b>" + colName + "</b> with default value <b>" + defaultValue.getValue() + "</b> to all rows in TDP");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/AddNewRowToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters.",
         applicationType = ApplicationType.MOBILE_WEB,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class AddNewRowToTDP extends WebAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/CopyTDPDetails.java
@@ -1,0 +1,47 @@
+package com.testsigma.addons.mobileweb;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Action(actionText = "Copy all rows from reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Copies all rows from a reference TDP into a target TDP. Appends every row from the reference TDP to the target TDP, preserving row names and data.",
+        applicationType = ApplicationType.MOBILE_WEB,
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends WebAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetEntireRowFromTDP.java
@@ -7,10 +7,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.MOBILE_WEB,
@@ -43,7 +44,7 @@ public class GetEntireRowFromTDP extends WebAction {
             runTimeData.setKey(testData4.getValue().toString());
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPColumncount.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.MOBILE_WEB,
@@ -37,7 +38,7 @@ public class GetTDPColumncount extends WebAction {
             runTimeData.setValue(String.valueOf(totalColumnCount));
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while getting total column count: " + e.getMessage());
+            setErrorMessage("Error occurred while getting total column count: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPRowcount.java
@@ -1,0 +1,46 @@
+package com.testsigma.addons.mobileweb;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.MOBILE_WEB,
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends WebAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.mobileweb.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/GetTDPValue.java
@@ -8,10 +8,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -51,7 +52,7 @@ public class GetTDPValue extends WebAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
         description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
         applicationType = ApplicationType.MOBILE_WEB,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class SetTDpIteratorToZero extends WebAction {
             setSuccessMessage("Set TDP iterator TDP_ITERATOR_KEY_NAME to 0");
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/StoreNextColumnTdpValue.java
@@ -8,11 +8,12 @@ import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestCaseResult;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.ArrayList;
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP for the given set name using iterator",
         applicationType = ApplicationType.MOBILE_WEB,
@@ -72,14 +73,14 @@ public class StoreNextColumnTdpValue extends WebAction {
                 iteratorRuntimeData.setValue(String.valueOf(iteratorValue));
                 iteratorRuntimeData.setKey("TDP_ITERATOR_KEY_NAME");
             } catch (NumberFormatException e) {
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.mobileweb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.MOBILE_WEB,
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends WebAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/mobileweb/UpdateTDPValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP.",
         applicationType = ApplicationType.MOBILE_WEB,
@@ -39,7 +40,7 @@ public class UpdateTDPValue extends WebAction {
             setSuccessMessage("Successfully updated parameter <b>" + parameterName.getValue() + "</b> to <b>" + parameterValue.getValue() + "</b> in set <b>" + setName.getValue() + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/AddColumnToTDP.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.NoSuchElementException;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP with the specified default value for all rows.",
         applicationType = ApplicationType.Salesforce,
@@ -38,7 +39,7 @@ public class AddColumnToTDP extends SalesforceAction {
             setSuccessMessage("Successfully added new column <b>" + colName + "</b> with default value <b>" + defaultValue.getValue() + "</b> to all rows in TDP");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/AddNewRowToTDP.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.NoSuchElementException;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters.",
         applicationType = ApplicationType.Salesforce,
         useCustomScreenshot = false)
@@ -33,7 +34,7 @@ public class AddNewRowToTDP extends SalesforceAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/CopyTDPDetails.java
@@ -1,0 +1,48 @@
+package com.testsigma.addons.salesforce;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.SalesforceAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.NoSuchElementException;
+
+@Action(actionText = "Copy all rows from reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Copies all rows from a reference TDP into a target TDP. Appends every row from the reference TDP to the target TDP, preserving row names and data.",
+        applicationType = ApplicationType.Salesforce,
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends SalesforceAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetEntireRowFromTDP.java
@@ -6,11 +6,12 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.Salesforce,
@@ -43,7 +44,7 @@ public class GetEntireRowFromTDP extends SalesforceAction {
             runTimeData.setKey(testData4.getValue().toString());
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPColumncount.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.Salesforce,
@@ -37,7 +38,7 @@ public class GetTDPColumncount extends SalesforceAction {
             runTimeData.setValue(String.valueOf(totalColumnCount));
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while getting total column count: " + e.getMessage());
+            setErrorMessage("Error occurred while getting total column count: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPRowcount.java
@@ -1,0 +1,46 @@
+package com.testsigma.addons.salesforce;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.SalesforceAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.Salesforce,
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends SalesforceAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.salesforce.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/GetTDPValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -51,7 +52,7 @@ public class GetTDPValue extends SalesforceAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
         description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
         applicationType = ApplicationType.Salesforce,
         useCustomScreenshot = false)
@@ -32,7 +33,7 @@ public class SetTDpIteratorToZero extends SalesforceAction {
             setSuccessMessage("Set TDP iterator TDP_ITERATOR_KEY_NAME to 0");
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/StoreNextColumnTdpValue.java
@@ -7,12 +7,13 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestCaseResult;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP for the given set name using iterator",
         applicationType = ApplicationType.Salesforce,
@@ -72,14 +73,14 @@ public class StoreNextColumnTdpValue extends SalesforceAction {
                 iteratorRuntimeData.setValue(String.valueOf(iteratorValue));
                 iteratorRuntimeData.setKey("TDP_ITERATOR_KEY_NAME");
             } catch (NumberFormatException e) {
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.salesforce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.SalesforceAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.Salesforce,
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends SalesforceAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/salesforce/UpdateTDPValue.java
@@ -6,12 +6,13 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP.",
         applicationType = ApplicationType.Salesforce,
@@ -39,7 +40,7 @@ public class UpdateTDPValue extends SalesforceAction {
             setSuccessMessage("Successfully updated parameter <b>" + parameterName.getValue() + "</b> to <b>" + parameterValue.getValue() + "</b> in set <b>" + setName.getValue() + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/util/TDPApiUtil.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/util/TDPApiUtil.java
@@ -10,6 +10,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -18,20 +19,11 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
-import org.apache.http.client.config.RequestConfig;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -323,6 +315,9 @@ public class TDPApiUtil {
             case "PATCH":
                 requestBuilder.patch(body);
                 break;
+            case "DELETE":
+                requestBuilder.delete(body);
+                break;
             default:
                 throw new IllegalArgumentException("Unsupported HTTP method: " + method);
         }
@@ -468,6 +463,103 @@ public class TDPApiUtil {
         requestBody.set("data", existingData);
 
         return makeHttpRequestWithBody(url, "PUT", objectMapper.writeValueAsString(requestBody), apiKey, logger);
+    }
+
+    /**
+     * Returns the total number of rows (sets/iterations) in a TDP.
+     *
+     * @param tdpId  The TDP ID
+     * @param apiKey The Bearer token for authentication
+     * @param logger Logger instance
+     * @return The number of rows in the TDP
+     * @throws Exception if the request or parsing fails
+     */
+    public static int getTDPRowCount(String tdpId, String apiKey, Logger logger) throws Exception {
+        String url = "https://app.testsigma.com/api/v1/test_data/" + tdpId;
+        logger.info("Fetching row count for TDP: " + tdpId);
+        String responseBody = makeHttpRequest2(url, apiKey, logger);
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        JsonNode dataArray = rootNode.get("data");
+        if (dataArray == null || !dataArray.isArray()) {
+            throw new RuntimeException("No data array found in the response");
+        }
+        int rowCount = dataArray.size();
+        logger.info("Total row count for TDP " + tdpId + ": " + rowCount);
+        return rowCount;
+    }
+
+    /**
+     * Replaces the target TDP with an exact replica of the reference TDP.
+     * Fetches the reference TDP in full and PUTs the entire payload (testDataName,
+     * columns, data) directly to the target — completely overwriting whatever was there.
+     *
+     * @param referenceTdpId The source TDP ID to copy from
+     * @param targetTdpId    The destination TDP ID to fully replace
+     * @param apiKey         The Bearer token for authentication
+     * @param logger         Logger instance
+     * @return The API response as a string
+     * @throws Exception if the request or parsing fails
+     */
+    public static String copyTDPRows(String referenceTdpId, String targetTdpId,
+                                      String apiKey, Logger logger) throws Exception {
+        String baseUrl = "https://app.testsigma.com/api/v1/test_data/";
+        logger.info("Replacing target TDP " + targetTdpId + " with exact replica of reference TDP " + referenceTdpId);
+
+        String referenceResponse = makeHttpRequest2(baseUrl + referenceTdpId, apiKey, logger);
+        JsonNode referenceJson = objectMapper.readTree(referenceResponse);
+
+        String targetResponse = makeHttpRequest2(baseUrl + targetTdpId, apiKey, logger);
+        JsonNode targetJson = objectMapper.readTree(targetResponse);
+
+        // Delete all existing rows in the target before inserting new ones.
+        // PUT's saveAll only inserts rows without IDs — it never removes old rows,
+        // so running the action multiple times would accumulate duplicates.
+        JsonNode targetDataNode = targetJson.get("data");
+        if (targetDataNode != null && targetDataNode.isArray() && targetDataNode.size() > 0) {
+            StringBuilder ids = new StringBuilder();
+            for (JsonNode row : targetDataNode) {
+                if (row.has("id")) {
+                    if (ids.length() > 0) ids.append(",");
+                    ids.append(row.get("id").asText());
+                }
+            }
+            if (ids.length() > 0) {
+                logger.info("Deleting " + targetDataNode.size() + " existing rows from target TDP " + targetTdpId);
+                makeHttpRequestWithBody(
+                        "https://app.testsigma.com/api/v1/test_data_sets/bulk?ids=" + ids,
+                        "DELETE", "{}", apiKey, logger);
+            }
+        }
+
+        JsonNode dataNode = referenceJson.get("data");
+        if (dataNode == null || !dataNode.isArray()) {
+            throw new RuntimeException("No data array found in reference TDP response");
+        }
+        logger.info("Reference TDP has " + dataNode.size() + " rows — sending as full replacement to target");
+
+        // Strip id and testDataProfileId so the server inserts fresh rows under the target.
+        ArrayNode cleanData = objectMapper.createArrayNode();
+        for (JsonNode row : dataNode) {
+            ObjectNode cleanRow = row.deepCopy();
+            cleanRow.remove("id");
+            cleanRow.remove("testDataProfileId");
+            cleanData.add(cleanRow);
+        }
+
+        // Keep the target's own name — using the reference name causes a unique-constraint
+        // violation when both TDPs share the same version.
+        String targetName = targetJson.has("testDataName")
+                ? targetJson.get("testDataName").asText()
+                : referenceJson.get("testDataName").asText();
+
+        ObjectNode requestBody = objectMapper.createObjectNode();
+        requestBody.put("testDataName", targetName);
+        if (referenceJson.has("columns")) {
+            requestBody.set("columns", referenceJson.get("columns"));
+        }
+        requestBody.set("data", cleanData);
+
+        return makeHttpRequestWithBody(baseUrl + targetTdpId, "PUT", objectMapper.writeValueAsString(requestBody), apiKey, logger);
     }
 
     /**

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/AddColumnToTDP.java
@@ -6,9 +6,10 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.NoSuchElementException;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP. The new column is added" +
                 " to every existing row with the specified default value. Uses PUT to fetch" +
@@ -54,8 +55,9 @@ public class AddColumnToTDP extends WebAction {
             return Result.SUCCESS;
 
         } catch (Exception e) {
-            logger.info("Error occurred while adding column to TDP: " + e.getMessage());
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while adding column to TDP: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/AddNewRowToTDP.java
@@ -7,8 +7,9 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters." +
                 " Uses PUT to fetch existing data, append the new row with empty values, and replace the full TDP data.",
         applicationType = ApplicationType.WEB,
@@ -35,8 +36,9 @@ public class AddNewRowToTDP extends WebAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            logger.info("Error occurred while adding new row to TDP: " + e.getMessage());
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while adding new row to TDP: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/CopyTDPDetails.java
@@ -1,0 +1,48 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Replaces the target TDP with an exact replica of the reference TDP. Fetches the full reference TDP (all rows, columns, and data) and PUTs it directly to the target, completely overwriting whatever was there.",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends WebAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetEntireRowFromTDP.java
@@ -9,12 +9,13 @@ import com.testsigma.sdk.annotation.RunTimeData;
 import org.openqa.selenium.NoSuchElementException;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.WEB,
@@ -80,7 +81,8 @@ public class GetEntireRowFromTDP extends WebAction {
             return com.testsigma.sdk.Result.SUCCESS;
             
         } catch (Exception e) {
-            logger.warn("Error occurred while processing TDP data: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.warn("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPColumncount.java
@@ -6,11 +6,12 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.WEB,
@@ -47,7 +48,8 @@ public class GetTDPColumncount extends WebAction {
             return com.testsigma.sdk.Result.SUCCESS;
         }
         catch (Exception e) {
-            logger.info("Error occurred while getting total column count of TDP: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total column count of TDP: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPRowcount.java
@@ -1,0 +1,46 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends WebAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.web.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/GetTDPValue.java
@@ -8,10 +8,11 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -53,8 +54,9 @@ public class GetTDPValue extends WebAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            logger.info("Error occurred while getting TDP value: " + e.getMessage());
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting TDP value: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
  description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
  applicationType = ApplicationType.WEB,
  useCustomScreenshot = false)
@@ -37,8 +38,9 @@ public class SetTDpIteratorToZero extends WebAction {
             return com.testsigma.sdk.Result.SUCCESS;
         }
         catch (Exception e) {
-            logger.info("Error occurred while setting runtime variable to 0: " + e.getMessage());
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/StoreNextColumnTdpValue.java
@@ -7,6 +7,7 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.testsigma.sdk.annotation.TestCaseResult;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 import java.util.ArrayList;
 
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP tdp-id for the set name set-name using the apikey" +
                 " api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variable runtime-variable",
@@ -100,16 +101,19 @@ public class StoreNextColumnTdpValue extends WebAction {
                 logger.info("Incremented iterator value: " + iteratorValue);
 
             } catch (NumberFormatException e) {
-                logger.info("Error occurred while parsing iterator value: " + e.getMessage());
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+                logger.info("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                logger.info("Error occurred while getting iterator value: " + e.getMessage());
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+                logger.info("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            logger.warn("Error occurred while processing TDP data: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.warn("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends WebAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/web/UpdateTDPValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import org.openqa.selenium.NoSuchElementException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP." +
                 " Uses the PATCH endpoint which matches rows by name and merges the updated data.",
@@ -60,8 +61,9 @@ public class UpdateTDPValue extends WebAction {
             return Result.SUCCESS;
 
         } catch (Exception e) {
-            logger.info("Error occurred while updating TDP value: " + e.getMessage());
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP value: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/AddColumnToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/AddColumnToTDP.java
@@ -6,8 +6,9 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new column column-name with default value default-value to TDP tdp-id" +
+@Action(actionText = "Add new column column-name with default value default-value to TDP tdp-id" +
         " using the apikey api-key",
         description = "Adds a new parameter/column to an existing TDP with the specified default value for all rows.",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
@@ -37,7 +38,7 @@ public class AddColumnToTDP extends WindowsAdvancedAction {
             setSuccessMessage("Successfully added new column <b>" + colName + "</b> with default value <b>" + defaultValue.getValue() + "</b> to all rows in TDP");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add column to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add column to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/AddNewRowToTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/AddNewRowToTDP.java
@@ -6,8 +6,9 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Action(actionText = "add new row row-name to TDP tdp-id using the apikey api-key",
+@Action(actionText = "Add new row row-name to TDP tdp-id using the apikey api-key",
         description = "Adds a new row/set to an existing TDP with empty values for all existing parameters.",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
         displayName = "Add new row to TDP with empty values",
@@ -32,7 +33,7 @@ public class AddNewRowToTDP extends WindowsAdvancedAction {
             setSuccessMessage("Successfully added new row <b>" + rowNameStr + "</b> to TDP with empty parameter values");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to add new row to TDP: " + e.getMessage());
+            setErrorMessage("Failed to add new row to TDP: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/CopyTDPDetails.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/CopyTDPDetails.java
@@ -1,0 +1,47 @@
+package com.testsigma.addons.windowsadvanced;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Action(actionText = "Copy all rows from reference TDP reference-tdp-id to target TDP target-tdp-id using apikey api-key",
+        description = "Copies all rows from a reference TDP into a target TDP. Appends every row from the reference TDP to the target TDP, preserving row names and data.",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        displayName = "Copy all rows from reference TDP to target TDP",
+        useCustomScreenshot = false)
+public class CopyTDPDetails extends WindowsAdvancedAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @Override
+    public Result execute() {
+        logger.info("Initiating CopyTDPDetails execution");
+        String referenceTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String targetTdpIdStr = targetTdpId.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        logger.info("Reference TDP ID: " + referenceTdpIdStr + ", Target TDP ID: " + targetTdpIdStr);
+        try {
+            TDPApiUtil.copyTDPRows(referenceTdpIdStr, targetTdpIdStr, apiKeyStr, logger);
+            logger.info("Successfully copied all rows from reference TDP to target TDP");
+            setSuccessMessage("Successfully copied all rows from reference TDP <b>" + referenceTdpIdStr
+                    + "</b> into target TDP <b>" + targetTdpIdStr + "</b>");
+            return Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while copying TDP rows: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to copy TDP rows: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetEntireRowFromTDP.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetEntireRowFromTDP.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
+@Action(actionText = "Get entire row from TDP tdp-id for the set name set-name using the apikey api-key and" +
         " store data in the run time variable runtime-variable",
         description = "Get entire row from TDP",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
@@ -43,7 +44,7 @@ public class GetEntireRowFromTDP extends WindowsAdvancedAction {
             runTimeData.setKey(testData4.getValue().toString());
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPColumncount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPColumncount.java
@@ -6,10 +6,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "store total column count of TDP tdp-id for the set name set-name using the apikey" +
+@Action(actionText = "Store total column count of TDP tdp-id for the set name set-name using the apikey" +
         " api-key into variable column-count-variable",
         description = "Get total column count of TDP",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
@@ -38,7 +39,7 @@ public class GetTDPColumncount extends WindowsAdvancedAction {
             runTimeData.setValue(String.valueOf(totalColumnCount));
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while getting total column count: " + e.getMessage());
+            setErrorMessage("Error occurred while getting total column count: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPRowcount.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPRowcount.java
@@ -1,0 +1,47 @@
+package com.testsigma.addons.windowsadvanced;
+
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.RunTimeData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+@Data
+@Action(actionText = "Store total row count of TDP tdp-id using the apikey api-key into variable row-count-variable",
+        description = "Get total row count of TDP",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        displayName = "Get TDP row count",
+        useCustomScreenshot = false)
+public class GetTDPRowcount extends WindowsAdvancedAction {
+
+    @TestData(reference = "tdp-id")
+    private com.testsigma.sdk.TestData testData1;
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData testData2;
+    @TestData(reference = "row-count-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData testData3;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected com.testsigma.sdk.Result execute() {
+        logger.info("Initiating execution com.testsigma.addons.windowsadvanced.GetTDPRowcount");
+        try {
+            String tdpId = testData1.getValue().toString();
+            String apiKey = testData2.getValue().toString();
+            int totalRowCount = TDPApiUtil.getTDPRowCount(tdpId, apiKey, logger);
+            runTimeData.setKey(testData3.getValue().toString());
+            runTimeData.setValue(String.valueOf(totalRowCount));
+            logger.info("Total row count: " + totalRowCount);
+            return com.testsigma.sdk.Result.SUCCESS;
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while getting total row count of TDP: " + ExceptionUtils.getMessage(e));
+            return com.testsigma.sdk.Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/GetTDPValue.java
@@ -7,10 +7,11 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 
-@Action(actionText = "get TDP tdp-id value for set name set-name and parameter parameter-name" +
+@Action(actionText = "Get TDP tdp-id value for set name set-name and parameter parameter-name" +
         " using the apikey api-key and store in variable runtime-variable",
         description = "Gets the value of a specific parameter/column for a given set name in the TDP" +
                 " and stores it in a runtime variable.",
@@ -51,7 +52,7 @@ public class GetTDPValue extends WindowsAdvancedAction {
             setSuccessMessage("Successfully retrieved parameter <b>" + paramName + "</b> = <b>" + value + "</b> from set <b>" + setNameStr + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to get TDP value: " + e.getMessage());
+            setErrorMessage("Failed to get TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/SetTDpIteratorToZero.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/SetTDpIteratorToZero.java
@@ -5,10 +5,11 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Objects;
 
-@Action(actionText = "set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
+@Action(actionText = "Set TDP iterator TDP_ITERATOR_KEY_NAME value to 0",
         description = "Set TDP iterator TDP_ITERATOR_KEY_NAME to 0",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
         displayName = "Set TDP iterator to zero",
@@ -33,7 +34,7 @@ public class SetTDpIteratorToZero extends WindowsAdvancedAction {
             setSuccessMessage("Set TDP iterator TDP_ITERATOR_KEY_NAME to 0");
             return com.testsigma.sdk.Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Error occurred while setting runtime variable to 0: " + e.getMessage());
+            setErrorMessage("Error occurred while setting runtime variable to 0: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
     }

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/StoreNextColumnTdpValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/StoreNextColumnTdpValue.java
@@ -7,11 +7,12 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestCaseResult;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.Map;
 import java.util.ArrayList;
 
-@Action(actionText = "store next column name and value from TDP tdp-id for the set name set-name using" +
+@Action(actionText = "Store next column name and value from TDP tdp-id for the set name set-name using" +
         " the apikey api-key and iterator TDP_ITERATOR_KEY_NAME in the runtime variables column-name and column-value",
         description = "Store next column name and value from TDP for the given set name using iterator",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
@@ -72,14 +73,14 @@ public class StoreNextColumnTdpValue extends WindowsAdvancedAction {
                 iteratorRuntimeData.setValue(String.valueOf(iteratorValue));
                 iteratorRuntimeData.setKey("TDP_ITERATOR_KEY_NAME");
             } catch (NumberFormatException e) {
-                setErrorMessage("Error occurred while parsing iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while parsing iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             } catch (Exception e) {
-                setErrorMessage("Error occurred while getting iterator value: " + e.getMessage());
+                setErrorMessage("Error occurred while getting iterator value: " + ExceptionUtils.getMessage(e));
                 return com.testsigma.sdk.Result.FAILED;
             }
         } catch (Exception e) {
-            setErrorMessage("Error occurred while processing TDP data: " + e.getMessage());
+            setErrorMessage("Error occurred while processing TDP data: " + ExceptionUtils.getMessage(e));
             return com.testsigma.sdk.Result.FAILED;
         }
         return com.testsigma.sdk.Result.SUCCESS;

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/UpdateTDPColumnByIndex.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/UpdateTDPColumnByIndex.java
@@ -1,0 +1,163 @@
+package com.testsigma.addons.windowsadvanced;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.testsigma.addons.util.TDPApiUtil;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Action(actionText = "Copy reference TDP reference-tdp-id to target TDP target-tdp-id updating column at index" +
+        " column-index in set set-name with value new-value using api key api-key and store resolved column name" +
+        " in column-name-variable",
+        description = "Fetches the reference TDP in full, updates only the specified column (by 1-based index)" +
+                " in the target row, then PUTs the entire modified payload to the target TDP — making it an exact" +
+                " replica of the reference with one value changed. Ignores whatever was previously in the target TDP.",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        displayName = "Copy reference TDP to target TDP updating column by dynamic index with new value",
+        useCustomScreenshot = false)
+public class UpdateTDPColumnByIndex extends WindowsAdvancedAction {
+
+    @TestData(reference = "reference-tdp-id")
+    private com.testsigma.sdk.TestData referenceTdpId;
+
+    @TestData(reference = "target-tdp-id")
+    private com.testsigma.sdk.TestData targetTdpId;
+
+    @TestData(reference = "set-name")
+    private com.testsigma.sdk.TestData setName;
+
+    @TestData(reference = "column-index")
+    private com.testsigma.sdk.TestData columnIndex;
+
+    @TestData(reference = "new-value")
+    private com.testsigma.sdk.TestData newValue;
+
+    @TestData(reference = "api-key")
+    private com.testsigma.sdk.TestData apiKey;
+
+    @TestData(reference = "column-name-variable", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData columnNameVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected Result execute() {
+        logger.info("Initiating UpdateTDPColumnByIndex execution");
+
+        String refTdpIdStr = referenceTdpId.getValue().toString().trim();
+        String tgtTdpIdStr = targetTdpId.getValue().toString().trim();
+        String setNameStr = setName.getValue().toString().trim();
+        String columnIndexStr = columnIndex.getValue().toString().trim();
+        String newValueStr = newValue.getValue().toString().trim();
+        String apiKeyStr = apiKey.getValue().toString().trim();
+        String columnNameVar = columnNameVariable.getValue().toString().trim();
+
+        logger.info("Reference TDP ID: " + refTdpIdStr + ", Target TDP ID: " + tgtTdpIdStr
+                + ", Set Name: " + setNameStr + ", Column Index: " + columnIndexStr + ", New Value: " + newValueStr);
+
+        int requestedIndex;
+        try {
+            requestedIndex = Integer.parseInt(columnIndexStr);
+            if (requestedIndex < 1) {
+                setErrorMessage("Column index must be 1 or greater, but got: " + columnIndexStr);
+                return Result.FAILED;
+            }
+        } catch (NumberFormatException e) {
+            setErrorMessage("Column index must be a valid integer, but got: " + columnIndexStr);
+            return Result.FAILED;
+        }
+
+        try {
+            String refUrl = "https://app.testsigma.com/api/v1/test_data/" + refTdpIdStr;
+            logger.info("Fetching reference TDP from: " + refUrl);
+            String responseBody = TDPApiUtil.makeHttpRequest2(refUrl, apiKeyStr, logger);
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode columnsNode = root.get("columns");
+            if (columnsNode == null || !columnsNode.isArray() || columnsNode.size() == 0) {
+                setErrorMessage("No columns array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            List<String> dataColumns = new ArrayList<>();
+            for (JsonNode col : columnsNode) {
+                String name = col.asText();
+                if (!name.equals("S.No.") && !name.equals("ETF") && !name.equals("Set Name")) {
+                    dataColumns.add(name);
+                }
+            }
+            logger.info("Data columns in reference TDP (" + dataColumns.size() + "): " + dataColumns);
+
+            if (requestedIndex > dataColumns.size()) {
+                setErrorMessage("Column index " + requestedIndex + " exceeds available data columns ("
+                        + dataColumns.size() + "). Available columns: " + dataColumns);
+                return Result.FAILED;
+            }
+
+            String resolvedColumnName = dataColumns.get(requestedIndex - 1);
+            logger.info("Resolved column at index " + requestedIndex + ": " + resolvedColumnName);
+
+            JsonNode dataArrayNode = root.get("data");
+            if (dataArrayNode == null || !dataArrayNode.isArray()) {
+                setErrorMessage("No data array found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+            ArrayNode dataArray = (ArrayNode) dataArrayNode;
+
+            boolean rowFound = false;
+            for (JsonNode row : dataArray) {
+                if (setNameStr.equals(row.get("name").asText())) {
+                    JsonNode rowData = row.get("data");
+                    if (rowData != null && rowData.isObject()) {
+                        ((ObjectNode) rowData).put(resolvedColumnName, newValueStr);
+                    }
+                    rowFound = true;
+                    break;
+                }
+            }
+
+            if (!rowFound) {
+                setErrorMessage("Row with name '" + setNameStr + "' not found in reference TDP " + refTdpIdStr);
+                return Result.FAILED;
+            }
+
+            ObjectNode putBody = objectMapper.createObjectNode();
+            putBody.put("testDataName", root.get("testDataName").asText());
+            putBody.set("data", dataArray);
+            putBody.set("columns", columnsNode);
+
+            String tgtUrl = "https://app.testsigma.com/api/v1/test_data/" + tgtTdpIdStr;
+            logger.info("Putting modified reference payload to target TDP: " + tgtUrl);
+            TDPApiUtil.makeHttpRequestWithBody(tgtUrl, "PUT", objectMapper.writeValueAsString(putBody), apiKeyStr, logger);
+            logger.info("Target TDP successfully replaced with modified reference data");
+
+            runTimeData.setKey(columnNameVar);
+            runTimeData.setValue(resolvedColumnName);
+            logger.info("Stored resolved column name '" + resolvedColumnName + "' in runtime variable: " + columnNameVar);
+
+            setSuccessMessage("Successfully copied reference TDP <b>" + refTdpIdStr + "</b> to target TDP <b>"
+                    + tgtTdpIdStr + "</b> with column <b>" + resolvedColumnName + "</b> (index " + requestedIndex
+                    + ") set to <b>" + newValueStr + "</b> in set <b>" + setNameStr + "</b>");
+            return Result.SUCCESS;
+
+        } catch (Exception e) {
+            logger.warn("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            logger.info("Error occurred while updating TDP column by index: " + ExceptionUtils.getMessage(e));
+            setErrorMessage("Failed to update TDP column by index: " + ExceptionUtils.getMessage(e));
+            return Result.FAILED;
+        }
+    }
+}

--- a/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/UpdateTDPValue.java
+++ b/iterating_through_columns_in_tdps/src/main/java/com/testsigma/addons/windowsadvanced/UpdateTDPValue.java
@@ -6,11 +6,12 @@ import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Action(actionText = "update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
+@Action(actionText = "Update TDP tdp-id set name set-name parameter parameter-name with value parameter-value" +
         " using the apikey api-key",
         description = "Updates the value of a specific parameter/column for a given set name in the TDP.",
         applicationType = ApplicationType.WINDOWS_ADVANCED,
@@ -39,7 +40,7 @@ public class UpdateTDPValue extends WindowsAdvancedAction {
             setSuccessMessage("Successfully updated parameter <b>" + parameterName.getValue() + "</b> to <b>" + parameterValue.getValue() + "</b> in set <b>" + setName.getValue() + "</b>");
             return Result.SUCCESS;
         } catch (Exception e) {
-            setErrorMessage("Failed to update TDP value: " + e.getMessage());
+            setErrorMessage("Failed to update TDP value: " + ExceptionUtils.getMessage(e));
             return Result.FAILED;
         }
     }


### PR DESCRIPTION
# Publish this addon as PUBLIC
Addon Name: Iterating through columns in TDPs
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/3072/addons
Jira : https://testsigma.atlassian.net/browse/CUS-13486



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new actions to copy TDP rows, get row counts, and update a specific column by index across multiple platforms.
  * Added support for storing results in runtime variables after row-count and column-update actions.

* **Bug Fixes**
  * Improved failure handling to show clearer exception messages and stack traces.
  * Standardized action names and capitalization for cleaner display in the UI.

* **Chores**
  * Updated the project version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->