### PR TITLE
feat/fix-5328-Added fix to get the OS Version

### DIFF
--- a/store_operating_system_version/pom.xml
+++ b/store_operating_system_version/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>store_operating_system_version</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -66,6 +66,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.17.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
 
     </dependencies>
     <build>
@@ -96,6 +101,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>15</source>
+                    <target>15</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/TokenGenerator.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/TokenGenerator.java
@@ -1,0 +1,10 @@
+package com.testsigma.addons;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class TokenGenerator {
+    public static String generateBase64Token(String input) {
+        return Base64.getEncoder().encodeToString(input.getBytes(StandardCharsets.UTF_8));
+    }
+}
+

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/android/StoreAndroidOSNameAndVersion.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/android/StoreAndroidOSNameAndVersion.java
@@ -7,9 +7,16 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
 import io.appium.java_client.android.AndroidDriver;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.NoSuchElementException;
+import io.appium.java_client.remote.AppiumCommandExecutor;
 import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.json.JSONObject;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Data
 @Action(
@@ -19,38 +26,134 @@ import lombok.Data;
 )
 public class StoreAndroidOSNameAndVersion extends AndroidAction {
 
+
     @TestData(reference = "variable-name", isRuntimeVariable = true)
-    private com.testsigma.sdk.TestData variableName;
+    private com.testsigma.sdk.TestData var;
 
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runtimeData;
 
+    private static final String DESIRED_CAPABILITY_NAME = "desired";
+
     @Override
     public Result execute() throws NoSuchElementException {
-        logger.info("Fetching Android OS name and version...");
+        logger.info("Initiating execution to store the device OS version.");
         Result result = Result.SUCCESS;
+        String osVersion = null;
 
         try {
             AndroidDriver driver = (AndroidDriver) this.driver;
-            Capabilities caps = driver.getCapabilities();
+            Capabilities capabilities = driver.getCapabilities();
 
-            String osVersion = (caps.getCapability("platformVersion") != null)
-                    ? caps.getCapability("platformVersion").toString()
-                    : "Unknown";
+            String environmentType = getEnvironmentType(capabilities);
 
-            String osInfo = "Android " + osVersion;
+            if (!environmentType.equals("error")) {
+                switch (environmentType) {
+                    case "browserstack":
+                        osVersion = getBrowserStackOSVersion();
+                        break;
+                    case "saucelabs":
+                    case "lambdatest":
+                    case "local":
+                    default:
+                        osVersion = getOSVersionFromCapabilities(capabilities);
+                        break;
+                }
+            } else {
+                setErrorMessage("Not able to determine the environment (cloud or local).");
+                return Result.FAILED;
+            }
 
-            runtimeData.setKey(variableName.getValue().toString());
-            runtimeData.setValue(osInfo);
+            // Fallback: if the environment-specific lookup came back empty, try capabilities directly
+            if (osVersion == null || osVersion.isEmpty()) {
+                osVersion = getOSVersionFromCapabilities(capabilities);
+            }
 
-            setSuccessMessage("Stored OS info '" + osInfo + "' in runtime variable: " + runtimeData.getKey());
-            logger.info("OS info: " + osInfo);
+            logger.info("OS version resolved: " + osVersion);
+
+            if (osVersion != null && !osVersion.isEmpty()) {
+                runtimeData.setValue(osVersion);
+                runtimeData.setKey(var.getValue().toString());
+                setSuccessMessage("Successfully stored OS version '" + osVersion + "' in runtime variable: " + runtimeData.getKey());
+                logger.info("Stored 'osVersion' : '" + osVersion + "' into runtime variable: " + runtimeData.getKey());
+            } else {
+                result = Result.FAILED;
+                setErrorMessage("Failed to retrieve OS version.");
+                logger.warn("Failed to retrieve OS version.");
+            }
 
         } catch (Exception e) {
             result = Result.FAILED;
-            setErrorMessage("Failed to retrieve Android OS version: " + e.getMessage());
-            logger.warn("Failed to retrieve Android OS version: " + e.getMessage());
+            String errorMsg = "Error occurred while trying to store the OS version: " + ExceptionUtils.getStackTrace(e);
+            setErrorMessage(errorMsg);
+            logger.warn(errorMsg);
         }
+
         return result;
+    }
+
+    private String getEnvironmentType(Capabilities capabilities) {
+        RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
+        try {
+            Object commandExecutor = remoteDriver.getCommandExecutor();
+            String remoteAddress;
+            if (commandExecutor instanceof AppiumCommandExecutor) {
+                remoteAddress = ((AppiumCommandExecutor) commandExecutor).getAddressOfRemoteServer().toString();
+            } else {
+                remoteAddress = "unknown";
+            }
+
+            // Primary: check remote URL (direct connections to cloud providers)
+            String lowerAddress = remoteAddress.toLowerCase();
+            if (lowerAddress.contains("lambdatest")) {
+                return "lambdatest";
+            } else if (lowerAddress.contains("browserstack")) {
+                return "browserstack";
+            } else if (lowerAddress.contains("saucelabs")) {
+                return "saucelabs";
+            }
+
+            // Secondary: check session ID prefix (when routed through Testsigma's proxy)
+            String sessionId = remoteDriver.getSessionId().toString();
+            if (sessionId.toLowerCase().startsWith("lt:")) {
+                return "lambdatest";
+            } else if (sessionId.toLowerCase().startsWith("sl:")) {
+                return "saucelabs";
+            } else if (sessionId.toLowerCase().startsWith("bs:")) {
+                return "browserstack";
+            }
+
+            // Tertiary: check chromedriver executable path in capabilities
+            String chromedriverExec = (String) capabilities.getCapability("appium:chromedriverExecutable");
+            if (chromedriverExec != null && chromedriverExec.toLowerCase().contains("browserstack")) {
+                return "browserstack";
+            }
+
+            return "local";
+        } catch (Exception e) {
+            logger.info("Exception in getEnvironmentType: " + ExceptionUtils.getStackTrace(e));
+            return "error";
+        }
+    }
+
+    /**
+     * BrowserStack reports the true OS version via getSessionDetails,
+     * which is more reliable than the platformVersion capability.
+     */
+    private String getBrowserStackOSVersion() {
+        JavascriptExecutor jse = (JavascriptExecutor) driver;
+        Object response = jse.executeScript("browserstack_executor: {\"action\": \"getSessionDetails\"}");
+        JSONObject json = new JSONObject((String) response);
+        return json.optString("os_version", null);
+    }
+
+    private String getOSVersionFromCapabilities(Capabilities capabilities) {
+        Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
+        String platformVersion = desiredCaps != null ? String.valueOf(desiredCaps.get("platformVersion")) : null;
+
+        if (platformVersion == null || platformVersion.equals("null") || platformVersion.isEmpty()) {
+            platformVersion = (String) capabilities.getCapability("appium:platformVersion");
+        }
+        return platformVersion;
     }
 }

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/ios/StoreIOSNameAndVersion.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/ios/StoreIOSNameAndVersion.java
@@ -6,60 +6,150 @@ import com.testsigma.sdk.Result;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
-
 import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.remote.AppiumCommandExecutor;
 import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.json.JSONObject;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Data
