### PR TITLE
feat/CUS-14240-Modified class to support latest edge version

### DIFF
--- a/get_latest_downloaded_file_path/pom.xml
+++ b/get_latest_downloaded_file_path/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>get_latest_downloaded_file_path</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFileName.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFileName.java
@@ -1,0 +1,103 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.Utilities;
+import com.testsigma.addons.web.util.UtilitiesFactory;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Action(actionText = "Get latest downloaded content and store in runtime variable variable-name",
+        description = "Retrieves the local path of the most recently downloaded file from the browser" +
+                " (Chrome/Edge) and stores it in a runtime variable.",
+        applicationType = ApplicationType.WEB)
+public class GetLatestDownloadedFileName extends WebAction {
+
+    @TestData(reference = "content", allowedValues = {"file-name", "file-path", "file-name-with-extension", "file-extension"})
+    private com.testsigma.sdk.TestData content;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        Utilities utilities = UtilitiesFactory.create(driver, logger);
+        String originalWindowHandle = driver.getWindowHandle();
+        try {
+            logger.info("Initiated execution");
+            String contentType = content.getValue().toString().trim().toLowerCase();
+
+            String storedValue;
+            if ("file-path".equals(contentType)) {
+                // Copy the file locally and return the temp file path
+                File localFile = utilities.copyFileFromDownloads();
+                logger.info("Local file path: " + localFile.getAbsolutePath());
+                storedValue = localFile.getAbsolutePath();
+            } else {
+                // For name/extension, read the original file name from the downloads page
+                // without copying the entire file
+                ((JavascriptExecutor) driver).executeScript("window.open('about:blank','_blank');");
+                List<String> tabs = new ArrayList<>(driver.getWindowHandles());
+                driver.switchTo().window(tabs.get(tabs.size() - 1));
+                try {
+                    if (!utilities.isFileDownloaded()) {
+                        throw new RuntimeException("File is still downloading.");
+                    }
+                    String originalPath = utilities.getDownloadedFileLocalPath();
+                    logger.info("Original downloaded file path: " + originalPath);
+
+                    int lastSep = Math.max(originalPath.lastIndexOf('/'), originalPath.lastIndexOf('\\'));
+                    String originalFileName = lastSep >= 0 ? originalPath.substring(lastSep + 1) : originalPath;
+                    int dotIndex = originalFileName.lastIndexOf('.');
+
+                    switch (contentType) {
+                        case "file-name":
+                            storedValue = dotIndex > 0 ? originalFileName.substring(0, dotIndex) : originalFileName;
+                            break;
+                        case "file-name-with-extension":
+                            storedValue = originalFileName;
+                            break;
+                        case "file-extension":
+                            storedValue = dotIndex > 0 ? originalFileName.substring(dotIndex + 1) : "";
+                            break;
+                        default:
+                            storedValue = originalFileName;
+                            break;
+                    }
+                } finally {
+                    driver.close();
+                    driver.switchTo().window(originalWindowHandle);
+                }
+            }
+
+            runTimeData.setKey(runtimeVariable.getValue().toString());
+            runTimeData.setValue(storedValue);
+            setSuccessMessage("Successfully stored the latest downloaded " + contentType + " in the runtime variable. "
+                    + runtimeVariable.getValue().toString() + " = " + storedValue);
+        } catch (Exception e) {
+            logger.info("Exception Occurred: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Exception Occurred while extracting the latest downloaded file content. Exception: "
+                    + ExceptionUtils.getMessage(e));
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+}

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFilePath.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/GetLatestDownloadedFilePath.java
@@ -17,7 +17,10 @@ import java.io.File;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-@Action(actionText = "Get latest downloaded file path and store in runtime variable variable-name", description = "Retrieves the local path of the most recently downloaded file from the browser (Chrome/Edge) and stores it in a runtime variable.", applicationType = ApplicationType.WEB)
+@Action(actionText = "Get latest downloaded file path and store in runtime variable variable-name",
+        description = "Retrieves the local path of the most recently downloaded file from the browser" +
+                " (Chrome/Edge) and stores it in a runtime variable.",
+        applicationType = ApplicationType.WEB)
 public class GetLatestDownloadedFilePath extends WebAction {
     @TestData(reference = "variable-name", isRuntimeVariable = true)
     private com.testsigma.sdk.TestData runtimeVariable;

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/VerifyIfTheLatestFileType.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/VerifyIfTheLatestFileType.java
@@ -1,0 +1,87 @@
+package com.testsigma.addons.web;
+
+import com.testsigma.addons.web.util.Utilities;
+import com.testsigma.addons.web.util.UtilitiesFactory;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.nio.file.Files;
+
+@Data
+@Action(actionText = "Verify if the latest downloaded file type is expected-file-type",
+        description = "Verifies that the most recently downloaded file has the expected file type/extension",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class VerifyIfTheLatestFileType extends WebAction {
+
+    @TestData(reference = "expected-file-type", allowedValues = {"pdf", "png", "jpg", "jpeg", "csv", "zip", "xlsx", "docx", "txt"})
+    private com.testsigma.sdk.TestData testData;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+
+        String currentWindowHandle = driver.getWindowHandle();
+        try {
+            String expectedFileType = testData.getValue().toString().trim().toLowerCase().replaceAll("^\\.", "");
+            logger.info("Expected file type: " + expectedFileType);
+
+            String expectedMimeType;
+            switch (expectedFileType) {
+                case "pdf":  expectedMimeType = "application/pdf"; break;
+                case "png":  expectedMimeType = "image/png"; break;
+                case "jpg":
+                case "jpeg": expectedMimeType = "image/jpeg"; break;
+                case "csv":  expectedMimeType = "text/csv"; break;
+                case "zip":  expectedMimeType = "application/zip"; break;
+                case "xlsx": expectedMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"; break;
+                case "docx": expectedMimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"; break;
+                case "txt":  expectedMimeType = "text/plain"; break;
+                default:
+                    setErrorMessage("Unsupported file type: '" + expectedFileType + "'. Supported types: pdf, png, jpg, jpeg, csv, zip, xlsx, docx, txt");
+                    return Result.FAILED;
+            }
+            logger.info("Expected MIME type: " + expectedMimeType);
+
+            Utilities utilities = UtilitiesFactory.create(driver, logger);
+            File localFile = utilities.copyFileFromDownloads();
+            logger.info("Local temp file: " + localFile.getAbsolutePath());
+
+            String actualFileType;
+            try {
+                actualFileType = Files.probeContentType(localFile.toPath());
+            } finally {
+                localFile.delete();
+            }
+
+            if (actualFileType == null) {
+                setErrorMessage("Could not determine file type of downloaded file: " + localFile.getName());
+                return Result.FAILED;
+            }
+            logger.info("Actual file type: " + actualFileType);
+
+            if (actualFileType.equals(expectedMimeType)) {
+                setSuccessMessage("Verified: the latest downloaded file type is '" + expectedFileType + "' as expected.");
+            } else {
+                setErrorMessage("File type mismatch: expected '" + expectedFileType + "' but found '" + actualFileType + "'.");
+                result = Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Error while verifying file type: " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Error while verifying file type: " + e.getMessage());
+            result = Result.FAILED;
+        } finally {
+            driver.switchTo().window(currentWindowHandle);
+        }
+
+        return result;
+    }
+}

--- a/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/util/EdgeUtilities.java
+++ b/get_latest_downloaded_file_path/src/main/java/com/testsigma/addons/web/util/EdgeUtilities.java
@@ -3,8 +3,7 @@ package com.testsigma.addons.web.util;
 import com.testsigma.sdk.Logger;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WindowType;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -21,84 +20,205 @@ public class EdgeUtilities extends BaseUtilities {
         super(driver, logger);
     }
 
+    private static final String NEW_MODEL_STATE_SCRIPT =
+            "return (function() {" +
+                    "    try {" +
+                    "        var app = document.querySelector('downloads-full-page-app');" +
+                    "        if (!app || !app.shadowRoot) return null;" +
+                    "        var list = app.shadowRoot.querySelector('downloads-list');" +
+                    "        if (!list || !Array.isArray(list.downloads)) return null;" +
+                    "        var downloads = [];" +
+                    "        list.downloads.forEach(function(group) {" +
+                    "            if (group && Array.isArray(group.downloads)) {" +
+                    "                group.downloads.forEach(function(item) {" +
+                    "                    if (item) downloads.push(item);" +
+                    "                });" +
+                    "            }" +
+                    "        });" +
+                    "        if (downloads.length === 0) return null;" +
+                    "        return !downloads.some(function(item) {" +
+                    "            var state = item && item.state ? String(item.state).toLowerCase() : '';" +
+                    "            return state.indexOf('progress') !== -1;" +
+                    "        });" +
+                    "    } catch (e) {" +
+                    "        return null;" +
+                    "    }" +
+                    "})();";
+
+    private static final String NEW_MODEL_PATH_SCRIPT =
+            "return (function() {" +
+                    "    try {" +
+                    "        var app = document.querySelector('downloads-full-page-app');" +
+                    "        if (!app || !app.shadowRoot) return null;" +
+                    "        var list = app.shadowRoot.querySelector('downloads-list');" +
+                    "        if (!list || !Array.isArray(list.downloads) || list.downloads.length === 0) return null;" +
+                    "        var group = list.downloads[0];" +
+                    "        if (!group || !Array.isArray(group.downloads) || group.downloads.length === 0) return null;" +
+                    "        var item = group.downloads[0];" +
+                    "        if (!item || !item.icon) return null;" +
+                    "        var match = String(item.icon).match(/path=([^&]*)/);" +
+                    "        if (!match || !match[1]) return null;" +
+                    "        return decodeURIComponent(match[1]).replace(/\\+/g, ' ');" +
+                    "    } catch (e) {" +
+                    "        return null;" +
+                    "    }" +
+                    "})();";
+
+    private static final String LEGACY_PROGRESS_SCRIPT =
+            "return (function() {" +
+                    "    var progressValues = [];" +
+                    "    var apps = document.querySelectorAll('downloads-app');" +
+                    "    apps.forEach(function(app) {" +
+                    "        if (!app.shadowRoot) return;" +
+                    "        app.shadowRoot.querySelectorAll('fluent-progress-bar').forEach(function(bar) {" +
+                    "            var value = bar.getAttribute('value');" +
+                    "            if (value !== null) progressValues.push(value);" +
+                    "        });" +
+                    "    });" +
+                    "    document.querySelectorAll('[role=\"progressbar\"]').forEach(function(bar) {" +
+                    "        var value = bar.getAttribute('aria-valuenow');" +
+                    "        if (value !== null) progressValues.push(value);" +
+                    "    });" +
+                    "    return progressValues;" +
+                    "})();";
+
+    private static final String LEGACY_PATH_SCRIPT =
+            "return (function() {" +
+                    "    try {" +
+                    "        var items = Array.from(" +
+                    "            document.querySelector('body > downloads-app')?.shadowRoot?.querySelectorAll('edge-card') || []" +
+                    "        );" +
+                    "        for (const item of items) {" +
+                    "            var title = item.querySelector('.downloads_itemTitle');" +
+                    "            if (!title || !title.textContent.trim()) continue;" +
+                    "            var img = item.querySelector('.downloads_itemIconContainer > img');" +
+                    "            var src = img ? img.getAttribute('src') : null;" +
+                    "            if (!src) continue;" +
+                    "            var decoded = decodeURIComponent(src);" +
+                    "            var match = decoded.match(/path=(.*)&scale/);" +
+                    "            if (match && match[1]) return match[1].replace(/\\+/g, ' ');" +
+                    "        }" +
+
+                    "        var legacyItems = document.querySelectorAll('div[role=\"listitem\"]');" +
+                    "        for (const item of legacyItems) {" +
+                    "            var button = item.querySelector('button[aria-label]');" +
+                    "            if (!button || !button.getAttribute('aria-label')) continue;" +
+                    "            var image = item.querySelector('img');" +
+                    "            var imageSrc = image ? image.getAttribute('src') : null;" +
+                    "            if (!imageSrc) continue;" +
+                    "            return decodeURIComponent(imageSrc.split('path=')[1].split('&')[0])" +
+                    "                .replace(/\\+/g, ' ');" +
+                    "        }" +
+                    "    } catch (e) {" +
+                    "        return null;" +
+                    "    }" +
+                    "    return null;" +
+                    "})();";
+
     @Override
     public File copyFileFromDownloads() throws Exception {
         String originalWindowHandle = driver.getWindowHandle();
-        File downloadedFile = null;
-        try {
-            // Create a new tab with JS
-            ((JavascriptExecutor) driver).executeScript("window.open('about:blank','_blank');");
 
-            // Switch to the new tab
+        try {
+            ((JavascriptExecutor) driver)
+                    .executeScript("window.open('about:blank','_blank');");
+
             List<String> tabs = new ArrayList<>(driver.getWindowHandles());
             driver.switchTo().window(tabs.get(tabs.size() - 1));
-
-            // Go to edge://downloads/
             driver.get("edge://downloads/");
 
-            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));
-            wait.until((ExpectedCondition<Boolean>) driver -> isFileDownloaded());
-            String remoteFilePath = getDownloadedFileLocalPath();
-            if (remoteFilePath != null) {
-                logger.info("Downloaded file path=" + remoteFilePath);
-                downloadedFile = super.createLocalFileFromDownloadsCopy(remoteFilePath);
-            } else {
-                throw new RuntimeException("File path not found.");
+            WebDriverWait wait =
+                    new WebDriverWait(driver, Duration.ofSeconds(60));
+
+            // Handle timeout and show a meaningful error message
+            try {
+                wait.until((ExpectedCondition<Boolean>) driver -> isFileDownloaded());
+            } catch (TimeoutException e) {
+                throw new RuntimeException("File was not downloaded.");
             }
-        } catch (RuntimeException e) {
-            throw new RuntimeException(e.getMessage(), e);
+
+            String remoteFilePath = getDownloadedFileLocalPath();
+
+            if (remoteFilePath == null || remoteFilePath.trim().isEmpty()) {
+                throw new RuntimeException("File was not downloaded.");
+            }
+
+            logger.info("Downloaded file path=" + remoteFilePath);
+
+            File downloadedFile =
+                    super.createLocalFileFromDownloadsCopy(remoteFilePath);
+
+            if (downloadedFile == null) {
+                throw new RuntimeException(
+                        "Unable to create a local copy of the downloaded file."
+                );
+            }
+
+            return downloadedFile;
+
         } finally {
             try {
                 driver.close();
                 driver.switchTo().window(originalWindowHandle);
             } catch (Exception e) {
-                logger.warn("Error closing downloads tab or switching back: " + e.getMessage());
+                logger.warn(
+                        "Error closing downloads tab or switching back: "
+                                + e.getMessage()
+                );
             }
         }
-        return downloadedFile;
     }
 
     @Override
     public boolean isFileDownloaded() {
-        if (!Objects.requireNonNull(driver.getCurrentUrl()).startsWith("edge://downloads")) {
+        if (!Objects.requireNonNull(driver.getCurrentUrl())
+                .startsWith("edge://downloads")) {
             driver.get("edge://downloads");
         }
 
         try {
-            String edgeJavaScript = "function getProgressValues() {" +
-                    "  let progressValues = [];" +
-                    "  const shadowRoots = document.querySelectorAll('downloads-app');" +
-                    "  if (shadowRoots.length > 0) {" +
-                    "    shadowRoots.forEach(shadowRoot => {" +
-                    "      const progressBarElements = shadowRoot.shadowRoot.querySelectorAll('fluent-progress-bar');" +
-                    "      progressBarElements.forEach(progressBar => {" +
-                    "        const progressValue = progressBar.getAttribute('value');" +
-                    "        if (progressValue !== null) {" +
-                    "          progressValues.push(progressValue);" +
-                    "        }" +
-                    "      });" +
-                    "    });" +
-                    "  }" +
-                    "  const progressBarElements = document.querySelectorAll('[role=\"progressbar\"]');" +
-                    "  progressBarElements.forEach(progressBar => {" +
-                    "    const progressValue = progressBar.getAttribute('aria-valuenow');" +
-                    "    if (progressValue !== null) {" +
-                    "      progressValues.push(progressValue);" +
-                    "    }" +
-                    "  });" +
-                    "  return progressValues;" +
-                    "}" +
-                    "return getProgressValues();";
-            List<WebElement> progressValues = (List<WebElement>) ((JavascriptExecutor) driver)
-                    .executeScript(edgeJavaScript);
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+
+            Object newModelResult =
+                    js.executeScript(NEW_MODEL_STATE_SCRIPT);
+
+            if (newModelResult instanceof Boolean) {
+                boolean complete = (Boolean) newModelResult;
+
+                logger.info(
+                        complete
+                                ? "Download is complete."
+                                : "Download is still in progress."
+                );
+
+                return complete;
+            }
+
+            @SuppressWarnings("unchecked")
+            List<String> progressValues =
+                    (List<String>) js.executeScript(LEGACY_PROGRESS_SCRIPT);
+
             if (progressValues != null && !progressValues.isEmpty()) {
                 logger.info("Download is still in progress.");
                 return false;
             }
-            logger.info("Download is complete.");
-            return true;
+
+            String legacyPath = getLegacyDownloadedFileLocalPath();
+
+            if (legacyPath != null && !legacyPath.trim().isEmpty()) {
+                logger.info("Download is complete.");
+                return true;
+            }
+
+            logger.info("No downloaded file found.");
+            return false;
+
         } catch (UnreachableBrowserException e) {
             logger.warn("Browser is unreachable: " + e.getMessage());
+            return false;
+
+        } catch (Exception e) {
+            logger.warn("Error checking download status: " + e.getMessage());
             return false;
         }
     }
@@ -107,74 +227,63 @@ public class EdgeUtilities extends BaseUtilities {
     public String getDownloadedFileLocalPath() {
         driver.get("edge://downloads");
 
-        logger.warn("Switched to downloads page.");
+        logger.info("Switched to downloads page.");
+
         try {
             JavascriptExecutor js = (JavascriptExecutor) driver;
 
-            String script = "return (function() {" +
-                    "    let pdfPath = null;" +
-                    "    try {" +
-                    "        let downloadItems = Array.from(document.querySelector(\"body > downloads-app\")?.shadowRoot?.querySelectorAll(\"edge-card\") || []);"
-                    +
-                    "        for (const downloadItem of downloadItems) {" +
-                    "            const fileNameElement = downloadItem.querySelector(\".downloads_itemTitle\");" +
-                    "            if (fileNameElement && fileNameElement.textContent.trim().length > 0) {" +
-                    "                const filePath = downloadItem.querySelector('.downloads_itemIconContainer > img')?.getAttribute('src');"
-                    +
-                    "                if (filePath) {" +
-                    "                    try {" +
-                    "                        const decodedPath = decodeURIComponent(filePath);" +
-                    "                        const match = decodedPath.match(/path=(.*)&scale/);" +
-                    "                        if (match && match[1]) {" +
-                    "                            pdfPath = match[1].replace(/\\+/g, ' ');" +
-                    "                            return pdfPath;" +
-                    "                        }" +
-                    "                    } catch (decodeError) { console.error('Error decoding file path:', decodeError); }"
-                    +
-                    "                }" +
-                    "            }" +
-                    "        }" +
+            Object newModelResult =
+                    js.executeScript(NEW_MODEL_PATH_SCRIPT);
 
-                    "        let downloadItemsLegacy = document.querySelectorAll('div[role=\"listitem\"]');" +
-                    "        for (const item of downloadItemsLegacy) {" +
-                    "            let fileNameElement = item.querySelector('button[aria-label]');" +
-                    "            if (fileNameElement) {" +
-                    "                let fileName = fileNameElement.getAttribute('aria-label');" +
-                    "                if (fileName && fileName.length > 0) {" +
-                    "                    let img = item.querySelector('img');" +
-                    "                    if (img) {" +
-                    "                        let src = img.getAttribute('src');" +
-                    "                        if (src) {" +
-                    "                            try {" +
-                    "                                pdfPath = decodeURIComponent(src.split('path=')[1].split('&')[0]).replace(/\\+/g, ' ');"
-                    +
-                    "                                return pdfPath;" +
-                    "                            } catch (e) { console.error('Error extracting or decoding file path:', e); }"
-                    +
-                    "                        }" +
-                    "                    }" +
-                    "                }" +
-                    "            }" +
-                    "        }" +
-                    "    } catch (error) {" +
-                    "        console.error('Error during PDF path retrieval:', error);" +
-                    "    }" +
-                    "    return null;" +
-                    "})();";
+            if (newModelResult != null) {
+                String path = newModelResult.toString();
 
-            Object result = js.executeScript(script);
-
-            if (result != null) {
-                String resultString = result.toString();
-                logger.info("Found file path: " + resultString);
-                return resultString;
-            } else {
-                logger.warn("No file found in downloads or an error occurred.");
-                return null;
+                if (!path.trim().isEmpty()) {
+                    logger.info("Found file path: " + path);
+                    return path;
+                }
             }
+
+            String legacyPath = getLegacyDownloadedFileLocalPath();
+
+            if (legacyPath != null && !legacyPath.trim().isEmpty()) {
+                logger.info("Found file path: " + legacyPath);
+                return legacyPath;
+            }
+
+            logger.warn("No downloaded file found in downloads page.");
+            return null;
+
         } catch (Exception e) {
-            logger.warn("Error retrieving the file path: " + e.getMessage());
+            logger.warn(
+                    "Error retrieving the file path: "
+                            + e.getMessage()
+            );
             return null;
         }
+    }
+
+    private String getLegacyDownloadedFileLocalPath() {
+        try {
+            Object result =
+                    ((JavascriptExecutor) driver)
+                            .executeScript(LEGACY_PATH_SCRIPT);
+
+            if (result != null) {
+                String path = result.toString();
+
+                if (!path.trim().isEmpty()) {
+                    return path;
+                }
+            }
+
+        } catch (Exception e) {
+            logger.warn(
+                    "Error retrieving legacy download path: "
+                            + e.getMessage()
+            );
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Publish this addon as PUBLIC
Addon Name: Get latest downloaded file path
Jarvis Link: https://jarvis.testsigma.com/ui/tenants/3072/addons
Jira : https://testsigma.atlassian.net/browse/CUS-14240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retrieve the latest downloaded file’s full path, filename, extension, or filename with extension and save it for later use.
  - Verify whether the latest downloaded file matches an expected file type.

- **Bug Fixes**
  - Improved download detection and file-path retrieval across newer and legacy browser download layouts.
  - Added clearer handling for incomplete downloads, unsupported types, missing files, and copy failures.
  - Ensured browser tabs are restored after download checks.

- **Chores**
  - Updated the project version to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->