### PR TITLE
feat/CUS-13815-Fix AI click accuracy in ClickOnImageUsingAi for ios

### DIFF
--- a/ai_based_action/pom.xml
+++ b/ai_based_action/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>ai_based_action</artifactId>
-    <version>1.0.27</version>
+    <version>1.0.28</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/ai_based_action/src/main/java/com/testsigma/addons/ios/ClickOnImageUsingAi.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/ios/ClickOnImageUsingAi.java
@@ -11,27 +11,58 @@ import com.testsigma.sdk.annotation.TestStepResult;
 import io.appium.java_client.ios.IOSDriver;
 import lombok.Data;
 import org.openqa.selenium.Dimension;
-import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.Pause;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Locates and taps a UI element on an iOS device using a coarse-locate + zoomed-crop-refine +
+ * zoomed-crop-verify AI pipeline for pixel-accurate taps.
+ *
+ * The previous single-pass implementation had two problems, found by comparing it against the
+ * working mobile-web equivalent ({@code com.testsigma.addons.mobileWeb.ClickOnImageUsingAi}):
+ *
+ *  1) It never downscaled the screenshot before sending it to the AI, and told the model to trust
+ *     and echo back the RAW capture dimensions (often 3-4 MP on retina iPhones). Claude's vision
+ *     input silently downscales large images internally ({@link AiActionUtils#MAX_IMAGE_EDGE} long
+ *     edge / {@link AiActionUtils#MAX_IMAGE_AREA} area), so the model ended up reasoning on a
+ *     resolution it was never told about, while the code mapped its answer back using the wrong
+ *     (too large) dimensions — a systematic miscalibration. This is fixed by resizing to a
+ *     known-safe size ourselves (via {@link AiActionUtils#fitWithinAiLimits}) and telling the AI
+ *     those exact dimensions up front instead of asking it to measure them.
+ *  2) It always called {@code getScreenshotAs(BYTES)} with no fallback; some iOS driver/WDA combos
+ *     need BASE64 instead — handled by {@link AiActionUtils#captureScreenshotWithFallback}.
+ *
+ * On top of that fix, this pipeline improves click PRECISION (as opposed to gross identification)
+ * via a crop-and-zoom refine/verify pass: the same percentage pixel-estimate error from the model
+ * becomes a much smaller physical-pixel error once the target area is magnified.
+ *
+ * Pipeline:
+ *  0) CAPTURE — screenshot via {@link AiActionUtils#captureScreenshotWithFallback}.
+ *  1) LOCATE  — resize to Claude's real vision limits, coarse-locate on that, scale back to full
+ *               capture space (retried once if not found).
+ *  2) CROP+ZOOM — crop around the coarse center and upscale it (also capped to vision limits).
+ *  3) REFINE  — precise tap point re-located from scratch on the zoomed crop.
+ *  4) VERIFY  — dot-overlay double-check on the same zoomed crop, with correction if needed.
+ *  5) TAP     — map back to full-image/physical/logical coordinates and tap, preferring the
+ *               native "mobile: tap" command with a W3C pointer-action fallback.
+ */
 @Data
 @Action(actionText = "Ai: Click on Image/text matching prompt prompt-describing-image",
-        description = "Locate and tap a UI element on an iOS device using two AI passes: " +
-                "Pass 1 locates the element; Pass 2 verifies the green-dot tap location and " +
-                "corrects it if needed. Fails if the element is not found.",
+        description = "Locate and tap a UI element on an iOS device using a coarse-locate + " +
+                "zoomed-crop-refine + zoomed-crop-verify AI pipeline for pixel-accurate taps. " +
+                "Retries the initial locate once before failing if the element isn't found.",
         displayName = "Ai: Click on Image/text matching prompt",
         applicationType = ApplicationType.IOS,
         useCustomScreenshot = true)
