### PR TITLE
Migrate network capture to raw CDP session and handle non-JSON responses

### DIFF
--- a/store_network_logs_data/dependency-reduced-pom.xml
+++ b/store_network_logs_data/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.testsigma.addons</groupId>
   <artifactId>store_network_logs_data</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.15</version>
   <build>
     <finalName>store_network_logs_data</finalName>
     <plugins>

--- a/store_network_logs_data/pom.xml
+++ b/store_network_logs_data/pom.xml
@@ -7,7 +7,7 @@
     
     <groupId>com.testsigma.addons</groupId>
     <artifactId>store_network_logs_data</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.15</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.33.0</version>
+            <version>4.37.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.appium/java-client -->
         <dependency>

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/GetDataFromResponseBody.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/GetDataFromResponseBody.java
@@ -69,7 +69,15 @@ public class GetDataFromResponseBody extends WebAction {
             try {
                 parsedJson = mapper.readValue(responseBody, Object.class);
             } catch (JsonProcessingException e) {
-                throw new Exception("Response body is not a valid JSON. Error: " + e.getMessage());
+                logger.warn("Response body is not valid JSON, falling back to raw body. Error: " + e.getMessage());
+                runTimeData.setKey(variableName.getValue().toString());
+                runTimeData.setValue(responseBody);
+                String fallbackMessage = String.format(
+                        "Response body is not valid JSON; stored the raw response body in runtime variable '%s'.",
+                        variableName.getValue());
+                setSuccessMessage(fallbackMessage);
+                logger.info(fallbackMessage);
+                return Result.SUCCESS;
             }
 
             // Step 3: Get parameters

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTracking.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTracking.java
@@ -2,6 +2,7 @@ package com.testsigma.addons.web;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.testsigma.addons.web.utilities.RawCdpNetworkSession;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -10,14 +11,11 @@ import com.testsigma.sdk.annotation.TestCaseResult;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.network.model.RequestId;
-import org.openqa.selenium.remote.Augmenter;
 
-
+import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.testsigma.addons.web.utilities.ResponseDataUtilities.saveAllNetworkData;
 
@@ -39,181 +37,97 @@ public class StartTracking extends WebAction {
 
     @Override
     public Result execute() {
-
         logger.info("Started execution for action: StartTracking");
         try {
-            // Enhance the driver to support DevTools
-            logger.info("Augmenting driver to support DevTools...");
-            driver = new Augmenter().augment(driver);
+            String urlPattern = urlVariable.getValue().toString();
+            String method = methodValue.getValue().toString();
+            Duration cdpTimeout = Duration.ofSeconds(10);
+            logger.info("Tracking requests where url contains \"" + urlPattern + "\" and method = " + method);
+            logger.info("driver class: " + driver.getClass().getName());
 
-            // Initialize DevTools and create a session
-            logger.info("Initializing DevTools...");
-            DevTools devTool;
-            
-            // Try to get DevTools from the driver
-            if (driver instanceof HasDevTools) {
-                devTool = ((HasDevTools) driver).getDevTools();
-                devTool.createSessionIfThereIsNotOne();
-                logger.info("DevTools session successfully created.");
-            } else {
-                logger.warn("DevTools not supported by this driver. Using alternative network logging approach.");
-                // For drivers that don't support DevTools, we'll use browser logs
+            RawCdpNetworkSession session = RawCdpNetworkSession.attach(driver, logger, cdpTimeout);
+
+            // requestId -> {payload, requestHeaders string, start time} for requests matching the filter, until their response arrives
+            Map<String, Object[]> pendingMatches = new ConcurrentHashMap<>();
+
+            session.onRequestWillBeSent((seq, params) -> {
                 try {
-                    // Enable browser logging
-                    logger.info("Enabling browser performance logging...");
-                    // This is a fallback approach - the main DevTools approach should work
-                    logger.info("DevTools approach failed, but action completed successfully.");
-                    return Result.SUCCESS;
-                } catch (Exception e) {
-                    logger.warn("Fallback approach also failed: " + e.getMessage());
-                    return Result.SUCCESS;
-                }
-            }
+                    String requestId = String.valueOf(params.get("requestId"));
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> request = (Map<String, Object>) params.get("request");
+                    if (request == null) return;
 
-            // Enable network interception with high buffer size
-            logger.info("Enabling network interception...");
-            try {
-                devTool.send(Network.enable(Optional.empty(),
-                        Optional.empty(), Optional.of(100000000)));
-                logger.info("Network interception enabled successfully.");
-            } catch (Exception e) {
-                logger.warn("Failed to enable network interception: " + e.getMessage());
-                return Result.SUCCESS;
-            }
+                    String requestUrl = String.valueOf(request.get("url"));
+                    String requestMethod = String.valueOf(request.get("method"));
+                    if (!requestUrl.contains(urlPattern) || !requestMethod.equalsIgnoreCase(method)) {
+                        return;
+                    }
 
-            final RequestId[] requestIds = new RequestId[1];
-            final String[] capturedRequestHeaders = new String[1];
-            final String[] capturedPayloads = new String[1];
-            final long[] requestStartTimes = new long[1];
-
-            // Listener to intercept network requests
-            logger.info("Adding listener for network requests...");
-            devTool.addListener(Network.requestWillBeSent(), request -> {
-                String requestUrl = request.getRequest().getUrl();
-                String requestMethod = request.getRequest().getMethod();
-                // request url should contain the url_variable value
-                if (requestUrl.contains(urlVariable.getValue().toString()) &&
-                        requestMethod.equalsIgnoreCase(methodValue.getValue().toString())) {
                     logger.info("Matching request found with URL: " + requestUrl + " and method: " + requestMethod);
-                    requestIds[0] = request.getRequestId();
-                    requestStartTimes[0] = System.currentTimeMillis();
-                    
-                    // Capture request payload
-                    try {
-                        Optional<String> payloadOptional = request.getRequest().getPostData();
-                        capturedPayloads[0] = payloadOptional.orElse("");
-                        logger.info("Captured payload: " + capturedPayloads[0]);
-                    } catch (Exception e) {
-                        logger.warn("Could not capture payload: " + e.getMessage());
-                        capturedPayloads[0] = "";
-                    }
-                    
-                    // Capture request headers from the request event and format them properly
-                    StringBuilder headersBuilder = new StringBuilder();
-                    logger.info("Capturing headers for request: " + request.getRequestId());
-                    logger.info("Headers map: " + request.getRequest().getHeaders());
-
-                    if (request.getRequest().getHeaders() != null && !request.getRequest().getHeaders().isEmpty()) {
-                        request.getRequest().getHeaders().forEach((key, value) -> {
-                            logger.info("Header - " + key + ": " + value);
-                            if (headersBuilder.length() > 0) {
-                                headersBuilder.append("\n");
-                            }
-                            headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
-                        });
-                    } else {
-                        logger.warn("No headers found in request. Trying alternative approach...");
-                        // Fallback: try to get headers from the request object directly
-                        if (request.getRequest().getUrl() != null) {
-                            headersBuilder.append(":method: ").append(request.getRequest().getMethod()).append("\n");
-                            headersBuilder.append(":path: ").append(request.getRequest().getUrl()).append("\n");
-                            headersBuilder.append(":scheme: https\n");
-                        }
-                    }
-
-                    capturedRequestHeaders[0] = headersBuilder.toString();
-                    logger.info("Captured headers string: " + capturedRequestHeaders[0]);
+                    Object postData = request.get("postData");
+                    String payload = postData == null ? "" : postData.toString();
+                    String requestHeaders = formatHeaders(request.get("headers"), requestMethod, requestUrl);
+                    pendingMatches.put(requestId, new Object[]{payload, requestHeaders, System.currentTimeMillis()});
+                } catch (Exception e) {
+                    logger.warn("Error while handling Network.requestWillBeSent: " + ExceptionUtils.getStackTrace(e));
                 }
             });
 
-            // Listener to intercept network responses
-            logger.info("Adding listener for network responses...");
-            devTool.addListener(Network.responseReceived(), response -> {
-                String responseUrl = response.getResponse().getUrl();
-                // logger.info("Intercepted response for URL: " + responseUrl);
-                
-                if (responseUrl.contains(urlVariable.getValue().toString()) &&
-                        requestIds[0] != null && requestIds[0].toString().equals(response.getRequestId().toString())) {
-                    logger.info("Matching response found for URL: " + responseUrl);
-                    
-                    // Get response data outside try block
-                    String responseBody = null;
-                    int status = response.getResponse().getStatus();
-                    
-                    logger.info("Response status: " + status);
-                    
-                    response.getResponse().getHeaders().forEach((key, value) -> {
-                        logger.info("Response Header - " + key + ": " + value);
-                    });
-                    
-                    // Try to get response body, but handle gracefully if not available
-                    try {
-                        responseBody = devTool.send(Network.getResponseBody(requestIds[0])).getBody();
-                        logger.info("Response body length: " + (responseBody != null ? responseBody.length() : 0));
-                    } catch (Exception e) {
-                        logger.warn("Could not retrieve response body: " + e.getMessage());
-                        responseBody = null;
+            session.onResponseReceived((seq, params) -> {
+                try {
+                    String requestId = String.valueOf(params.get("requestId"));
+                    Object[] pending = pendingMatches.remove(requestId);
+                    if (pending == null) return;
+
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> response = (Map<String, Object>) params.get("response");
+                    if (response == null) return;
+
+                    String responseUrl = String.valueOf(response.get("url"));
+                    int status = ((Number) response.get("status")).intValue();
+                    logger.info("Matching response found for URL: " + responseUrl + " status: " + status);
+
+                    String payload = (String) pending[0];
+                    String requestHeaders = (String) pending[1];
+                    long startTime = (Long) pending[2];
+                    long responseTime = System.currentTimeMillis() - startTime;
+
+                    Optional<String> responseBody = session.getResponseBody(requestId, cdpTimeout);
+                    logger.info("Response time: " + responseTime + "ms, body length: "
+                            + responseBody.map(String::length).orElse(0));
+
+                    if (requestHeaders.isEmpty() || status <= 0) {
+                        logger.warn("Skipping data storage - missing required data. Request headers present: "
+                                + !requestHeaders.isEmpty() + ", status: " + status);
+                        return;
                     }
-                    
-                    // Check if we have all required data before saving
-                    String requestHeaders = capturedRequestHeaders[0] != null ? capturedRequestHeaders[0] : "";
-                    String payload = capturedPayloads[0] != null ? capturedPayloads[0] : "";
-                    
-                    // Calculate response time
-                    long responseTime = 0;
-                    if (requestStartTimes[0] > 0) {
-                        responseTime = System.currentTimeMillis() - requestStartTimes[0];
-                        logger.info("Response time: " + responseTime + "ms");
-                    }
-                    
-                    if (requestHeaders != null && !requestHeaders.isEmpty() && status > 0) {
-                        logger.info("Storing network data...");
-                        logger.info("Request headers to store: " + requestHeaders);
-                        logger.info("Response body to store: " + (responseBody != null ? responseBody : "null"));
-                        logger.info("Payload to store: " + payload);
-                        logger.info("Response time to store: " + responseTime + "ms");
 
-                        // Create JsonObject and store all data together in one operation
-                        JsonObject allData = new JsonObject();
-                        allData.addProperty("statusCode", status);
-                        allData.addProperty("responseTime", responseTime);
-                        allData.addProperty("payload", payload);
+                    JsonObject allData = new JsonObject();
+                    allData.addProperty("statusCode", status);
+                    allData.addProperty("responseTime", responseTime);
 
-                        JsonArray headersArray = new JsonArray();
-                        headersArray.add(requestHeaders);
-                        allData.add("requestHeaders", headersArray);
+                    JsonArray payloadArray = new JsonArray();
+                    payloadArray.add(payload);
+                    allData.add("payload", payloadArray);
 
-                        JsonArray responseArray = new JsonArray();
-                        responseArray.add(responseBody != null ? responseBody : "");
-                        allData.add("responseBody", responseArray);
+                    JsonArray headersArray = new JsonArray();
+                    headersArray.add(requestHeaders);
+                    allData.add("requestHeaders", headersArray);
 
-                        // Save all data at once
-                        try {
-                            saveAllNetworkData(testCaseResult.getId(), allData, logger);
-                            logger.info("All network data stored together successfully.");
-                        } catch (Exception e) {
-                            logger.warn("Error while saving network data: " + ExceptionUtils.getStackTrace(e));
-                        }
-                    } else {
-                        logger.warn("Skipping data storage - missing required data:");
-                        logger.warn("Request headers: " + (requestHeaders != null ? "present" : "null"));
-                        logger.warn("Status code: " + status);
-                    }
+                    JsonArray responseArray = new JsonArray();
+                    responseArray.add(responseBody.orElse(""));
+                    allData.add("responseBody", responseArray);
+
+                    saveAllNetworkData(testCaseResult.getId(), allData, logger);
+                    logger.info("Network data stored successfully.");
+                } catch (Exception e) {
+                    logger.warn("Error while handling Network.responseReceived: " + ExceptionUtils.getStackTrace(e));
                 }
             });
+
+            logger.info("Raw CDP network listener attached.");
 
         } catch (Exception e) {
-            // Log the exception details and set the error message
             logger.warn("Exception occurred during execution: " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Exception occurred while adding Network Response Listener" +
                     " to the driver: " + e.getMessage());
@@ -221,5 +135,22 @@ public class StartTracking extends WebAction {
         }
         setSuccessMessage("Added Network Response Listener to the driver.");
         return Result.SUCCESS;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String formatHeaders(Object headersObj, String requestMethod, String requestUrl) {
+        StringBuilder headersBuilder = new StringBuilder();
+        if (headersObj instanceof Map) {
+            ((Map<String, Object>) headersObj).forEach((key, value) -> {
+                if (headersBuilder.length() > 0) headersBuilder.append("\n");
+                headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
+            });
+        }
+        if (headersBuilder.length() == 0) {
+            headersBuilder.append(":method: ").append(requestMethod).append("\n");
+            headersBuilder.append(":path: ").append(requestUrl).append("\n");
+            headersBuilder.append(":scheme: https\n");
+        }
+        return headersBuilder.toString();
     }
 }

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTrackingAndClickOnElement.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTrackingAndClickOnElement.java
@@ -2,6 +2,7 @@ package com.testsigma.addons.web;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.testsigma.addons.web.utilities.RawCdpNetworkSession;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -12,15 +13,14 @@ import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.network.model.RequestId;
-import org.openqa.selenium.remote.Augmenter;
 
+import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.testsigma.addons.web.utilities.ResponseDataUtilities.saveAllNetworkData;
+import static com.testsigma.addons.web.utilities.ResponseDataUtilities.savePayloadData;
 
 @Data
 @Action(actionText = "Add Network Listener for url url_variable and method method_value then perform element click element-locator",
@@ -42,186 +42,105 @@ public class StartTrackingAndClickOnElement extends WebAction {
 
     @Override
     public Result execute() {
-
-        logger.info("Started execution for action: StartTracking");
+        logger.info("Started execution for action: StartTrackingAndClickOnElement");
         try {
-            // Enhance the driver to support DevTools
-            logger.info("Augmenting driver to support DevTools...");
-            driver = new Augmenter().augment(driver);
+            String urlPattern = urlVariable.getValue().toString();
+            String method = methodValue.getValue().toString();
+            Duration cdpTimeout = Duration.ofSeconds(10);
+            logger.info("Tracking requests where url contains \"" + urlPattern + "\" and method = " + method);
+            logger.info("driver class: " + driver.getClass().getName());
 
-            // Initialize DevTools and create a session
-            logger.info("Initializing DevTools...");
-            DevTools devTool;
+            RawCdpNetworkSession session = RawCdpNetworkSession.attach(driver, logger, cdpTimeout);
 
-            // Try to get DevTools from the driver
-            if (driver instanceof HasDevTools) {
-                devTool = ((HasDevTools) driver).getDevTools();
-                devTool.createSessionIfThereIsNotOne();
-                logger.info("DevTools session successfully created.");
-            } else {
-                logger.warn("DevTools not supported by this driver. Using alternative network logging approach.");
-                // For drivers that don't support DevTools, we'll use browser logs
+            // Only the first matching request is captured; subsequent matches are ignored.
+            AtomicBoolean captured = new AtomicBoolean(false);
+            String[] capturedRequestId = new String[1];
+            String[] capturedRequestHeaders = new String[1];
+            long[] requestStartTime = new long[1];
+
+            session.onRequestWillBeSent((seq, params) -> {
                 try {
-                    // Enable browser logging
-                    logger.info("Enabling browser performance logging...");
-                    // This is a fallback approach - the main DevTools approach should work
-                    logger.info("DevTools approach failed, but action completed successfully.");
-                    return Result.SUCCESS;
+                    if (captured.get()) return;
+
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> request = (Map<String, Object>) params.get("request");
+                    if (request == null) return;
+
+                    String requestUrl = String.valueOf(request.get("url"));
+                    String requestMethod = String.valueOf(request.get("method"));
+                    if (!requestUrl.contains(urlPattern) || !requestMethod.equalsIgnoreCase(method)) {
+                        return;
+                    }
+                    if (!captured.compareAndSet(false, true)) return;
+
+                    String requestId = String.valueOf(params.get("requestId"));
+                    capturedRequestId[0] = requestId;
+                    requestStartTime[0] = System.currentTimeMillis();
+                    capturedRequestHeaders[0] = formatHeaders(request.get("headers"), requestMethod, requestUrl);
+                    logger.info("Matching request captured: " + requestUrl + " id: " + requestId);
+
+                    Object postData = request.get("postData");
+                    String payload = postData == null ? "" : postData.toString();
+                    if (!payload.isEmpty()) {
+                        savePayloadData(testCaseResult.getId(), payload, logger);
+                    }
                 } catch (Exception e) {
-                    logger.warn("Fallback approach also failed: " + e.getMessage());
-                    return Result.SUCCESS;
-                }
-            }
-
-            // Enable network interception with high buffer size
-            logger.info("Enabling network interception...");
-            try {
-                devTool.send(Network.enable(Optional.empty(),
-                        Optional.empty(), Optional.of(100000000)));
-                logger.info("Network interception enabled successfully.");
-            } catch (Exception e) {
-                logger.warn("Failed to enable network interception: " + e.getMessage());
-                return Result.SUCCESS;
-            }
-
-            final RequestId[] requestIds = new RequestId[1];
-            final String[] capturedRequestHeaders = new String[1];
-            final String[] capturedPayloads = new String[1];
-            final long[] requestStartTimes = new long[1];
-
-            // Listener to intercept network requests
-            logger.info("Adding listener for network requests...");
-            devTool.addListener(Network.requestWillBeSent(), request -> {
-                String requestUrl = request.getRequest().getUrl();
-                String requestMethod = request.getRequest().getMethod();
-                // request url should contain the url_variable value
-                if (requestUrl.contains(urlVariable.getValue().toString()) &&
-                        requestMethod.equalsIgnoreCase(methodValue.getValue().toString())) {
-                    logger.info("Matching request found with URL: " + requestUrl + " and method: " + requestMethod);
-                    requestIds[0] = request.getRequestId();
-                    requestStartTimes[0] = System.currentTimeMillis();
-
-                    // Capture request payload
-                    try {
-                        Optional<String> payloadOptional = request.getRequest().getPostData();
-                        capturedPayloads[0] = payloadOptional.orElse("");
-                        logger.info("Captured payload: " + capturedPayloads[0]);
-                    } catch (Exception e) {
-                        logger.warn("Could not capture payload: " + e.getMessage());
-                        capturedPayloads[0] = "";
-                    }
-
-                    // Capture request headers from the request event and format them properly
-                    StringBuilder headersBuilder = new StringBuilder();
-                    logger.info("Capturing headers for request: " + request.getRequestId());
-                    logger.info("Headers map: " + request.getRequest().getHeaders());
-
-                    if (request.getRequest().getHeaders() != null && !request.getRequest().getHeaders().isEmpty()) {
-                        request.getRequest().getHeaders().forEach((key, value) -> {
-                            logger.info("Header - " + key + ": " + value);
-                            if (headersBuilder.length() > 0) {
-                                headersBuilder.append("\n");
-                            }
-                            headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
-                        });
-                    } else {
-                        logger.warn("No headers found in request. Trying alternative approach...");
-                        // Fallback: try to get headers from the request object directly
-                        if (request.getRequest().getUrl() != null) {
-                            headersBuilder.append(":method: ").append(request.getRequest().getMethod()).append("\n");
-                            headersBuilder.append(":path: ").append(request.getRequest().getUrl()).append("\n");
-                            headersBuilder.append(":scheme: https\n");
-                        }
-                    }
-
-                    capturedRequestHeaders[0] = headersBuilder.toString();
-                    logger.info("Captured headers string: " + capturedRequestHeaders[0]);
+                    logger.warn("Error while handling Network.requestWillBeSent: " + ExceptionUtils.getStackTrace(e));
                 }
             });
 
-            // Listener to intercept network responses
-            logger.info("Adding listener for network responses...");
-            devTool.addListener(Network.responseReceived(), response -> {
-                String responseUrl = response.getResponse().getUrl();
-                // logger.info("Intercepted response for URL: " + responseUrl);
+            session.onResponseReceived((seq, params) -> {
+                try {
+                    String requestId = String.valueOf(params.get("requestId"));
+                    if (capturedRequestId[0] == null || !capturedRequestId[0].equals(requestId)) return;
 
-                if (responseUrl.contains(urlVariable.getValue().toString()) &&
-                        requestIds[0] != null && requestIds[0].toString().equals(response.getRequestId().toString())) {
-                    logger.info("Matching response found for URL: " + responseUrl);
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> response = (Map<String, Object>) params.get("response");
+                    if (response == null) return;
 
-                    // Get response data outside try block
-                    String responseBody = null;
-                    int status = response.getResponse().getStatus();
+                    String responseUrl = String.valueOf(response.get("url"));
+                    int status = ((Number) response.get("status")).intValue();
+                    logger.info("Matching response for URL: " + responseUrl + " status: " + status);
 
-                    logger.info("Response status: " + status);
-
-                    response.getResponse().getHeaders().forEach((key, value) -> {
-                        logger.info("Response Header - " + key + ": " + value);
-                    });
-
-                    // Try to get response body, but handle gracefully if not available
-                    try {
-                        responseBody = devTool.send(Network.getResponseBody(requestIds[0])).getBody();
-                        logger.info("Response body length: " + (responseBody != null ? responseBody.length() : 0));
-                    } catch (Exception e) {
-                        logger.warn("Could not retrieve response body: " + e.getMessage());
-                        responseBody = null;
-                    }
-
-                    // Check if we have all required data before saving
                     String requestHeaders = capturedRequestHeaders[0] != null ? capturedRequestHeaders[0] : "";
-                    String payload = capturedPayloads[0] != null ? capturedPayloads[0] : "";
+                    long responseTime = requestStartTime[0] > 0 ? System.currentTimeMillis() - requestStartTime[0] : 0;
+                    logger.info("Response time: " + responseTime + "ms");
 
-                    // Calculate response time
-                    long responseTime = 0;
-                    if (requestStartTimes[0] > 0) {
-                        responseTime = System.currentTimeMillis() - requestStartTimes[0];
-                        logger.info("Response time: " + responseTime + "ms");
+                    if (requestHeaders.isEmpty() || status <= 0) {
+                        logger.warn("Skipping storage - headers empty: " + requestHeaders.isEmpty() + ", status: " + status);
+                        return;
                     }
 
-                    if (requestHeaders != null && !requestHeaders.isEmpty() && status > 0) {
-                        logger.info("Storing network data...");
-                        logger.info("Request headers to store: " + requestHeaders);
-                        logger.info("Response body to store: " + (responseBody != null ? responseBody : "null"));
-                        logger.info("Payload to store: " + payload);
-                        logger.info("Response time to store: " + responseTime + "ms");
+                    Optional<String> responseBody = session.getResponseBody(requestId, cdpTimeout);
+                    logger.info("Response body length: " + responseBody.map(String::length).orElse(0));
 
-                        // Create JsonObject and store all data together in one operation
-                        JsonObject allData = new JsonObject();
-                        allData.addProperty("statusCode", status);
-                        allData.addProperty("responseTime", responseTime);
-                        allData.addProperty("payload", payload);
+                    JsonObject allData = new JsonObject();
+                    allData.addProperty("statusCode", status);
+                    allData.addProperty("responseTime", responseTime);
 
-                        JsonArray headersArray = new JsonArray();
-                        headersArray.add(requestHeaders);
-                        allData.add("requestHeaders", headersArray);
+                    JsonArray headersArray = new JsonArray();
+                    headersArray.add(requestHeaders);
+                    allData.add("requestHeaders", headersArray);
 
-                        JsonArray responseArray = new JsonArray();
-                        responseArray.add(responseBody != null ? responseBody : "");
-                        allData.add("responseBody", responseArray);
+                    JsonArray responseArray = new JsonArray();
+                    responseArray.add(responseBody.orElse(""));
+                    allData.add("responseBody", responseArray);
 
-                        // Save all data at once
-                        try {
-                            saveAllNetworkData(testCaseResult.getId(), allData, logger);
-                            logger.info("All network data stored together successfully.");
-                        } catch (Exception e) {
-                            logger.warn("Error while saving network data: " + ExceptionUtils.getStackTrace(e));
-                        }
-                    } else {
-                        logger.warn("Skipping data storage - missing required data:");
-                        logger.warn("Request headers: " + (requestHeaders != null ? "present" : "null"));
-                        logger.warn("Status code: " + status);
-                    }
+                    saveAllNetworkData(testCaseResult.getId(), allData, logger);
+                    logger.info("Network data stored successfully.");
+                } catch (Exception e) {
+                    logger.warn("Error while handling Network.responseReceived: " + ExceptionUtils.getStackTrace(e));
                 }
             });
 
-            WebElement element1 = element.getElement();
-            element1.click();
+            logger.info("Raw CDP network listener attached.");
+
+            WebElement webElement = element.getElement();
+            webElement.click();
             logger.info("Clicked on element successfully");
             Thread.sleep(15000);
 
         } catch (Exception e) {
-            // Log the exception details and set the error message
             logger.warn("Exception occurred during execution: " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Exception occurred while adding Network Response Listener" +
                     " to the driver: " + e.getMessage());
@@ -229,5 +148,22 @@ public class StartTrackingAndClickOnElement extends WebAction {
         }
         setSuccessMessage("Added Network Response Listener to the driver.");
         return Result.SUCCESS;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String formatHeaders(Object headersObj, String requestMethod, String requestUrl) {
+        StringBuilder headersBuilder = new StringBuilder();
+        if (headersObj instanceof Map) {
+            ((Map<String, Object>) headersObj).forEach((key, value) -> {
+                if (headersBuilder.length() > 0) headersBuilder.append("\n");
+                headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
+            });
+        }
+        if (headersBuilder.length() == 0) {
+            headersBuilder.append(":method: ").append(requestMethod).append("\n");
+            headersBuilder.append(":path: ").append(requestUrl).append("\n");
+            headersBuilder.append(":scheme: https\n");
+        }
+        return headersBuilder.toString();
     }
 }

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTrackingAndNavigateToUrl.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/StartTrackingAndNavigateToUrl.java
@@ -2,6 +2,7 @@ package com.testsigma.addons.web;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.testsigma.addons.web.utilities.RawCdpNetworkSession;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
@@ -10,13 +11,11 @@ import com.testsigma.sdk.annotation.TestCaseResult;
 import com.testsigma.sdk.annotation.TestData;
 import lombok.Data;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.network.model.RequestId;
-import org.openqa.selenium.remote.Augmenter;
 
+import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.testsigma.addons.web.utilities.ResponseDataUtilities.saveAllNetworkData;
 
@@ -40,185 +39,101 @@ public class StartTrackingAndNavigateToUrl extends WebAction {
 
     @Override
     public Result execute() {
-
-        logger.info("Started execution for action: StartTracking");
+        logger.info("Started execution for action: StartTrackingAndNavigateToUrl");
         try {
-            // Enhance the driver to support DevTools
-            logger.info("Augmenting driver to support DevTools...");
-            driver = new Augmenter().augment(driver);
+            String urlPattern = urlVariable.getValue().toString();
+            String method = methodValue.getValue().toString();
+            Duration cdpTimeout = Duration.ofSeconds(10);
+            logger.info("Tracking requests where url contains \"" + urlPattern + "\" and method = " + method);
+            logger.info("driver class: " + driver.getClass().getName());
 
-            // Initialize DevTools and create a session
-            logger.info("Initializing DevTools...");
-            DevTools devTool;
+            RawCdpNetworkSession session = RawCdpNetworkSession.attach(driver, logger, cdpTimeout);
 
-            // Try to get DevTools from the driver
-            if (driver instanceof HasDevTools) {
-                devTool = ((HasDevTools) driver).getDevTools();
-                devTool.createSessionIfThereIsNotOne();
-                logger.info("DevTools session successfully created.");
-            } else {
-                logger.warn("DevTools not supported by this driver. Using alternative network logging approach.");
-                // For drivers that don't support DevTools, we'll use browser logs
+            // requestId -> {payload, requestHeaders string, start time} for requests matching the filter, until their response arrives
+            Map<String, Object[]> pendingMatches = new ConcurrentHashMap<>();
+
+            session.onRequestWillBeSent((seq, params) -> {
                 try {
-                    // Enable browser logging
-                    logger.info("Enabling browser performance logging...");
-                    // This is a fallback approach - the main DevTools approach should work
-                    logger.info("DevTools approach failed, but action completed successfully.");
-                    return Result.SUCCESS;
-                } catch (Exception e) {
-                    logger.warn("Fallback approach also failed: " + e.getMessage());
-                    return Result.SUCCESS;
-                }
-            }
+                    String requestId = String.valueOf(params.get("requestId"));
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> request = (Map<String, Object>) params.get("request");
+                    if (request == null) return;
 
-            // Enable network interception with high buffer size
-            logger.info("Enabling network interception...");
-            try {
-                devTool.send(Network.enable(Optional.empty(),
-                        Optional.empty(), Optional.of(100000000)));
-                logger.info("Network interception enabled successfully.");
-            } catch (Exception e) {
-                logger.warn("Failed to enable network interception: " + e.getMessage());
-                return Result.SUCCESS;
-            }
+                    String requestUrl = String.valueOf(request.get("url"));
+                    String requestMethod = String.valueOf(request.get("method"));
+                    if (!requestUrl.contains(urlPattern) || !requestMethod.equalsIgnoreCase(method)) {
+                        return;
+                    }
 
-            final RequestId[] requestIds = new RequestId[1];
-            final String[] capturedRequestHeaders = new String[1];
-            final String[] capturedPayloads = new String[1];
-            final long[] requestStartTimes = new long[1];
-
-            // Listener to intercept network requests
-            logger.info("Adding listener for network requests...");
-            devTool.addListener(Network.requestWillBeSent(), request -> {
-                String requestUrl = request.getRequest().getUrl();
-                String requestMethod = request.getRequest().getMethod();
-                // request url should contain the url_variable value
-                if (requestUrl.contains(urlVariable.getValue().toString()) &&
-                        requestMethod.equalsIgnoreCase(methodValue.getValue().toString())) {
                     logger.info("Matching request found with URL: " + requestUrl + " and method: " + requestMethod);
-                    requestIds[0] = request.getRequestId();
-                    requestStartTimes[0] = System.currentTimeMillis();
-
-                    // Capture request payload
-                    try {
-                        Optional<String> payloadOptional = request.getRequest().getPostData();
-                        capturedPayloads[0] = payloadOptional.orElse("");
-                        logger.info("Captured payload: " + capturedPayloads[0]);
-                    } catch (Exception e) {
-                        logger.warn("Could not capture payload: " + e.getMessage());
-                        capturedPayloads[0] = "";
-                    }
-
-                    // Capture request headers from the request event and format them properly
-                    StringBuilder headersBuilder = new StringBuilder();
-                    logger.info("Capturing headers for request: " + request.getRequestId());
-                    logger.info("Headers map: " + request.getRequest().getHeaders());
-
-                    if (request.getRequest().getHeaders() != null && !request.getRequest().getHeaders().isEmpty()) {
-                        request.getRequest().getHeaders().forEach((key, value) -> {
-                            logger.info("Header - " + key + ": " + value);
-                            if (headersBuilder.length() > 0) {
-                                headersBuilder.append("\n");
-                            }
-                            headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
-                        });
-                    } else {
-                        logger.warn("No headers found in request. Trying alternative approach...");
-                        // Fallback: try to get headers from the request object directly
-                        if (request.getRequest().getUrl() != null) {
-                            headersBuilder.append(":method: ").append(request.getRequest().getMethod()).append("\n");
-                            headersBuilder.append(":path: ").append(request.getRequest().getUrl()).append("\n");
-                            headersBuilder.append(":scheme: https\n");
-                        }
-                    }
-
-                    capturedRequestHeaders[0] = headersBuilder.toString();
-                    logger.info("Captured headers string: " + capturedRequestHeaders[0]);
+                    Object postData = request.get("postData");
+                    String payload = postData == null ? "" : postData.toString();
+                    String requestHeaders = formatHeaders(request.get("headers"), requestMethod, requestUrl);
+                    pendingMatches.put(requestId, new Object[]{payload, requestHeaders, System.currentTimeMillis()});
+                } catch (Exception e) {
+                    logger.warn("Error while handling Network.requestWillBeSent: " + ExceptionUtils.getStackTrace(e));
                 }
             });
 
-            // Listener to intercept network responses
-            logger.info("Adding listener for network responses...");
-            devTool.addListener(Network.responseReceived(), response -> {
-                String responseUrl = response.getResponse().getUrl();
-                // logger.info("Intercepted response for URL: " + responseUrl);
+            session.onResponseReceived((seq, params) -> {
+                try {
+                    String requestId = String.valueOf(params.get("requestId"));
+                    Object[] pending = pendingMatches.remove(requestId);
+                    if (pending == null) return;
 
-                if (responseUrl.contains(urlVariable.getValue().toString()) &&
-                        requestIds[0] != null && requestIds[0].toString().equals(response.getRequestId().toString())) {
-                    logger.info("Matching response found for URL: " + responseUrl);
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> response = (Map<String, Object>) params.get("response");
+                    if (response == null) return;
 
-                    // Get response data outside try block
-                    String responseBody = null;
-                    int status = response.getResponse().getStatus();
+                    String responseUrl = String.valueOf(response.get("url"));
+                    int status = ((Number) response.get("status")).intValue();
+                    logger.info("Matching response found for URL: " + responseUrl + " status: " + status);
 
-                    logger.info("Response status: " + status);
+                    String payload = (String) pending[0];
+                    String requestHeaders = (String) pending[1];
+                    long startTime = (Long) pending[2];
+                    long responseTime = System.currentTimeMillis() - startTime;
 
-                    response.getResponse().getHeaders().forEach((key, value) -> {
-                        logger.info("Response Header - " + key + ": " + value);
-                    });
+                    Optional<String> responseBody = session.getResponseBody(requestId, cdpTimeout);
+                    logger.info("Response time: " + responseTime + "ms, body length: "
+                            + responseBody.map(String::length).orElse(0));
 
-                    // Try to get response body, but handle gracefully if not available
-                    try {
-                        responseBody = devTool.send(Network.getResponseBody(requestIds[0])).getBody();
-                        logger.info("Response body length: " + (responseBody != null ? responseBody.length() : 0));
-                    } catch (Exception e) {
-                        logger.warn("Could not retrieve response body: " + e.getMessage());
-                        responseBody = null;
+                    if (requestHeaders.isEmpty() || status <= 0) {
+                        logger.warn("Skipping data storage - missing required data. Request headers present: "
+                                + !requestHeaders.isEmpty() + ", status: " + status);
+                        return;
                     }
 
-                    // Check if we have all required data before saving
-                    String requestHeaders = capturedRequestHeaders[0] != null ? capturedRequestHeaders[0] : "";
-                    String payload = capturedPayloads[0] != null ? capturedPayloads[0] : "";
+                    JsonObject allData = new JsonObject();
+                    allData.addProperty("statusCode", status);
+                    allData.addProperty("responseTime", responseTime);
 
-                    // Calculate response time
-                    long responseTime = 0;
-                    if (requestStartTimes[0] > 0) {
-                        responseTime = System.currentTimeMillis() - requestStartTimes[0];
-                        logger.info("Response time: " + responseTime + "ms");
-                    }
+                    JsonArray payloadArray = new JsonArray();
+                    payloadArray.add(payload);
+                    allData.add("payload", payloadArray);
 
-                    if (requestHeaders != null && !requestHeaders.isEmpty() && status > 0) {
-                        logger.info("Storing network data...");
-                        logger.info("Request headers to store: " + requestHeaders);
-                        logger.info("Response body to store: " + (responseBody != null ? responseBody : "null"));
-                        logger.info("Payload to store: " + payload);
-                        logger.info("Response time to store: " + responseTime + "ms");
+                    JsonArray headersArray = new JsonArray();
+                    headersArray.add(requestHeaders);
+                    allData.add("requestHeaders", headersArray);
 
-                        // Create JsonObject and store all data together in one operation
-                        JsonObject allData = new JsonObject();
-                        allData.addProperty("statusCode", status);
-                        allData.addProperty("responseTime", responseTime);
-                        allData.addProperty("payload", payload);
+                    JsonArray responseArray = new JsonArray();
+                    responseArray.add(responseBody.orElse(""));
+                    allData.add("responseBody", responseArray);
 
-                        JsonArray headersArray = new JsonArray();
-                        headersArray.add(requestHeaders);
-                        allData.add("requestHeaders", headersArray);
-
-                        JsonArray responseArray = new JsonArray();
-                        responseArray.add(responseBody != null ? responseBody : "");
-                        allData.add("responseBody", responseArray);
-
-                        // Save all data at once
-                        try {
-                            saveAllNetworkData(testCaseResult.getId(), allData, logger);
-                            logger.info("All network data stored together successfully.");
-                        } catch (Exception e) {
-                            logger.warn("Error while saving network data: " + ExceptionUtils.getStackTrace(e));
-                        }
-                    } else {
-                        logger.warn("Skipping data storage - missing required data:");
-                        logger.warn("Request headers: " + (requestHeaders != null ? "present" : "null"));
-                        logger.warn("Status code: " + status);
-                    }
+                    saveAllNetworkData(testCaseResult.getId(), allData, logger);
+                    logger.info("Network data stored successfully.");
+                } catch (Exception e) {
+                    logger.warn("Error while handling Network.responseReceived: " + ExceptionUtils.getStackTrace(e));
                 }
             });
+
+            logger.info("Raw CDP network listener attached.");
 
             driver.navigate().to(navigateUrl.getValue().toString());
             logger.info("Navigated to URL '" + navigateUrl.getValue().toString() + "' successfully");
             Thread.sleep(15000);
 
         } catch (Exception e) {
-            // Log the exception details and set the error message
             logger.warn("Exception occurred during execution: " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Exception occurred while adding Network Response Listener" +
                     " to the driver: " + e.getMessage());
@@ -226,5 +141,22 @@ public class StartTrackingAndNavigateToUrl extends WebAction {
         }
         setSuccessMessage("Added Network Response Listener to the driver.");
         return Result.SUCCESS;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String formatHeaders(Object headersObj, String requestMethod, String requestUrl) {
+        StringBuilder headersBuilder = new StringBuilder();
+        if (headersObj instanceof Map) {
+            ((Map<String, Object>) headersObj).forEach((key, value) -> {
+                if (headersBuilder.length() > 0) headersBuilder.append("\n");
+                headersBuilder.append(key).append(": ").append(value != null ? value.toString() : "");
+            });
+        }
+        if (headersBuilder.length() == 0) {
+            headersBuilder.append(":method: ").append(requestMethod).append("\n");
+            headersBuilder.append(":path: ").append(requestUrl).append("\n");
+            headersBuilder.append(":scheme: https\n");
+        }
+        return headersBuilder.toString();
     }
 }

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/FileUtilities.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/FileUtilities.java
@@ -26,6 +26,36 @@ public class FileUtilities {
         }
     }
 
+    private static String getPayloadFileName(Long runId) {
+        return folderPath + "/" + runId + "_payload";
+    }
+
+    public static void writePayloadToFile(Long runId, String payload) throws Exception {
+        String fileName = getPayloadFileName(runId);
+        File file = new File(fileName);
+        try {
+            File parentDir = file.getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                if (!parentDir.mkdirs()) {
+                    throw new IOException("Failed to create directory: " + parentDir);
+                }
+            }
+            FileUtils.writeStringToFile(file, payload, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new Exception(e);
+        }
+    }
+
+    public static String readPayloadFromFile(Long runId) {
+        String fileName = getPayloadFileName(runId);
+        File file = new File(fileName);
+        try {
+            return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
     public static void writeToFile(Long runId, String content) throws Exception {
         String fileName = getFileName(runId);
         File file = new File(fileName);

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/RawCdpNetworkSession.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/RawCdpNetworkSession.java
@@ -1,0 +1,216 @@
+package com.testsigma.addons.web.utilities;
+
+import com.testsigma.sdk.Logger;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.devtools.CdpEndpointFinder;
+import org.openqa.selenium.devtools.Command;
+import org.openqa.selenium.devtools.Connection;
+import org.openqa.selenium.devtools.Event;
+import org.openqa.selenium.devtools.SeleniumCdpConnection;
+import org.openqa.selenium.devtools.idealized.target.model.SessionID;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+/**
+ * Talks Network.* CDP directly over the raw JSON-RPC connection Selenium already establishes
+ * (local ChromeDriver or grid-proxied — SeleniumCdpConnection handles both), bypassing
+ * DevTools.createSession()/CdpVersionFinder entirely. That version-matching layer is what fails
+ * with "no-op implementation of the CDP" whenever the shared Selenium install's bundled
+ * devtools-vNNN jars don't cover the live browser's major version — a gap outside this addon's
+ * control, since that install lives in the host agent, not this addon's own classpath. The
+ * Target.attachToTarget + Network.* wire format below is plain CDP JSON and has been stable
+ * across Chrome versions for years, so it isn't tied to any bundled binding at all.
+ */
+public class RawCdpNetworkSession implements AutoCloseable {
+
+    private final Connection connection;
+    private final SessionID sessionId;
+    private final Logger logger;
+
+    private RawCdpNetworkSession(Connection connection, SessionID sessionId, Logger logger) {
+        this.connection = connection;
+        this.sessionId = sessionId;
+        this.logger = logger;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static RawCdpNetworkSession attach(WebDriver driver, Logger logger, Duration timeout) throws Exception {
+        org.openqa.selenium.Capabilities capabilities = null;
+        if (driver instanceof org.openqa.selenium.HasCapabilities) {
+            capabilities = ((org.openqa.selenium.HasCapabilities) driver).getCapabilities();
+        } else {
+            logger.info("[raw-cdp] driver does not implement HasCapabilities: " + driver.getClass().getName());
+        }
+
+        if (isSauceLabs(capabilities)) {
+            logger.warn("[raw-cdp] Detected an unsupported test lab environment for CDP-based network capture.");
+            throw new UnsupportedOperationException(
+                    "Network capture is not currently supported in this test lab environment.");
+        }
+
+        try {
+            if (capabilities != null) {
+                Optional<java.net.URI> reportedUri = CdpEndpointFinder.getReportedUri(capabilities);
+                logger.info("[raw-cdp] driver capabilities reported CDP endpoint: " + reportedUri);
+            }
+        } catch (Exception e) {
+            logger.info("[raw-cdp] could not read reported CDP endpoint from capabilities: " + e.getMessage());
+        }
+
+        logger.info("[raw-cdp] calling SeleniumCdpConnection.create(driver)...");
+        Optional<Connection> connectionOpt = SeleniumCdpConnection.create(driver);
+        logger.info("[raw-cdp] SeleniumCdpConnection.create returned present=" + connectionOpt.isPresent());
+        Connection connection = connectionOpt.orElseThrow(() -> new IllegalStateException(
+                "Could not establish a raw CDP connection (no CDP endpoint reported for this driver)."));
+
+        String targetId;
+        try {
+            targetId = driver.getWindowHandle();
+        } catch (Exception e) {
+            logger.warn("[raw-cdp] driver.getWindowHandle() failed: " + e.getMessage());
+            throw e;
+        }
+        logger.info("[raw-cdp] driver.getWindowHandle() (used as CDP targetId): " + targetId);
+
+        logger.info("[raw-cdp] sending Target.attachToTarget with targetId=" + targetId + ", flatten=true, timeout=" + timeout);
+        Map<String, Object> attachResult;
+        try {
+            attachResult = connection.sendAndWait(
+                    new SessionID(""),
+                    new Command<>("Target.attachToTarget", Map.of("targetId", targetId, "flatten", true), Map.class),
+                    timeout);
+        } catch (Exception e) {
+            logger.warn("[raw-cdp] Target.attachToTarget threw: " + e);
+            throw e;
+        }
+        logger.info("[raw-cdp] Target.attachToTarget raw result: " + attachResult);
+
+        Object rawSessionId = attachResult == null ? null : attachResult.get("sessionId");
+        if (rawSessionId == null) {
+            throw new IllegalStateException("Target.attachToTarget did not return a sessionId: " + attachResult);
+        }
+        logger.info("[raw-cdp] attached, sessionId: " + rawSessionId);
+
+        RawCdpNetworkSession session = new RawCdpNetworkSession(connection, new SessionID(rawSessionId.toString()), logger);
+        session.enableNetwork(timeout);
+        return session;
+    }
+
+    /**
+     * Sauce Labs relays a session's CDP endpoint through its own tunnel/proxy, which does not
+     * expose a usable raw CDP connection for SeleniumCdpConnection to attach to (see
+     * sauce-cdp-check's standalone reproduction) - so fail fast with a clear message instead of
+     * letting the attach hang or fail later with an opaque error.
+     *
+     * Sauce Labs sessions don't reliably echo back a top-level "sauce:options"-style capability
+     * key, so a shallow key scan misses them. The one marker observed consistently in practice is
+     * buried in a nested value instead - e.g. chrome.userDataDir being under
+     * "C:\Users\sauce\AppData\..." - so this scans the whole capabilities structure (keys and
+     * values, recursing into nested maps/lists) for a "sauce" substring rather than just top-level keys.
+     */
+    private static boolean isSauceLabs(org.openqa.selenium.Capabilities capabilities) {
+        if (capabilities == null) {
+            return false;
+        }
+        return containsSauceMarker(capabilities.asMap());
+    }
+
+    private static boolean containsSauceMarker(Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Map) {
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                if (containsSauceMarker(entry.getKey()) || containsSauceMarker(entry.getValue())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (value instanceof Iterable) {
+            for (Object item : (Iterable<?>) value) {
+                if (containsSauceMarker(item)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return value.toString().toLowerCase().contains("sauce");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void enableNetwork(Duration timeout) {
+        logger.info("[raw-cdp] sending Network.enable for sessionId=" + sessionId);
+        try {
+            Map<String, Object> result = connection.sendAndWait(sessionId, new Command<>("Network.enable", Map.of(), Map.class), timeout);
+            logger.info("[raw-cdp] Network.enable raw result: " + result);
+        } catch (Exception e) {
+            logger.warn("[raw-cdp] Network.enable threw: " + e);
+            throw e;
+        }
+    }
+
+    /** requestWillBeSent params: requestId, request:{url, method, headers, postData?}, timestamp */
+    @SuppressWarnings("unchecked")
+    public void onRequestWillBeSent(BiConsumer<Long, Map<String, Object>> handler) {
+        logger.info("[raw-cdp] registering listener for Network.requestWillBeSent");
+        connection.addListener(new Event<>("Network.requestWillBeSent", input -> (Map<String, Object>) input.read(Map.class)), (seq, params) -> {
+            try {
+                Map<String, Object> request = (Map<String, Object>) params.get("request");
+                logger.info("[raw-cdp] Network.requestWillBeSent seq=" + seq + " requestId=" + params.get("requestId")
+                        + " url=" + (request == null ? null : request.get("url"))
+                        + " method=" + (request == null ? null : request.get("method")));
+            } catch (Exception e) {
+                logger.warn("[raw-cdp] failed to log requestWillBeSent event: " + e);
+            }
+            handler.accept(seq, params);
+        });
+    }
+
+    /** responseReceived params: requestId, response:{url, status, headers}, timestamp */
+    @SuppressWarnings("unchecked")
+    public void onResponseReceived(BiConsumer<Long, Map<String, Object>> handler) {
+        logger.info("[raw-cdp] registering listener for Network.responseReceived");
+        connection.addListener(new Event<>("Network.responseReceived", input -> (Map<String, Object>) input.read(Map.class)), (seq, params) -> {
+            try {
+                Map<String, Object> response = (Map<String, Object>) params.get("response");
+                logger.info("[raw-cdp] Network.responseReceived seq=" + seq + " requestId=" + params.get("requestId")
+                        + " url=" + (response == null ? null : response.get("url"))
+                        + " status=" + (response == null ? null : response.get("status")));
+            } catch (Exception e) {
+                logger.warn("[raw-cdp] failed to log responseReceived event: " + e);
+            }
+            handler.accept(seq, params);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    public Optional<String> getResponseBody(String requestId, Duration timeout) {
+        logger.info("[raw-cdp] sending Network.getResponseBody for requestId=" + requestId);
+        try {
+            Map<String, Object> result = connection.sendAndWait(
+                    sessionId,
+                    new Command<>("Network.getResponseBody", Map.of("requestId", requestId), Map.class),
+                    timeout);
+            logger.info("[raw-cdp] Network.getResponseBody raw result keys: " + (result == null ? null : result.keySet()));
+            Object body = result == null ? null : result.get("body");
+            return Optional.ofNullable(body == null ? null : body.toString());
+        } catch (Exception e) {
+            logger.warn("[raw-cdp] Network.getResponseBody threw for requestId=" + requestId + ": " + e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void close() {
+        logger.info("[raw-cdp] closing connection");
+        try {
+            connection.close();
+        } catch (Exception e) {
+            logger.warn("[raw-cdp] error closing connection: " + e);
+        }
+    }
+}

--- a/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/ResponseDataUtilities.java
+++ b/store_network_logs_data/src/main/java/com/testsigma/addons/web/utilities/ResponseDataUtilities.java
@@ -2,6 +2,7 @@ package com.testsigma.addons.web.utilities;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.testsigma.sdk.Logger;
@@ -24,7 +25,7 @@ public class ResponseDataUtilities {
             throw new Exception(e);
         }
     }
-    
+
 
     private static JsonArray getResponseBodyData(Long runId, Logger logger) throws Exception {
         logger.info("Getting all data for runId: " + runId);
@@ -42,7 +43,7 @@ public class ResponseDataUtilities {
                 return data.getAsJsonArray("responseBody");
             }
         } catch (JsonParseException e) {
-            
+
             logger.info("Failed to parse data for runId: " + runId + " with exception: " + e.getMessage());
             throw new Exception(e);
         }
@@ -61,7 +62,7 @@ public class ResponseDataUtilities {
 
     public static String getResponseBody(Long runId, Logger logger) throws Exception {
         String responseBody = getResponseBodyData(runId, logger).getAsString();
-        
+
         return responseBody;
     }
 
@@ -84,7 +85,7 @@ public class ResponseDataUtilities {
                 logger.info("No request headers data found for runId: " + runId);
             }
         } catch (JsonParseException e) {
-            
+
             logger.info("Failed to parse request headers data for runId: " + runId + " with exception: " + e.getMessage());
             throw new Exception(e);
         }
@@ -128,9 +129,20 @@ public class ResponseDataUtilities {
         saveAllData(runId, allData, logger);
     }
 
+    public static void savePayloadData(Long runId, String payload, Logger logger) throws Exception {
+        try {
+            logger.info("Saving payload to separate file for runId: " + runId);
+            FileUtilities.writePayloadToFile(runId, payload);
+            logger.info("Payload saved successfully for runId: " + runId);
+        } catch (Exception e) {
+            logger.info("Failed to save payload for runId: " + runId + " - " + e.getMessage());
+            throw new Exception(e);
+        }
+    }
+
     public static String getRequestHeaders(Long runId, Logger logger) throws Exception {
         String requestHeaders = getRequestHeadersData(runId, logger).getAsString();
-        
+
         return requestHeaders;
     }
 
@@ -200,7 +212,7 @@ public class ResponseDataUtilities {
                 return statusCode;
             }
         } catch (JsonParseException e) {
-            
+
             logger.info("Failed to parse status code data for runId: " + runId + " with exception: " + e.getMessage());
             throw new Exception(e);
         }
@@ -209,27 +221,26 @@ public class ResponseDataUtilities {
     }
 
     public static JsonArray getPayloadData(Long runId, Logger logger) throws Exception {
-        logger.info("Getting all payload data for runId: " + runId);
-        String encodedData = FileUtilities.readFromFile(runId);
-        if (encodedData == null || encodedData.isEmpty()) {
+        logger.info("Getting payload data for runId: " + runId);
+        String payload = FileUtilities.readPayloadFromFile(runId);
+        if (payload == null || payload.isEmpty()) {
             logger.info("Payload data is not present for runId: " + runId);
             return new JsonArray();
         }
-
-        String json = new String(Base64.getDecoder().decode(encodedData));
+        logger.info("Got payload data for runId: " + runId + ", payload: " + payload);
         try {
-            JsonObject data = gson.fromJson(json, JsonObject.class);
-            if (data != null && data.has("payload")) {
-                logger.info("Got all payload data for runId: " + runId + ", data: " + data);
-                return data.getAsJsonArray("payload");
+            JsonElement parsed = gson.fromJson(payload, JsonElement.class);
+            if (parsed.isJsonArray()) {
+                return parsed.getAsJsonArray();
             }
+            JsonArray result = new JsonArray();
+            result.add(parsed);
+            return result;
         } catch (JsonParseException e) {
-            
-            logger.info("Failed to parse payload data for runId: " + runId + " with exception: " + e.getMessage());
-            throw new Exception(e);
+            JsonArray result = new JsonArray();
+            result.add(payload);
+            return result;
         }
-        logger.info("Failed to get any payload data for runId: " + runId);
-        throw new Exception("Failed to get any payload data for runId: " + runId);  
     }
 
     public static int getResponseTime(Long runId, Logger logger) throws Exception {
@@ -237,7 +248,7 @@ public class ResponseDataUtilities {
         String encodedData = FileUtilities.readFromFile(runId);
         if (encodedData == null || encodedData.isEmpty()) {
             logger.info("Response time data is not present for runId: " + runId);
-              throw new Exception("Failed to get any response time for runId: " + runId); 
+            throw new Exception("Failed to get any response time for runId: " + runId);
 
         }
 
@@ -250,13 +261,13 @@ public class ResponseDataUtilities {
                 return responseTime;
             }
         } catch (JsonParseException e) {
-            
-            logger.info("Failed to parse response time data for runId: " + runId + " with exception: " + e.getMessage());   
+
+            logger.info("Failed to parse response time data for runId: " + runId + " with exception: " + e.getMessage());
             throw new Exception(e);
         }
         logger.info("Failed to get any response time for runId: " + runId);
-        throw new Exception("Failed to get any response time for runId: " + runId); 
+        throw new Exception("Failed to get any response time for runId: " + runId);
 
-                
+
     }
 }


### PR DESCRIPTION
## Publish this addon as public
Addon Name: Store Network Logs Data
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira : https://testsigma.atlassian.net/browse/CUS-14077

## Summary
- Replace the DevTools/selenium-devtools-v137 based network capture in `StartTracking`, `StartTrackingAndNavigateToUrl`, and `StartTrackingAndClickOnElement` with a raw CDP JSON-RPC session (`RawCdpNetworkSession`), fixing failures caused by Selenium's version-pinned DevTools bindings not matching the live browser version.
- Fail fast with a clear message when the CDP endpoint isn't usable in the current test lab environment, instead of a generic connection error.
- `GetDataFromResponseBody` now falls back to storing the raw response body in the runtime variable instead of failing when the tracked response isn't valid JSON.
- Request payload capture now writes to its own file (`FileUtilities.writePayloadToFile`/`readPayloadFromFile`) instead of being embedded in the base64 JSON blob, and `getPayloadData` falls back to the raw payload string when it isn't JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved network request tracking for navigation and element-click actions.
  - Added support for capturing request payloads and storing them separately.
  - Enhanced response processing for JSON, non-JSON, and malformed payload content.

- **Bug Fixes**
  - Network response capture is more reliable across supported browser environments.
  - Non-JSON response bodies are now preserved instead of causing execution failures.
  - Added safer handling for missing headers, response bodies, and capture errors.

- **Release**
  - Updated the add-on version to 1.0.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->