-@Action(
-        actionText = "Store iOS device name and OS version in runtime variable variable-name",
-        description = "Fetches the connected iOS device name and iOS version (e.g., iPhone 15 Pro - iOS 18.1) and stores it in the runtime variable.",
-        applicationType = ApplicationType.IOS
-)
+@Action(actionText = "Store iOS version in runtime variable variable-name",
+        description = "Fetches the iOS version (e.g., iOS 18.1) and stores it in the runtime variable.",
+        applicationType = ApplicationType.IOS)
 public class StoreIOSNameAndVersion extends IOSAction {
 
     @TestData(reference = "variable-name", isRuntimeVariable = true)
-    private com.testsigma.sdk.TestData variableName;
+    private com.testsigma.sdk.TestData var;
 
     @RunTimeData
     private com.testsigma.sdk.RunTimeData runtimeData;
 
+    private static final String DESIRED_CAPABILITY_NAME = "desired";
+
     @Override
-    public Result execute() {
-        logger.info("Starting to fetch iOS device name and OS version...");
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution to store the device OS version.");
         Result result = Result.SUCCESS;
+        String osVersion = null;
 
         try {
             IOSDriver driver = (IOSDriver) this.driver;
+            Capabilities capabilities = driver.getCapabilities();
 
-            // Retrieve device name and OS version from capabilities
-            String deviceName = (String) driver.getCapabilities().getCapability("deviceName");
-            String platformVersion = (String) driver.getCapabilities().getCapability("platformVersion");
+            String environmentType = getEnvironmentType(capabilities);
 
-            if (deviceName == null || platformVersion == null) {
-                logger.info("Device name or platform version is null.");
-                setErrorMessage("Could not retrieve device name or platform version from the iOS device.");
+            if (!environmentType.equals("error")) {
+                switch (environmentType) {
+                    case "browserstack":
+                        osVersion = getBrowserStackOSVersion();
+                        break;
+                    case "saucelabs":
+                    case "lambdatest":
+                    case "local":
+                    default:
+                        osVersion = getOSVersionFromCapabilities(capabilities);
+                        break;
+                }
+            } else {
+                setErrorMessage("Not able to determine the environment (cloud or local).");
                 return Result.FAILED;
             }
-            String deviceInfo = deviceName + " - iOS " + platformVersion;
-            logger.info("Detected device info: " + deviceInfo);
 
-            // Store in runtime variable
-            runtimeData = new com.testsigma.sdk.RunTimeData();
-            runtimeData.setKey(variableName.getValue().toString());
-            runtimeData.setValue(deviceInfo);
-            logger.info("Successfully stored device info in runtime variable: " + runtimeData.getKey());
-            setSuccessMessage("Successfully stored OS info <b>'" + deviceInfo + "'</b> in runtime variable: "
-                    + runtimeData.getKey());
-            logger.info("iOS device info successfully saved.");
+            // Fallback: if the environment-specific lookup came back empty, try capabilities directly
+            if (osVersion == null || osVersion.isEmpty()) {
+                osVersion = getOSVersionFromCapabilities(capabilities);
+            }
+
+            logger.info("OS version resolved: " + osVersion);
+
+            if (osVersion != null && !osVersion.isEmpty()) {
+                runtimeData.setValue(osVersion);
+                runtimeData.setKey(var.getValue().toString());
+                setSuccessMessage("Successfully stored OS version '" + osVersion + "' in runtime variable: " + runtimeData.getKey());
+                logger.info("Stored 'osVersion' : '" + osVersion + "' into runtime variable: " + runtimeData.getKey());
+            } else {
+                result = Result.FAILED;
+                setErrorMessage("Failed to retrieve OS version.");
+                logger.warn("Failed to retrieve OS version.");
+            }
 
         } catch (Exception e) {
             result = Result.FAILED;
-            String errorMsg = "Failed to retrieve iOS device info: " + e.getMessage();
+            String errorMsg = "Error occurred while trying to store the OS version: " + ExceptionUtils.getStackTrace(e);
             setErrorMessage(errorMsg);
             logger.warn(errorMsg);
         }
 
         return result;
+    }
+
+    private String getEnvironmentType(Capabilities capabilities) {
+        RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
+        try {
+            Object commandExecutor = remoteDriver.getCommandExecutor();
+            String remoteAddress;
+            if (commandExecutor instanceof AppiumCommandExecutor) {
+                remoteAddress = ((AppiumCommandExecutor) commandExecutor).getAddressOfRemoteServer().toString();
+            } else {
+                remoteAddress = "unknown";
+            }
+
+            String lowerAddress = remoteAddress.toLowerCase();
+            if (lowerAddress.contains("lambdatest")) {
+                return "lambdatest";
+            } else if (lowerAddress.contains("browserstack")) {
+                return "browserstack";
+            } else if (lowerAddress.contains("saucelabs")) {
+                return "saucelabs";
+            }
+
+            String sessionId = remoteDriver.getSessionId().toString();
+            if (sessionId.toLowerCase().startsWith("lt:")) {
+                return "lambdatest";
+            } else if (sessionId.toLowerCase().startsWith("sl:")) {
+                return "saucelabs";
+            } else if (sessionId.toLowerCase().startsWith("bs:")) {
+                return "browserstack";
+            }
+
+            String chromedriverExec = (String) capabilities.getCapability("appium:chromedriverExecutable");
+            String bootstrapPath = (String) capabilities.getCapability("appium:bootstrapPath");
+            if ((chromedriverExec != null && chromedriverExec.toLowerCase().contains("browserstack"))
+                    || (bootstrapPath != null && bootstrapPath.toLowerCase().contains("browserstack"))) {
+                return "browserstack";
+            }
+
+            return "local";
+        } catch (Exception e) {
+            logger.info("Exception in getEnvironmentType: " + ExceptionUtils.getStackTrace(e));
+            return "error";
+        }
+    }
+
+    /**
+     * BrowserStack reports the true OS version via getSessionDetails,
+     * which is more reliable than the platformVersion capability.
+     */
+    private String getBrowserStackOSVersion() {
+        JavascriptExecutor jse = (JavascriptExecutor) driver;
+        Object response = jse.executeScript("browserstack_executor: {\"action\": \"getSessionDetails\"}");
+        JSONObject json = new JSONObject((String) response);
+        return json.optString("os_version", null);
+    }
+
+    private String getOSVersionFromCapabilities(Capabilities capabilities) {
+        Map<String, Object> desiredCaps = (Map<String, Object>) capabilities.getCapability(DESIRED_CAPABILITY_NAME);
+        String platformVersion = desiredCaps != null ? String.valueOf(desiredCaps.get("platformVersion")) : null;
+
+        if (platformVersion == null || platformVersion.equals("null") || platformVersion.isEmpty()) {
+            platformVersion = (String) capabilities.getCapability("appium:platformVersion");
+        }
+        return platformVersion;
     }
 }

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/mobileweb/StoreOSNameAndVersion.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/mobileweb/StoreOSNameAndVersion.java
@@ -6,10 +6,15 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.json.JSONObject;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -35,15 +40,54 @@ public class StoreOSNameAndVersion extends WebAction {
             RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
             Capabilities caps = remoteDriver.getCapabilities();
 
-            String platformName = (caps.getCapability("platformName") != null)
-                    ? caps.getCapability("platformName").toString()
-                    : "Unknown";
-            
-            String platformVersion = (caps.getCapability("platformVersion") != null)
-                    ? caps.getCapability("platformVersion").toString()
-                    : "Unknown";
+            String platformName = "Unknown";
+            String platformVersion = "Unknown";
 
-            String osInfo = platformName + " " + platformVersion;
+            // Try BrowserStack's getSessionDetails unconditionally rather than pre-detecting the
+            // environment: Testsigma's execution engine proxies the WebDriver connection, so neither
+            // the command executor's remote address nor bstack:options survives to reveal BrowserStack
+            // is actually in play (confirmed on a real BrowserStack session - both were absent).
+            // "browserstack_executor: {...}" is a harmless no-op (a JS labeled statement returning
+            // null) on any other provider, so attempting it everywhere is safe.
+            JSONObject bsSession = getBrowserStackSessionDetails();
+            if (bsSession != null) {
+                String bsOs = bsSession.optString("os", null);
+                if (bsOs != null && !bsOs.isEmpty()) {
+                    platformName = bsOs;
+                }
+                String bsOsVersion = bsSession.optString("os_version", null);
+                if (bsOsVersion != null && !bsOsVersion.isEmpty()) {
+                    platformVersion = bsOsVersion;
+                }
+            }
+
+            // Fallback: prefer the raw capability, since getPlatformName() defaults to
+            // Platform.ANY (not null) when the remote end never reported a real platform.
+            if (platformName.equals("Unknown")) {
+                try {
+                    if (caps.getCapability("platformName") != null) {
+                        platformName = caps.getCapability("platformName").toString();
+                    } else if (caps.getPlatformName() != null && caps.getPlatformName() != Platform.ANY) {
+                        platformName = caps.getPlatformName().toString();
+                    }
+                    if (platformName.equalsIgnoreCase("any")) {
+                        platformName = "Unknown";
+                    }
+                } catch (Exception e) {
+                    logger.warn("Could not get platformName from capabilities: " + e.getMessage());
+                }
+            }
+
+            // Fallback: try JavaScript executor, then capabilities
+            if (platformVersion.equals("Unknown")) {
+                platformVersion = getOSVersionFromJS(remoteDriver);
+                if (platformVersion == null || platformVersion.isEmpty() || platformVersion.equals("Unknown")) {
+                    platformVersion = getOSVersion(caps);
+                }
+            }
+
+            // Format OS info based on platform
+            String osInfo = formatOSInfo(platformName, platformVersion);
 
             runtimeData.setKey(variableName.getValue().toString());
             runtimeData.setValue(osInfo);
@@ -57,5 +101,161 @@ public class StoreOSNameAndVersion extends WebAction {
             logger.warn("Failed to retrieve OS version: " + e.getMessage());
         }
         return result;
+    }
+
+    private String formatOSInfo(String platformName, String platformVersion) {
+        if (platformName == null || platformName.equals("Unknown")) {
+            return "Unknown";
+        }
+
+        String osName = platformName.toLowerCase();
+
+        // Format macOS version (e.g., "mac 15" for macOS 15.x)
+        if (osName.contains("mac") || osName.contains("darwin")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                // Extract major version number (e.g., "15.0" -> "15", "13.6" -> "13")
+                String majorVersion = platformVersion.split("\\.")[0];
+                return "mac " + majorVersion;
+            }
+            return "mac";
+        }
+
+        // Format Android version
+        if (osName.contains("android")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                return "Android " + platformVersion;
+            }
+            return "Android";
+        }
+
+        // Format iOS version
+        if (osName.contains("ios")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                return "iOS " + platformVersion;
+            }
+            return "iOS";
+        }
+
+        // Format Windows version
+        if (osName.contains("win")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                return "Windows " + platformVersion;
+            }
+            return "Windows";
+        }
+
+        // Default: return platform name and version as-is
+        if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+            return platformName + " " + platformVersion;
+        }
+        return platformName;
+    }
+
+    // --- Get OS version using JavaScript executor ---
+    private String getOSVersionFromJS(RemoteWebDriver driver) {
+        try {
+            if (driver instanceof JavascriptExecutor) {
+                JavascriptExecutor js = (JavascriptExecutor) driver;
+
+                // JavaScript to extract OS version from user agent
+                String jsCode = "var ua = navigator.userAgent || navigator.vendor || window.opera; " +
+                        "var os = 'Unknown'; " +
+                        "var version = 'Unknown'; " +
+                        "if (ua.indexOf('Mac OS X') !== -1) { " +
+                        "  os = 'mac'; " +
+                        "  var match = ua.match(/Mac OS X (\\d+)[._](\\d+)/); " +
+                        "  if (match) version = match[1]; " +
+                        "} else if (ua.indexOf('Windows') !== -1) { " +
+                        "  os = 'Windows'; " +
+                        "  var match = ua.match(/Windows NT (\\d+)\\.(\\d+)/); " +
+                        "  if (match) { " +
+                        "    var major = parseInt(match[1]); " +
+                        "    var minor = parseInt(match[2]); " +
+                        "    if (major === 10 && minor === 0) version = '10'; " +
+                        "    else if (major === 6 && minor === 1) version = '7'; " +
+                        "    else if (major === 6 && minor === 2) version = '8'; " +
+                        "    else if (major === 6 && minor === 3) version = '8.1'; " +
+                        "    else version = major + '.' + minor; " +
+                        "  } " +
+                        "} else if (ua.indexOf('Linux') !== -1) { " +
+                        "  os = 'Linux'; " +
+                        "  var match = ua.match(/Linux[^\\d]*(\\d+[\\.\\d]*)/); " +
+                        "  if (match) version = match[1]; " +
+                        "} else if (ua.indexOf('Android') !== -1) { " +
+                        "  os = 'Android'; " +
+                        "  var match = ua.match(/Android (\\d+[\\.\\d]*)/); " +
+                        "  if (match) version = match[1]; " +
+                        "} else if (/iPad|iPhone|iPod/.test(ua)) { " +
+                        "  os = 'iOS'; " +
+                        "  var match = ua.match(/OS (\\d+)[._](\\d+)/); " +
+                        "  if (match) version = match[1] + '.' + match[2]; " +
+                        "} " +
+                        "return os + '|' + version;";
+
+                Object result = js.executeScript(jsCode);
+                if (result != null) {
+                    String[] parts = result.toString().split("\\|");
+                    if (parts.length == 2 && !parts[1].equals("Unknown")) {
+                        logger.info("OS version from JavaScript: " + parts[0] + " " + parts[1]);
+                        return parts[1];
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to get OS version from JavaScript: " + e.getMessage());
+        }
+        return "Unknown";
+    }
+
+    // --- OS version lookup with cloud lab support ---
+    private String getOSVersion(Capabilities caps) {
+        // 1. Standard Appium/Selenium
+        if (caps.getCapability("platformVersion") != null)
+            return caps.getCapability("platformVersion").toString();
+
+        // 2. BrowserStack
+        if (caps.getCapability("osVersion") != null)
+            return caps.getCapability("osVersion").toString();
+
+        // 3. BrowserStack legacy
+        if (caps.getCapability("os_version") != null)
+            return caps.getCapability("os_version").toString();
+
+        // 4. bstack:options
+        Object bs = caps.getCapability("bstack:options");
+        if (bs instanceof Map && ((Map<?, ?>) bs).get("osVersion") != null)
+            return ((Map<?, ?>) bs).get("osVersion").toString();
+
+        // 5. Sauce Labs
+        Object sauce = caps.getCapability("sauce:options");
+        if (sauce instanceof Map && ((Map<?, ?>) sauce).get("platformVersion") != null)
+            return ((Map<?, ?>) sauce).get("platformVersion").toString();
+
+        // 6. LambdaTest
+        Object lt = caps.getCapability("lt:options");
+        if (lt instanceof Map && ((Map<?, ?>) lt).get("platformVersion") != null)
+            return ((Map<?, ?>) lt).get("platformVersion").toString();
+
+        // 7. System properties as fallback
+        String osVersion = System.getProperty("os.version");
+        if (osVersion != null && !osVersion.isEmpty())
+            return osVersion;
+
+        return "Unknown";
+    }
+
+    // --- BrowserStack reports the true OS name/version via getSessionDetails ---
+    private JSONObject getBrowserStackSessionDetails() {
+        try {
+            JavascriptExecutor jse = (JavascriptExecutor) driver;
+            Object response = jse.executeScript("browserstack_executor: {\"action\": \"getSessionDetails\"}");
+            if (response == null) {
+                return null;
+            }
+            return new JSONObject((String) response);
+        } catch (Exception e) {
+            logger.info("Cloud session details not available via JS executor: " + e.getClass().getSimpleName());
+            return null;
+        }
     }
 }

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/web/StoreOSNameAndVersion.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/web/StoreOSNameAndVersion.java
@@ -6,10 +6,15 @@ import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
 import com.testsigma.sdk.annotation.TestData;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.json.JSONObject;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -35,15 +40,52 @@ public class StoreOSNameAndVersion extends WebAction {
             RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
             Capabilities caps = remoteDriver.getCapabilities();
 
-            String platformName = (caps.getCapability("platformName") != null)
-                    ? caps.getCapability("platformName").toString()
-                    : "Unknown";
-            
-            String platformVersion = (caps.getCapability("platformVersion") != null)
-                    ? caps.getCapability("platformVersion").toString()
-                    : "Unknown";
+            String platformName = "Unknown";
+            String platformVersion = "Unknown";
 
-            String osInfo = platformName + " " + platformVersion;
+            // Try BrowserStack's getSessionDetails unconditionally rather than pre-detecting the
+            // environment: Testsigma's execution engine proxies the WebDriver connection, so neither
+            // the command executor's remote address nor bstack:options survives to reveal BrowserStack
+            // is actually in play (confirmed: both were absent even on a real BrowserStack session).
+            // "browserstack_executor: {...}" is a harmless no-op (a JS labeled statement returning
+            // null) on any other provider, so attempting it everywhere is safe.
+            JSONObject bsSession = getBrowserStackSessionDetails();
+            if (bsSession != null) {
+                String bsOs = bsSession.optString("os", null);
+                if (bsOs != null && !bsOs.isEmpty()) {
+                    platformName = bsOs;
+                }
+                String bsOsVersion = bsSession.optString("os_version", null);
+                if (bsOsVersion != null && !bsOsVersion.isEmpty()) {
+                    platformVersion = bsOsVersion;
+                }
+            }
+
+            // Fallback: prefer the raw capability, since getPlatformName() defaults to
+            // Platform.ANY (not null) when the remote end never reported a real platform.
+            if (platformName.equals("Unknown")) {
+                try {
+                    if (caps.getCapability("platformName") != null) {
+                        platformName = caps.getCapability("platformName").toString();
+                    } else if (caps.getPlatformName() != null && caps.getPlatformName() != Platform.ANY) {
+                        platformName = caps.getPlatformName().toString();
+                    }
+                    if (platformName.equalsIgnoreCase("any")) {
+                        platformName = "Unknown";
+                    }
+                } catch (Exception e) {
+                    logger.warn("Could not get platformName from capabilities: " + e.getMessage());
+                }
+            }
+
+            // Fallback: Sauce Labs / LambdaTest / BrowserStack nested capability maps, then plain capabilities
+            if (platformVersion.equals("Unknown")) {
+                platformVersion = getOSVersion(caps);
+            }
+
+            String osInfo = formatOSInfo(platformName, platformVersion);
+
+            logger.warn("Platform Name detected: " + platformName);
 
             runtimeData.setKey(variableName.getValue().toString());
             runtimeData.setValue(osInfo);
@@ -57,5 +99,95 @@ public class StoreOSNameAndVersion extends WebAction {
             logger.warn("Failed to retrieve OS version: " + e.getMessage());
         }
         return result;
+    }
+
+    // --- BrowserStack reports the true OS name/version via getSessionDetails ---
+    private JSONObject getBrowserStackSessionDetails() {
+        try {
+            JavascriptExecutor jse = (JavascriptExecutor) driver;
+            Object response = jse.executeScript("browserstack_executor: {\"action\": \"getSessionDetails\"}");
+            if (response == null) {
+                return null;
+            }
+            return new JSONObject((String) response);
+        } catch (Exception e) {
+            // Expected on any non-BrowserStack provider: browserstack_executor is a magic string
+            // BrowserStack's proxy intercepts before it reaches a real browser - elsewhere it hits
+            // the actual JS engine and throws a SyntaxError. Not an error condition, so log briefly
+            // rather than dumping Selenium's verbose WebDriverException message. Deliberately don't
+            // name the provider here - which lab/cloud provider is in use is not surfaced in logs.
+            logger.info("Cloud session details not available via JS executor: " + e.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    // --- OS version lookup with cloud lab support (Sauce Labs / LambdaTest / BrowserStack) ---
+    private String getOSVersion(Capabilities caps) {
+        // 1. Standard Selenium/Appium
+        if (caps.getCapability("platformVersion") != null)
+            return caps.getCapability("platformVersion").toString();
+
+        // 2. BrowserStack
+        if (caps.getCapability("osVersion") != null)
+            return caps.getCapability("osVersion").toString();
+
+        // 3. BrowserStack legacy
+        if (caps.getCapability("os_version") != null)
+            return caps.getCapability("os_version").toString();
+
+        // 4. bstack:options
+        Object bs = caps.getCapability("bstack:options");
+        if (bs instanceof Map && ((Map<?, ?>) bs).get("osVersion") != null)
+            return ((Map<?, ?>) bs).get("osVersion").toString();
+
+        // 5. Sauce Labs
+        Object sauce = caps.getCapability("sauce:options");
+        if (sauce instanceof Map && ((Map<?, ?>) sauce).get("platformVersion") != null)
+            return ((Map<?, ?>) sauce).get("platformVersion").toString();
+
+        // 6. LambdaTest
+        Object lt = caps.getCapability("lt:options");
+        if (lt instanceof Map && ((Map<?, ?>) lt).get("platformVersion") != null)
+            return ((Map<?, ?>) lt).get("platformVersion").toString();
+
+        return "Unknown";
+    }
+
+    private String formatOSInfo(String platformName, String platformVersion) {
+        if (platformName == null || platformName.equals("Unknown")) {
+            return "Unknown";
+        }
+
+        String osName = platformName.toLowerCase();
+        boolean hasVersion = platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown");
+
+        // Some providers (e.g. Sauce Labs) resolve "platformName" as an already-complete string
+        // like "Windows 11" rather than a bare family name + separate version capability. Don't
+        // collapse that down to just "Windows" and lose the version it already carries.
+        boolean nameAlreadyHasVersion = platformName.chars().anyMatch(Character::isDigit);
+
+        if (osName.contains("mac") || osName.contains("darwin")) {
+            if (hasVersion) {
+                String majorVersion = platformVersion.split("\\.")[0];
+                return "mac " + majorVersion;
+            }
+            return nameAlreadyHasVersion ? platformName : "mac";
+        }
+
+        if (osName.contains("win")) {
+            if (hasVersion) {
+                return "Windows " + platformVersion;
+            }
+            return nameAlreadyHasVersion ? platformName : "Windows";
+        }
+
+        if (osName.contains("linux")) {
+            if (hasVersion) {
+                return "Linux " + platformVersion;
+            }
+            return nameAlreadyHasVersion ? platformName : "Linux";
+        }
+
+        return hasVersion ? platformName + " " + platformVersion : platformName;
     }
 }

--- a/store_operating_system_version/src/main/java/com/testsigma/addons/windowslite/StoreOSNameAndVersion.java
+++ b/store_operating_system_version/src/main/java/com/testsigma/addons/windowslite/StoreOSNameAndVersion.java
@@ -2,7 +2,6 @@ package com.testsigma.addons.windowslite;
 
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
-import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.WindowsAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.RunTimeData;
@@ -12,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -37,15 +37,23 @@ public class StoreOSNameAndVersion extends WindowsAction {
             RemoteWebDriver remoteDriver = (RemoteWebDriver) driver;
             Capabilities caps = remoteDriver.getCapabilities();
 
-            String platformName = (caps.getCapability("platformName") != null)
-                    ? caps.getCapability("platformName").toString()
-                    : "Unknown";
-            
-            String platformVersion = (caps.getCapability("platformVersion") != null)
-                    ? caps.getCapability("platformVersion").toString()
-                    : "Unknown";
+            // Get platform name - try getPlatformName() method first, then capability
+            String platformName = "Unknown";
+            try {
+                if (caps.getPlatformName() != null) {
+                    platformName = caps.getPlatformName().toString();
+                } else if (caps.getCapability("platformName") != null) {
+                    platformName = caps.getCapability("platformName").toString();
+                }
+            } catch (Exception e) {
+                logger.warn("Could not get platformName from capabilities: " + e.getMessage());
+            }
 
-            String osInfo = platformName + " " + platformVersion;
+            // Get platform version using vendor-compatible lookup
+            String platformVersion = getOSVersion(caps);
+
+            // Format OS info based on platform
+            String osInfo = formatOSInfo(platformName, platformVersion);
 
             runtimeData = new com.testsigma.sdk.RunTimeData();
             runtimeData.setKey(variableName.getValue().toString());
@@ -60,5 +68,82 @@ public class StoreOSNameAndVersion extends WindowsAction {
             logger.warn("Failed to retrieve OS version: " + ExceptionUtils.getStackTrace(e));
         }
         return result;
+    }
+
+    private String formatOSInfo(String platformName, String platformVersion) {
+        if (platformName == null || platformName.equals("Unknown")) {
+            return "Unknown";
+        }
+
+        String osName = platformName.toLowerCase();
+        
+        // Format macOS version (e.g., "mac 15" for macOS 15.x)
+        if (osName.contains("mac") || osName.contains("darwin")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                // Extract major version number (e.g., "15.0" -> "15", "13.6" -> "13")
+                String majorVersion = platformVersion.split("\\.")[0];
+                return "mac " + majorVersion;
+            }
+            return "mac";
+        }
+        
+        // Format Windows version
+        if (osName.contains("win")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                return "Windows " + platformVersion;
+            }
+            return "Windows";
+        }
+        
+        // Format Linux version
+        if (osName.contains("linux")) {
+            if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+                return "Linux " + platformVersion;
+            }
+            return "Linux";
+        }
+        
+        // Default: return platform name and version as-is
+        if (platformVersion != null && !platformVersion.isEmpty() && !platformVersion.equals("Unknown")) {
+            return platformName + " " + platformVersion;
+        }
+        return platformName;
+    }
+
+    // --- OS version lookup with cloud lab support ---
+    private String getOSVersion(Capabilities caps) {
+        // 1. Standard Appium/Selenium
+        if (caps.getCapability("platformVersion") != null)
+            return caps.getCapability("platformVersion").toString();
+
+        // 2. BrowserStack
+        if (caps.getCapability("osVersion") != null)
+            return caps.getCapability("osVersion").toString();
+
+        // 3. BrowserStack legacy
+        if (caps.getCapability("os_version") != null)
+            return caps.getCapability("os_version").toString();
+
+        // 4. bstack:options
+        Object bs = caps.getCapability("bstack:options");
+        if (bs instanceof Map && ((Map<?, ?>) bs).get("osVersion") != null)
+            return ((Map<?, ?>) bs).get("osVersion").toString();
+
+        // 5. Sauce Labs
+        Object sauce = caps.getCapability("sauce:options");
+        if (sauce instanceof Map && ((Map<?, ?>) sauce).get("platformVersion") != null)
+            return ((Map<?, ?>) sauce).get("platformVersion").toString();
+
+        // 6. LambdaTest
+        Object lt = caps.getCapability("lt:options");
+        if (lt instanceof Map && ((Map<?, ?>) lt).get("platformVersion") != null)
+            return ((Map<?, ?>) lt).get("platformVersion").toString();
+
+        // 7. System properties as fallback
+        String osVersion = System.getProperty("os.version");
+        if (osVersion != null && !osVersion.isEmpty())
+            return osVersion;
+
+        return "Unknown";
     }
 }


### PR DESCRIPTION
# Publish this addon as PUBLIC
Addon Name: Store Operating system version
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/3072/addons
Jira : https://testsigma.atlassian.net/browse/TP-5328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OS/version details are now captured more reliably across mobile and web environments, including cloud providers and local runs.
  * iOS and Android actions now store the resolved OS version directly in runtime variables.

* **Bug Fixes**
  * Improved handling for missing or inconsistent capability data, reducing failed lookups.
  * Refined OS formatting so results are more consistent, including macOS, Windows, and Linux values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->