@@ -46,44 +77,75 @@ public class ClickOnImageUsingAi extends IOSAction {
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
 
-    // ── Iteration-2 prompt ────────────────────────────────────────────────────
-    // Coordinates are NOT injected — the AI locates the dot visually via the arrow overlay.
-    // Build order: PART1 + query + PART2_STEPS
+    private static final int MIN_CROP_SIZE = 240;
+    private static final int MAX_CROP_SIZE = 900;
+    private static final int CROP_PADDING_MULTIPLIER = 4;
+    private static final int ZOOM_TARGET_LONG_SIDE = 1200;
+    private static final double MAX_ZOOM_SCALE = 4.0;
+    private static final float JPEG_QUALITY = 0.97f;
+
+    private static final String REFINE_PROMPT_PART1 =
+            "You are a UI element locator working on a ZOOMED-IN CROP of a larger iOS screenshot. " +
+                    "This crop was extracted around the approximate location of a target element found " +
+                    "by an earlier, coarser pass — the element you are looking for should be visible " +
+                    "somewhere in this image, but may not be perfectly centered.\n\n" +
+                    "The element to find is described as: \"";
+
+    private static final String REFINE_PROMPT_PART2 =
+            "\"\n\n" +
+                    "STEP 1 — Use the given image dimensions:\n" +
+                    "  The exact pixel dimensions of THIS CROPPED image are stated at the top of this " +
+                    "prompt (see IMAGE DIMENSIONS). Do NOT guess or re-measure them. Return coordinates " +
+                    "in that pixel space and echo the given \"imageWidth\"/\"imageHeight\".\n\n" +
+                    "STEP 2 — Locate the element precisely:\n" +
+                    "  Because this image is a zoomed-in crop, you can be far more precise than on a " +
+                    "full-screen screenshot. Find the exact visual center of the described element's " +
+                    "tappable area.\n" +
+                    "  If the element is NOT visible anywhere in this crop, set \"found\" to false — do " +
+                    "not guess.\n\n" +
+                    "STEP 3 — Return the precise tap point:\n" +
+                    "  Report the single best (click_x, click_y) point to tap — the visual center of the " +
+                    "element, accounting for padding/text centering, never on a border, gap, or a " +
+                    "neighboring element.\n\n" +
+                    "OUTPUT FORMAT — strict JSON only, no markdown, no explanation:\n" +
+                    "If found:\n" +
+                    "  {\"found\": true, \"click_x\": <int>, \"click_y\": <int>, " +
+                    "\"imageWidth\": <int>, \"imageHeight\": <int>, " +
+                    "\"confidence\": <0-100>, \"reason\": \"<what the element is and why this point>\"}\n" +
+                    "If NOT found in this crop:\n" +
+                    "  {\"found\": false, \"click_x\": 0, \"click_y\": 0, " +
+                    "\"imageWidth\": <int>, \"imageHeight\": <int>, " +
+                    "\"confidence\": 0, \"reason\": \"<why it is not visible in this crop>\"}";
+
     private static final String VERIFY_PROMPT_PART1 =
-            "You are given two screenshots of the same UI, attached in order:\n" +
-                    "  1. CLEAN IMAGE (first attachment) — the original, unaltered screenshot with no overlays.\n" +
-                    "  2. ANNOTATED IMAGE (second attachment) — the same screenshot with two overlays " +
-                    "added by an automated tool (NOT part of the original UI):\n" +
-                    "       • GREEN DOT — the exact intended tap point proposed by a first AI pass.\n" +
-                    "       • MAGENTA ARROW — points from the left toward the green dot " +
-                    "(arrowhead stops ~20 px to the left of the dot) to indicate the tap location.\n\n" +
-                    "Use the clean image to understand the UI. " +
-                    "Use the annotated image to find the green dot via the arrow, then evaluate it.\n\n" +
+            "You are given two images, attached in order, both showing the SAME ZOOMED-IN CROP of a " +
+                    "larger iOS screenshot:\n" +
+                    "  1. CLEAN CROP (first attachment) — the crop with no overlays.\n" +
+                    "  2. ANNOTATED CROP (second attachment) — the same crop with a GREEN DOT added by " +
+                    "an automated tool (NOT part of the original UI) marking a proposed tap point.\n\n" +
+                    "Use the clean crop to understand the UI. Use the annotated crop to evaluate the " +
+                    "green dot.\n\n" +
                     "The element we are trying to tap is described as: \"";
 
-    private static final String VERIFY_PROMPT_PART2_STEPS =
+    private static final String VERIFY_PROMPT_PART2 =
             "\"\n\n" +
-                    "STEP 1 — Measure the image:\n" +
-                    "  Record the raw pixel dimensions as \"imageWidth\" and \"imageHeight\".\n\n" +
-                    "STEP 2 — Follow the arrow to the green dot:\n" +
-                    "  In the annotated image, follow the magenta arrow to locate the green dot. " +
-                    "Cross-reference with the clean image to identify " +
-                    "exactly which UI element the green dot is sitting on.\n" +
-                    "  • Is the green dot on the CORRECT target element described by the query?\n" +
-                    "  • Is it at a good tappable position — center of the element, " +
-                    "not on a border, gap, or neighboring element?\n" +
+                    "STEP 1 — Use the given image dimensions:\n" +
+                    "  Both images share the exact pixel dimensions stated at the top of this prompt " +
+                    "(see IMAGE DIMENSIONS). Do NOT guess or re-measure them. Return coordinates in that " +
+                    "pixel space and echo the given \"imageWidth\"/\"imageHeight\".\n\n" +
+                    "STEP 2 — Evaluate the green dot:\n" +
+                    "  • Is the green dot on the CORRECT target element described above?\n" +
+                    "  • Is it at a good tappable position — center of the element, not on a border, " +
+                    "gap, or a neighboring element?\n" +
                     "  Set \"accurate\": true only if BOTH conditions are met.\n\n" +
                     "STEP 3 — Return the best tap location:\n" +
-                    "  Always return the most precise (click_x, click_y) for the target element.\n" +
-                    "  • Green dot IS correct → confirm it, return the same or very close coordinates.\n" +
-                    "  • Green dot is wrong or slightly off → return the corrected center of the " +
-                    "actual target element.\n" +
-                    "  The returned point MUST land at the visual center of the target's tappable " +
-                    "area and must NOT fall on any adjacent or neighboring element.\n" +
-                    "  In the \"reason\" field, state which element the dot is on, whether it was " +
-                    "correct, and if corrected — by how many pixels it moved (dx, dy).\n\n" +
+                    "  Because this is a zoomed-in crop, be as precise as possible.\n" +
+                    "  • Dot is correct → confirm it, return the same or very close coordinates.\n" +
+                    "  • Dot is wrong or off → return the corrected center of the actual target element " +
+                    "within this same crop. If the target element is not visible in this crop at all, " +
+                    "set \"accurate\" to false and \"outOfCrop\" to true.\n\n" +
                     "OUTPUT FORMAT — strict JSON only, no markdown, no explanation:\n" +
-                    "{\"accurate\": <bool>, " +
+                    "{\"accurate\": <bool>, \"outOfCrop\": <bool>, " +
                     "\"click_x\": <int>, \"click_y\": <int>, " +
                     "\"imageWidth\": <int>, \"imageHeight\": <int>, " +
                     "\"reason\": \"<element the dot is on; accurate or corrected; if corrected: dx=N dy=N>\"}";
@@ -91,181 +153,237 @@ public class ClickOnImageUsingAi extends IOSAction {
     @Override
     public Result execute() {
         logger.info("=== ClickOnImageUsingAi (iOS): Starting ===");
-        File screenshotFile     = null;
-        File annotatedJpegFile  = null;
-        File finalAnnotatedFile = null;
+        File fullShotFile      = null;
+        File zoomCleanFile     = null;
+        File zoomAnnotatedFile = null;
+        File finalResultFile   = null;
 
         try {
             String query = queryDescribingElement.getValue().toString();
             logger.info("Query: " + query);
 
-            byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-            BufferedImage pageCapture = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
-            int captureW = pageCapture.getWidth();
-            int captureH = pageCapture.getHeight();
-            logger.info("Device screenshot size: " + captureW + "x" + captureH);
+            IOSDriver iosDriver = (IOSDriver) driver;
+            Dimension windowSize = iosDriver.manage().window().getSize();
+            logger.info("Device logical window size: " + windowSize.width + "x" + windowSize.height);
 
-            screenshotFile = AiActionUtils.captureAsJpeg(pageCapture, "ai_ios_capture", logger);
+            BufferedImage fullCapture = null;
+            int captureW = 0;
+            int captureH = 0;
+            int sentW = 0;
+            int sentH = 0;
+            JsonNode locateNode = null;
+            int attempts = 0;
 
-            // ──────────────────────────────────────────────────────────────────────
-            // ITERATION 1 — Locate the element in the clean screenshot
-            // ──────────────────────────────────────────────────────────────────────
-            logger.info("[Iteration 1] Locating element...");
-            String aiResponse1 = AiActionUtils.invokeAiAnthropicFirst(
-                    ai, screenshotFile, AiActionUtils.LOCATE_PROMPT_IOS, query, logger);
-            JsonNode node1 = AiActionUtils.parseAiJson(aiResponse1, logger);
+            // ── PASS 1 — coarse locate on a resized screenshot, retried once ───
+            while (attempts < 2) {
+                attempts++;
+                fullCapture = AiActionUtils.captureScreenshotWithFallback((TakesScreenshot) driver, logger);
+                captureW = fullCapture.getWidth();
+                captureH = fullCapture.getHeight();
+                logger.info("Device screenshot size: " + captureW + "x" + captureH);
 
-            if (node1 == null) {
-                setErrorMessage("Failed to get image response from AI (contact support)");
-                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_click_failed");
-                ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
-                return Result.FAILED;
+                // Resize BEFORE sending so we control the exact pixel space the AI reasons in —
+                // raw iOS retina captures routinely exceed Claude's real vision-input limits, and
+                // relying on its internal auto-downscale (while telling it the raw dimensions)
+                // causes systematic coordinate drift.
+                int[] sent = AiActionUtils.fitWithinAiLimits(captureW, captureH);
+                sentW = sent[0];
+                sentH = sent[1];
+                BufferedImage aiImage = (sentW == captureW && sentH == captureH)
+                        ? fullCapture : AiActionUtils.resizeImage(fullCapture, sentW, sentH);
+                logger.info(String.format("[Pass 1] capture %dx%d -> sent %dx%d",
+                        captureW, captureH, sentW, sentH));
+
+                AiActionUtils.deleteQuietly(fullShotFile);
+                fullShotFile = AiActionUtils.captureAsJpeg(aiImage, "ai_ios_capture", JPEG_QUALITY, logger);
+
+                logger.info("[Pass 1 attempt " + attempts + "] Coarse locate on resized screenshot...");
+                String locateResponse = AiActionUtils.invokeAiAnthropicFirst(
+                        ai, fullShotFile, AiActionUtils.LOCATE_PROMPT_IOS, query, sentW, sentH, logger);
+                locateNode = AiActionUtils.parseAiJson(locateResponse, logger);
+
+                if (locateNode != null && locateNode.path("found").asBoolean(false)) {
+                    break;
+                }
+                if (attempts < 2) {
+                    logger.info("[Pass 1] Element not found — retrying once after a short settle delay.");
+                    Thread.sleep(600);
+                }
             }
 
-            if (!node1.path("found").asBoolean(false)) {
-                String reason = node1.path("description").asText("element not found");
-                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_click_failed");
-                ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
+            if (locateNode == null) {
+                setErrorMessage("Failed to get a response from AI while locating the element (contact support)");
+                finalResultFile = ScreenshotUtils.saveScreenshotToFile(fullCapture, "ai_click_failed");
+                ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalResultFile, logger);
+                return Result.FAILED;
+            }
+            if (!locateNode.path("found").asBoolean(false)) {
+                String reason = locateNode.path("description").asText("element not found");
+                finalResultFile = ScreenshotUtils.saveScreenshotToFile(fullCapture, "ai_click_failed");
+                ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalResultFile, logger);
                 setErrorMessage("AI could not locate '" + query + "': " + reason);
                 return Result.FAILED;
             }
 
-            int aiX1        = node1.path("x1").asInt(0);
-            int aiY1        = node1.path("y1").asInt(0);
-            int aiX2        = node1.path("x2").asInt(0);
-            int aiY2        = node1.path("y2").asInt(0);
-            int aiCx        = node1.path("cx").asInt(0);
-            int aiCy        = node1.path("cy").asInt(0);
-            int imageWidth  = node1.path("imageWidth").asInt(0);
-            int imageHeight = node1.path("imageHeight").asInt(0);
-            int conf1       = node1.path("confidence").asInt(50);
-            String desc1    = node1.path("description").asText("");
+            int rawX1 = locateNode.path("x1").asInt(0);
+            int rawY1 = locateNode.path("y1").asInt(0);
+            int rawX2 = locateNode.path("x2").asInt(0);
+            int rawY2 = locateNode.path("y2").asInt(0);
+            int rawCx = locateNode.path("cx").asInt(0);
+            int rawCy = locateNode.path("cy").asInt(0);
+            int conf1 = locateNode.path("confidence").asInt(50);
+            String desc1 = locateNode.path("description").asText("");
 
-            logger.info(String.format(
-                    "[Iteration 1] AI result — bbox: (%d,%d)-(%d,%d) | cx/cy: (%d,%d) | " +
-                            "AI image dims: %dx%d | confidence: %d | desc: '%s'",
-                    aiX1, aiY1, aiX2, aiY2, aiCx, aiCy, imageWidth, imageHeight, conf1, desc1));
+            // The AI reasoned in the RESIZED (sentW x sentH) pixel space we told it about — scale
+            // its bbox back up to the full-capture pixel space using the known sent/capture ratio,
+            // rather than trusting any imageWidth/imageHeight it echoed back.
+            int[] scaledBox = AiActionUtils.scaleAiToCapture(rawX1, rawY1, rawX2, rawY2, sentW, sentH, captureW, captureH);
+            int lx1 = clamp(scaledBox[0], 0, captureW - 1);
+            int ly1 = clamp(scaledBox[1], 0, captureH - 1);
+            int lx2 = clamp(scaledBox[2], 0, captureW - 1);
+            int ly2 = clamp(scaledBox[3], 0, captureH - 1);
+            if (lx2 <= lx1) lx2 = Math.min(captureW - 1, lx1 + 1);
+            if (ly2 <= ly1) ly2 = Math.min(captureH - 1, ly1 + 1);
 
-            if (imageWidth <= 0 || imageHeight <= 0) {
-                setErrorMessage(String.format(
-                        "AI returned invalid image dimensions (imageWidth=%d, imageHeight=%d).",
-                        imageWidth, imageHeight));
-                finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(pageCapture, "ai_click_failed");
-                ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
-                return Result.FAILED;
-            }
-
-            int[] cap = AiActionUtils.scaleAiToCapture(aiX1, aiY1, aiX2, aiY2, imageWidth, imageHeight, captureW, captureH);
-
-            // Use AI's reported visual center (cx/cy) when present; fall back to bbox midpoint.
-            int tapX, tapY;
-            if (aiCx > 0 && aiCy > 0) {
-                tapX = (int) Math.round((double) aiCx / imageWidth  * captureW);
-                tapY = (int) Math.round((double) aiCy / imageHeight * captureH);
+            int coarseCx, coarseCy;
+            if (rawCx > 0 && rawCy > 0) {
+                coarseCx = clamp((int) Math.round((double) rawCx / sentW * captureW), 0, captureW - 1);
+                coarseCy = clamp((int) Math.round((double) rawCy / sentH * captureH), 0, captureH - 1);
             } else {
-                tapX = (cap[0] + cap[2]) / 2;
-                tapY = (cap[1] + cap[3]) / 2;
+                coarseCx = (lx1 + lx2) / 2;
+                coarseCy = (ly1 + ly2) / 2;
             }
-            // Clamp to bbox so the tap always lands within the detected element
-            tapX = Math.max(cap[0], Math.min(cap[2], tapX));
-            tapY = Math.max(cap[1], Math.min(cap[3], tapY));
 
             logger.info(String.format(
-                    "[Iteration 1] Device bbox: (%d,%d)-(%d,%d)  tap: (%d,%d)",
-                    cap[0], cap[1], cap[2], cap[3], tapX, tapY));
+                    "[Pass 1] bbox: (%d,%d)-(%d,%d) | center: (%d,%d) | confidence: %d | desc: '%s'",
+                    lx1, ly1, lx2, ly2, coarseCx, coarseCy, conf1, desc1));
 
-            BufferedImage annotated1 = AiActionUtils.drawHighlight(
-                    pageCapture, cap[0], cap[1], cap[2], cap[3], tapX, tapY, Color.MAGENTA);
-            annotatedJpegFile = AiActionUtils.captureAsJpeg(annotated1, "ai_ios_annotated", logger);
+            // ── Build a crop around the coarse location and upscale it ─────────
+            int elementSize = Math.max(lx2 - lx1, ly2 - ly1);
+            int cropSize = clamp(elementSize * CROP_PADDING_MULTIPLIER, MIN_CROP_SIZE, MAX_CROP_SIZE);
 
-            // ──────────────────────────────────────────────────────────────────────
-            // ITERATION 2 — Verify the GREEN DOT in the annotated screenshot
-            // ──────────────────────────────────────────────────────────────────────
+            int cropX1 = clamp(coarseCx - cropSize / 2, 0, Math.max(0, captureW - 1));
+            int cropY1 = clamp(coarseCy - cropSize / 2, 0, Math.max(0, captureH - 1));
+            int cropW = Math.max(1, Math.min(cropSize, captureW - cropX1));
+            int cropH = Math.max(1, Math.min(cropSize, captureH - cropY1));
+
+            BufferedImage crop = cropRegion(fullCapture, cropX1, cropY1, cropW, cropH);
+
+            double desiredScale = Math.max(1.0, Math.min(MAX_ZOOM_SCALE,
+                    (double) ZOOM_TARGET_LONG_SIDE / Math.max(cropW, cropH)));
+            int desiredZoomW = (int) Math.round(cropW * desiredScale);
+            int desiredZoomH = (int) Math.round(cropH * desiredScale);
+            // Cap to the same real vision limits used for Pass 1 — a near-square crop at
+            // MAX_CROP_SIZE upscaled by desiredScale can otherwise exceed Claude's ~1.15 MP cap.
+            int[] zoomFit = AiActionUtils.fitWithinAiLimits(desiredZoomW, desiredZoomH);
+            int zoomW = zoomFit[0];
+            int zoomH = zoomFit[1];
+            BufferedImage zoomed = AiActionUtils.resizeImage(crop, zoomW, zoomH);
+
+            // Compute actual applied scale per axis (may differ minutely due to rounding) so the
+            // reverse mapping back to full-capture space stays exact.
+            double zoomScaleX = (double) zoomW / cropW;
+            double zoomScaleY = (double) zoomH / cropH;
+
             logger.info(String.format(
-                    "[Iteration 2] Verifying green-dot at physical (%d,%d)...", tapX, tapY));
-            String verifyPrompt = VERIFY_PROMPT_PART1 + query + VERIFY_PROMPT_PART2_STEPS;
-            String aiResponse2  = AiActionUtils.invokeAiWithFilesAnthropicFirst(
-                    ai, List.of(screenshotFile, annotatedJpegFile), verifyPrompt, "", logger);
-            JsonNode node2 = AiActionUtils.parseAiJson(aiResponse2, logger);
+                    "[Crop] region: (%d,%d) %dx%d | zoomed to %dx%d (scaleX=%.2f scaleY=%.2f)",
+                    cropX1, cropY1, cropW, cropH, zoomW, zoomH, zoomScaleX, zoomScaleY));
 
-            String finalDesc = desc1;
+            zoomCleanFile = AiActionUtils.captureAsJpeg(zoomed, "ai_ios_zoom_clean", JPEG_QUALITY, logger);
 
-            if (node2 != null) {
-                boolean accurate = node2.path("accurate").asBoolean(true);
-                int     rawX     = node2.path("click_x").asInt(0);
-                int     rawY     = node2.path("click_y").asInt(0);
-                int     imgW2    = node2.path("imageWidth").asInt(0);
-                int     imgH2    = node2.path("imageHeight").asInt(0);
-                String  reason   = node2.path("reason").asText("");
+            // ── PASS 2 — precise refine on the zoomed crop ──────────────────────
+            logger.info("[Pass 2] Refining tap point on zoomed crop...");
+            String refinePrompt = REFINE_PROMPT_PART1 + query + REFINE_PROMPT_PART2;
+            String refineResponse = AiActionUtils.invokeAiAnthropicFirst(
+                    ai, zoomCleanFile, refinePrompt, "", zoomW, zoomH, logger);
+            JsonNode refineNode = AiActionUtils.parseAiJson(refineResponse, logger);
 
-                if (rawX > 0 && rawY > 0 && imgW2 > 0 && imgH2 > 0) {
-                    int prevX = tapX;
-                    int prevY = tapY;
+            int zoomTapX = clamp((int) Math.round((coarseCx - cropX1) * zoomScaleX), 0, zoomW - 1);
+            int zoomTapY = clamp((int) Math.round((coarseCy - cropY1) * zoomScaleY), 0, zoomH - 1);
+            int conf2 = conf1;
+            String desc2 = desc1;
 
-                    if (accurate) {
-                        // Dot confirmed correct — use the geometric center of the Iteration 1 bbox.
-                        tapX = (cap[0] + cap[2]) / 2;
-                        tapY = (cap[1] + cap[3]) / 2;
-                    } else {
-                        // Dot is on the wrong element — use Iteration 2's corrected coordinates,
-                        // clamped to the Iteration 1 bbox as a safety bound.
-                        double sx2 = (double) captureW / imgW2;
-                        double sy2 = (double) captureH / imgH2;
-                        tapX = (int) Math.round(rawX * sx2);
-                        tapY = (int) Math.round(rawY * sy2);
-                        tapX = Math.max(cap[0], Math.min(cap[2], tapX));
-                        tapY = Math.max(cap[1], Math.min(cap[3], tapY));
-                    }
-
-                    int dx = tapX - prevX;
-                    int dy = tapY - prevY;
-                    boolean corrected = Math.abs(dx) > 2 || Math.abs(dy) > 2;
-                    finalDesc = reason;
-
-                    logger.info(String.format(
-                            "[Iteration 2] accurate: %b | corrected: %b | " +
-                                    "dot was (%d,%d) → corrected to (%d,%d) | delta: dx=%d dy=%d | reason: '%s'",
-                            accurate, corrected, prevX, prevY, tapX, tapY, dx, dy, reason));
-                } else {
-                    logger.info("[Iteration 2] Invalid coordinates in response — using Iteration 1 result.");
+            if (refineNode != null && refineNode.path("found").asBoolean(true)) {
+                int rx = refineNode.path("click_x").asInt(0);
+                int ry = refineNode.path("click_y").asInt(0);
+                if (rx > 0 && ry > 0) {
+                    zoomTapX = clamp(rx, 0, zoomW - 1);
+                    zoomTapY = clamp(ry, 0, zoomH - 1);
+                    conf2 = refineNode.path("confidence").asInt(conf1);
+                    desc2 = refineNode.path("reason").asText(desc1);
                 }
             } else {
-                logger.info("[Iteration 2] No usable result — using Iteration 1 coordinates.");
+                logger.info("[Pass 2] Refine pass did not confirm the element in the crop — " +
+                        "keeping the coarse (re-projected) center as the working point.");
             }
 
-            // Final annotation: bbox rectangle + crosshair + green dot (no misleading arrow)
-            BufferedImage finalAnnotated = AiActionUtils.drawFinalAnnotation(
-                    pageCapture, cap[0], cap[1], cap[2], cap[3], tapX, tapY);
-            finalAnnotatedFile = ScreenshotUtils.saveScreenshotToFile(finalAnnotated, "ai_click_elem_result");
-            ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalAnnotatedFile, logger);
+            logger.info(String.format("[Pass 2] zoom tap: (%d,%d) | confidence: %d | desc: '%s'",
+                    zoomTapX, zoomTapY, conf2, desc2));
 
-            // iOS screenshot is in physical pixels; PointerInput expects logical points (UIKit).
-            IOSDriver iosDriver = (IOSDriver) driver;
-            Dimension windowSize = iosDriver.manage().window().getSize();
-            int logicalTapX = (int) Math.round((double) tapX * windowSize.width  / captureW);
+            // ── PASS 3 — verify the proposed point with a dot overlay, on the zoom ─
+            BufferedImage zoomAnnotated = AiActionUtils.drawHighlight(
+                    zoomed, 0, 0, 0, 0, zoomTapX, zoomTapY, Color.GREEN);
+            zoomAnnotatedFile = AiActionUtils.captureAsJpeg(zoomAnnotated, "ai_ios_zoom_annotated", JPEG_QUALITY, logger);
+
+            logger.info("[Pass 3] Verifying tap point via dot overlay on zoomed crop...");
+            String verifyPrompt = VERIFY_PROMPT_PART1 + query + VERIFY_PROMPT_PART2;
+            String verifyResponse = AiActionUtils.invokeAiWithFilesAnthropicFirst(
+                    ai, List.of(zoomCleanFile, zoomAnnotatedFile), verifyPrompt, "",
+                    zoomW, zoomH, logger);
+            JsonNode verifyNode = AiActionUtils.parseAiJson(verifyResponse, logger);
+
+            String finalDesc = desc2;
+            if (verifyNode != null && !verifyNode.path("outOfCrop").asBoolean(false)) {
+                boolean accurate = verifyNode.path("accurate").asBoolean(true);
+                int vx = verifyNode.path("click_x").asInt(0);
+                int vy = verifyNode.path("click_y").asInt(0);
+                String reason = verifyNode.path("reason").asText(finalDesc);
+
+                if (!accurate && vx > 0 && vy > 0) {
+                    int prevX = zoomTapX;
+                    int prevY = zoomTapY;
+                    zoomTapX = clamp(vx, 0, zoomW - 1);
+                    zoomTapY = clamp(vy, 0, zoomH - 1);
+                    logger.info(String.format(
+                            "[Pass 3] corrected: (%d,%d) -> (%d,%d) | reason: '%s'",
+                            prevX, prevY, zoomTapX, zoomTapY, reason));
+                } else {
+                    logger.info("[Pass 3] accurate=" + accurate + " | reason: '" + reason + "'");
+                }
+                finalDesc = reason;
+            } else if (verifyNode != null) {
+                logger.info("[Pass 3] Verification reports the element is out of this crop — " +
+                        "keeping Pass 2's tap point.");
+            }
+
+            // ── Map final zoom-space point back to full-image physical pixels ──
+            int tapX = clamp(cropX1 + (int) Math.round(zoomTapX / zoomScaleX), 0, captureW - 1);
+            int tapY = clamp(cropY1 + (int) Math.round(zoomTapY / zoomScaleY), 0, captureH - 1);
+
+            logger.info(String.format("[Final] physical tap point: (%d,%d)", tapX, tapY));
+
+            BufferedImage finalAnnotated = AiActionUtils.drawFinalAnnotation(
+                    fullCapture, lx1, ly1, lx2, ly2, tapX, tapY);
+            finalResultFile = ScreenshotUtils.saveScreenshotToFile(finalAnnotated, "ai_click_elem_result");
+            ScreenshotUtils.uploadScreenshotToS3(testStepResult, finalResultFile, logger);
+
+            // iOS screenshot is in physical pixels; taps need logical points (UIKit).
+            int logicalTapX = (int) Math.round((double) tapX * windowSize.width / captureW);
             int logicalTapY = (int) Math.round((double) tapY * windowSize.height / captureH);
             logger.info(String.format(
-                    "Tapping at physical (%d,%d) → logical (%d,%d)  window=%dx%d  confidence=%d",
-                    tapX, tapY, logicalTapX, logicalTapY,
-                    windowSize.width, windowSize.height, conf1));
+                    "Tapping at physical (%d,%d) -> logical (%d,%d)  window=%dx%d",
+                    tapX, tapY, logicalTapX, logicalTapY, windowSize.width, windowSize.height));
+
             try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) {
-                // ignore
+                Thread.sleep(250);
+            } catch (InterruptedException ignored) {
             }
 
-            PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
-            Sequence tap = new Sequence(finger, 0);
-            tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), logicalTapX, logicalTapY));
-            tap.addAction(finger.createPointerDown(0));
-            tap.addAction(new Pause(finger, Duration.ofMillis(50)));
-            tap.addAction(finger.createPointerUp(0));
-            ((Interactive) iosDriver).perform(Collections.singletonList(tap));
+            performTap(iosDriver, logicalTapX, logicalTapY);
 
             setSuccessMessage(String.format(
-                    "Successfully tapped '%s' at logical (%d,%d) | physical (%d,%d) | bbox (%d,%d)-(%d,%d) | confidence=%d | %s",
-                    query, logicalTapX, logicalTapY, tapX, tapY,
-                    cap[0], cap[1], cap[2], cap[3], conf1, finalDesc));
+                    "Successfully tapped '%s' at logical (%d,%d) | physical (%d,%d) | confidence=%d | %s",
+                    query, logicalTapX, logicalTapY, tapX, tapY, conf2, finalDesc));
             return Result.SUCCESS;
 
         } catch (Exception e) {
@@ -273,9 +391,47 @@ public class ClickOnImageUsingAi extends IOSAction {
             setErrorMessage("Failed to tap using AI. Error: " + e.getMessage());
             return Result.FAILED;
         } finally {
-            AiActionUtils.deleteQuietly(screenshotFile);
-            AiActionUtils.deleteQuietly(annotatedJpegFile);
-            AiActionUtils.deleteQuietly(finalAnnotatedFile);
+            AiActionUtils.deleteQuietly(fullShotFile);
+            AiActionUtils.deleteQuietly(zoomCleanFile);
+            AiActionUtils.deleteQuietly(zoomAnnotatedFile);
+            AiActionUtils.deleteQuietly(finalResultFile);
         }
+    }
+
+    /**
+     * Prefers the XCUITest "mobile: tap" native command (the officially recommended, most
+     * reliable tap for iOS — it handles custom controls/webviews that raw W3C pointer sequences
+     * sometimes miss) and falls back to a manual W3C touch action if it's unsupported.
+     */
+    private void performTap(IOSDriver iosDriver, int x, int y) {
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("x", x);
+            params.put("y", y);
+            iosDriver.executeScript("mobile: tap", params);
+            logger.info("Tap executed via 'mobile: tap'.");
+        } catch (Exception mobileTapEx) {
+            logger.info("'mobile: tap' failed (" + mobileTapEx.getMessage() + "); falling back to W3C touch action.");
+            PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+            Sequence tap = new Sequence(finger, 0);
+            tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), x, y));
+            tap.addAction(finger.createPointerDown(0));
+            tap.addAction(new Pause(finger, Duration.ofMillis(80)));
+            tap.addAction(finger.createPointerUp(0));
+            ((Interactive) iosDriver).perform(Collections.singletonList(tap));
+        }
+    }
+
+    private static int clamp(int value, int min, int max) {
+        if (max < min) return min;
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static BufferedImage cropRegion(BufferedImage src, int x, int y, int w, int h) {
+        BufferedImage out = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = out.createGraphics();
+        g.drawImage(src, 0, 0, w, h, x, y, x + w, y + h, null);
+        g.dispose();
+        return out;
     }
 }

--- a/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/ClickOnImageUsingAi.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/mobileWeb/ClickOnImageUsingAi.java
@@ -13,16 +13,13 @@ import com.testsigma.sdk.annotation.TestStepResult;
 import lombok.Data;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.Pause;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
@@ -45,9 +42,6 @@ public class ClickOnImageUsingAi extends WebAction {
 
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
-
-    private static final int  MAX_IMAGE_EDGE = 1536;        // safely under Claude's ~1568 px long-edge cap
-    private static final long MAX_IMAGE_AREA = 1_150_000L;  // Claude's ~1.15 MP cap
 
     @Override
     public Result execute() {
@@ -118,15 +112,7 @@ public class ClickOnImageUsingAi extends WebAction {
 
     /** Reads the current screenshot, tolerating iOS Appium returning a base64 payload. */
     private BufferedImage readScreenshot() throws Exception {
-        byte[] bytes;
-        try {
-            bytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-        } catch (Exception ex) {
-            // Some iOS driver/WDA combos need BASE64 instead of raw bytes
-            String base64 = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BASE64);
-            bytes = java.util.Base64.getDecoder().decode(base64);
-        }
-        return ImageIO.read(new ByteArrayInputStream(bytes));
+        return AiActionUtils.captureScreenshotWithFallback((TakesScreenshot) driver, logger);
     }
 
     /** Locates {@code query} in {@code source}; returns null on no response, found=false if absent. */
@@ -135,7 +121,7 @@ public class ClickOnImageUsingAi extends WebAction {
         int srcH = source.getHeight();
 
         // Resize before sending so we control the pixel space the AI reasons in
-        int[] sent = fitWithinAiLimits(srcW, srcH);
+        int[] sent = AiActionUtils.fitWithinAiLimits(srcW, srcH);
         int sentW = sent[0];
         int sentH = sent[1];
         BufferedImage aiImage = AiActionUtils.resizeImage(source, sentW, sentH);
@@ -181,22 +167,6 @@ public class ClickOnImageUsingAi extends WebAction {
         } finally {
             AiActionUtils.deleteQuietly(file);
         }
-    }
-
-    /** Largest size within Claude's vision limits that preserves aspect ratio. */
-    private static int[] fitWithinAiLimits(int w, int h) {
-        double scale = 1.0;
-        int longEdge = Math.max(w, h);
-        if (longEdge > MAX_IMAGE_EDGE) {
-            scale = (double) MAX_IMAGE_EDGE / longEdge;
-        }
-        double area = (w * scale) * (h * scale);
-        if (area > MAX_IMAGE_AREA) {
-            scale *= Math.sqrt(MAX_IMAGE_AREA / area);
-        }
-        int nw = Math.max(1, (int) Math.round(w * scale));
-        int nh = Math.max(1, (int) Math.round(h * scale));
-        return new int[]{nw, nh};
     }
 
     /** Snaps an approximate AI box onto the real content pixels around it; safe no-op on failure. */

--- a/ai_based_action/src/main/java/com/testsigma/addons/util/AiActionUtils.java
+++ b/ai_based_action/src/main/java/com/testsigma/addons/util/AiActionUtils.java
@@ -9,12 +9,21 @@ import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 
+import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.util.Base64;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -25,6 +34,12 @@ public class AiActionUtils {
 
     /** Used for verify and store (data extraction) actions (Anthropic direct). */
     public static final String AI_MODEL_ANTHROPIC = "claude-opus-4-8";
+
+    /** Claude's real vision-input limits — sending anything larger makes it silently downscale
+     *  internally, so callers should resize to this via {@link #fitWithinAiLimits} first and
+     *  reason in that known pixel space rather than trusting whatever it echoes back. */
+    public static final int MAX_IMAGE_EDGE = 1536;
+    public static final long MAX_IMAGE_AREA = 1_150_000L;
 
     private static final String CUSTOM_INSTRUCTIONS =
             "<custom_instructions>\n" +
@@ -372,6 +387,63 @@ public class AiActionUtils {
         return file;
     }
 
+    /**
+     * Same as {@link #captureAsJpeg(BufferedImage, String, Logger)} but writes at an explicit
+     * JPEG compression quality (0.0–1.0). The default ImageIO JPEG writer settings noticeably
+     * soften small icons/text, which matters for zoomed-crop refine/verify passes that need the
+     * AI to read fine detail precisely.
+     */
+    public static File captureAsJpeg(BufferedImage image, String prefix, float quality, Logger logger) throws Exception {
+        BufferedImage rgb = image.getType() == BufferedImage.TYPE_INT_RGB ? image : toRgb(image);
+        File file = File.createTempFile(prefix, ".jpg");
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
+        ImageWriter writer = writers.next();
+        ImageWriteParam param = writer.getDefaultWriteParam();
+        param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        param.setCompressionQuality(quality);
+        try (ImageOutputStream ios = ImageIO.createImageOutputStream(file)) {
+            writer.setOutput(ios);
+            writer.write(null, new IIOImage(rgb, null, null), param);
+        } finally {
+            writer.dispose();
+        }
+        logger.info(String.format("JPEG written (quality=%.2f): %s (size=%d bytes, dims=%dx%d)",
+                quality, file.getAbsolutePath(), file.length(), image.getWidth(), image.getHeight()));
+        return file;
+    }
+
+    /**
+     * Reads the current screenshot, tolerating iOS Appium/WDA combos where BYTES capture is
+     * unreliable by falling back to BASE64.
+     */
+    public static BufferedImage captureScreenshotWithFallback(TakesScreenshot driver, Logger logger) throws Exception {
+        byte[] bytes;
+        try {
+            bytes = driver.getScreenshotAs(OutputType.BYTES);
+        } catch (Exception ex) {
+            logger.info("BYTES screenshot capture failed (" + ex.getMessage() + "); retrying with BASE64.");
+            String base64 = driver.getScreenshotAs(OutputType.BASE64);
+            bytes = Base64.getDecoder().decode(base64);
+        }
+        return ImageIO.read(new ByteArrayInputStream(bytes));
+    }
+
+    /** Largest size within Claude's real vision limits ({@link #MAX_IMAGE_EDGE}/{@link #MAX_IMAGE_AREA}) that preserves aspect ratio. */
+    public static int[] fitWithinAiLimits(int w, int h) {
+        double scale = 1.0;
+        int longEdge = Math.max(w, h);
+        if (longEdge > MAX_IMAGE_EDGE) {
+            scale = (double) MAX_IMAGE_EDGE / longEdge;
+        }
+        double area = (w * scale) * (h * scale);
+        if (area > MAX_IMAGE_AREA) {
+            scale *= Math.sqrt(MAX_IMAGE_AREA / area);
+        }
+        int nw = Math.max(1, (int) Math.round(w * scale));
+        int nh = Math.max(1, (int) Math.round(h * scale));
+        return new int[]{nw, nh};
+    }
+
     /** Builds the full AI prompt and invokes the AI service with a single screenshot. */
     public static String invokeAi(AI ai, File screenshotFile,
                                   String basePrompt, String query,
@@ -384,6 +456,19 @@ public class AiActionUtils {
                                                 String basePrompt, String query,
                                                 Logger logger) throws Exception {
         return invokeAiWithFilesAnthropicFirst(ai, List.of(screenshotFile), basePrompt, query, logger);
+    }
+
+    /**
+     * Same as {@link #invokeAiAnthropicFirst(AI, File, String, String, Logger)} but states the
+     * attached image's exact pixel dimensions up front in the prompt, so the model doesn't have
+     * to (mis-)measure them itself — needed whenever the caller already resized the image and
+     * must reason about the AI's returned coordinates in that exact known pixel space.
+     */
+    public static String invokeAiAnthropicFirst(AI ai, File screenshotFile,
+                                                String basePrompt, String query,
+                                                int imageWidth, int imageHeight,
+                                                Logger logger) throws Exception {
+        return invokeAiWithFilesAnthropicFirst(ai, List.of(screenshotFile), basePrompt, query, imageWidth, imageHeight, logger);
     }
 
     /**
@@ -413,6 +498,21 @@ public class AiActionUtils {
             logger.info("Fallback AI response: " + response);
         }
         return response;
+    }
+
+    /** Same as {@link #invokeAiWithFilesAnthropicFirst(AI, List, String, String, Logger)} but states
+     *  the attached images' exact known pixel dimensions up front in the prompt (see
+     *  {@link #invokeAiAnthropicFirst(AI, File, String, String, int, int, Logger)}). */
+    public static String invokeAiWithFilesAnthropicFirst(AI ai, List<File> files,
+                                                         String basePrompt, String query,
+                                                         int imageWidth, int imageHeight,
+                                                         Logger logger) throws Exception {
+        return invokeAiWithFilesAnthropicFirst(ai, files, withKnownDimensions(basePrompt, imageWidth, imageHeight), query, logger);
+    }
+
+    private static String withKnownDimensions(String basePrompt, int width, int height) {
+        return String.format("IMAGE DIMENSIONS: this image is exactly %dx%d pixels — use these " +
+                "exact values, do not re-measure or guess them.\n\n", width, height) + basePrompt;
     }
 
     /**


### PR DESCRIPTION
## Publish this addon as PUBLIC
Addon Name: Ai based action
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-13681

Fixes AI-based element tapping on iOS, which was failing due to a coordinate miscalibration bug, and removes duplicated helper logic in the process.                                                     
                                                                                                                                                                                                           
  **Root cause:** `ios/ClickOnImageUsingAi` sent the raw, full-resolution device screenshot (often 3-4 MP on retina iPhones) to the AI and relied on the model to self-report the image dimensions it "measured." Claude's vision input silently downscales large images internally, so the model reasoned in a resolution it was never told about, while the code mapped its returned coordinates back using the wrong (too large) dimensions — causing consistently mis-placed taps. It also called `getScreenshotAs(BYTES)` with no fallback, which some iOS driver/WDA combos don't support reliably.              
                                                                                                                                                                                                           
  **Fix:** resize the screenshot ourselves to a known-safe size before sending it, tell the AI those exact dimensions up front instead of asking it to measure them, and add a BASE64 fallback for screenshot capture. On top of that, added a crop-and-zoom refine/verify pass so the same percentage pixel-estimate error from the model becomes a much smaller physical-pixel error once the target area is magnified — improving tap precision, not just gross element detection.                                                                                                                                
                                                                                                                                                                                                           
## Changes                                                                                                                                                                                               
                                                                                                                                                                                                           
  - **`util/AiActionUtils.java`** — added shared, reusable helpers (additive only, no existing signatures changed):                                                                                        
    - `fitWithinAiLimits(w, h)` + `MAX_IMAGE_EDGE`/`MAX_IMAGE_AREA` constants                                                                                                                              
    - `captureScreenshotWithFallback(driver, logger)` — BYTES capture with BASE64 fallback                                                                                                                 
    - `captureAsJpeg(image, prefix, quality, logger)` — quality-controlled JPEG writer (default ImageIO quality softens small icons/text, hurting precision on zoomed crops)                               
    - Dimension-aware `invokeAiAnthropicFirst` / `invokeAiWithFilesAnthropicFirst` overloads that state the image's exact known pixel size in the prompt instead of asking the AI to measure it            
  - **`ios/ClickOnImageUsingAi.java`** — rewritten pipeline: coarse locate (resized screenshot, retried once) → crop + zoom around the coarse hit → AI refine pass on the zoomed crop → AI dot-overlay     
  verify pass → tap, preferring the native `mobile: tap` XCUITest command with a W3C pointer-action fallback. Same `actionText`/`reference`, so it's a drop-in behavior fix, not a new action.             
  - **`mobileWeb/ClickOnImageUsingAi.java`** — its private `readScreenshot()`/`fitWithinAiLimits()` (duplicated logic/constants) now delegate to the new shared `AiActionUtils` helpers instead of keeping 
  their own copies.
