### PR TITLE
[CUS-14381] added bulk pdf visual testing for the given folders.

### DIFF
--- a/pdf_visual_testing/pom.xml
+++ b/pdf_visual_testing/pom.xml
@@ -6,18 +6,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.testsigma.addons</groupId>
     <artifactId>pdf_visual_testing_addon</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.12_cloud</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.24_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
 
     </properties>
 

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForFolder.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForFolder.java
@@ -1,55 +1,12 @@
 package com.testsigma.addons.web;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.testsigma.addons.web.util.Constants;
-import com.testsigma.addons.web.util.Coordinate;
-import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.addons.web.util.PdfFolderComparisonEngine;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WebAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
-import org.apache.pdfbox.rendering.PDFRenderer;
 import org.openqa.selenium.NoSuchElementException;
-
-import javax.imageio.ImageIO;
-import java.awt.AlphaComposite;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Action(actionText = "Perform visual testing on all pdf files in base folder base-folder-path against the" +
         " pdf files in actual folder actual-folder-path, pairing files by pairing-strategy",
@@ -73,20 +30,6 @@ public class PDFVisualTestingForFolder extends WebAction {
     @TestData(reference = "pairing-strategy", allowedValues = {"filename", "position"})
     private com.testsigma.sdk.TestData pairingStrategy_;
 
-    // Number of pages compared concurrently per file. The remote visual-comparison API call is
-    // a network round trip and dominates page processing time; performing them one at a time
-    // per page serializes hundreds/thousands of round trips. PDF rendering itself stays
-    // single-threaded (PDFRenderer/PDDocument are not safe for concurrent use).
-    private static final int PAGE_CONCURRENCY = 10;
-
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    // Shared, connection-pooled HTTP client reused across every page/file so pages benefit from
-    // HTTP keep-alive instead of paying a fresh TCP+TLS handshake on every single page.
-    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
-            .connectionPool(new okhttp3.ConnectionPool(32, 5, TimeUnit.MINUTES))
-            .build();
-
     @Override
     public Result execute() throws NoSuchElementException {
         logger.info("Initiating execution for PDFVisualTestingForFolder action");
@@ -96,393 +39,33 @@ public class PDFVisualTestingForFolder extends WebAction {
         logger.info("Base folder path: " + baseFolderPath + ", Actual folder path: " + actualFolderPath +
                 ", Pairing strategy: " + pairingStrategy);
 
-        int filesPassed = 0;
-        int filesFailed = 0;
-        StringBuilder failureDetails = new StringBuilder();
-        String setupError = null;
-
-        // Bounded queue + CallerRunsPolicy: once PAGE_CONCURRENCY*2 page-comparisons are queued,
-        // the calling thread runs the next one itself instead of racing ahead of the network
-        // and piling up rendered pages/temp PNGs in memory.
-        ExecutorService pageExecutor = new ThreadPoolExecutor(PAGE_CONCURRENCY, PAGE_CONCURRENCY,
-                60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(PAGE_CONCURRENCY * 2),
-                new ThreadPoolExecutor.CallerRunsPolicy());
-
-        File reportFile;
-        try (PDDocument reportDocument = new PDDocument(IOUtils.createTempFileOnlyStreamCache())) {
-            try {
-                File baseFolder = new File(baseFolderPath);
-                File actualFolder = new File(actualFolderPath);
-                logger.info("checking if base folder and actual folder exist and are directories");
-
-                if (!baseFolder.isDirectory()) {
-                    setupError = "Base folder does not exist or is not a directory : " + baseFolderPath;
-                } else if (!actualFolder.isDirectory()) {
-                    setupError = "Actual folder does not exist or is not a directory : " + actualFolderPath;
-                } else {
-                    List<String> unmatchedBaseFiles = new ArrayList<>();
-                    logger.info("Pairing files in base folder and actual folder using pairing strategy: " + pairingStrategy);
-                    Map<File, File> pairs = pairFiles(baseFolder, actualFolder, pairingStrategy, unmatchedBaseFiles);
-                    int totalFilePairs = pairs.size();
-                    logger.info(String.format("Found %d matched pdf file pair(s) to compare and %d unmatched" +
-                            " file(s) in the base folder", totalFilePairs, unmatchedBaseFiles.size()));
-
-                    for (String unmatched : unmatchedBaseFiles) {
-                        filesFailed++;
-                        failureDetails.append(unmatched).append(" - no matching file found in actual folder; ");
-                        addMessagePageToReport(reportDocument,
-                                unmatched + " - FAILED (no matching file found in actual folder)");
-                    }
-
-                    int fileIndex = 0;
-                    for (Map.Entry<File, File> entry : pairs.entrySet()) {
-                        fileIndex++;
-                        logger.info(String.format("Iterating file %d/%d : %s", fileIndex, totalFilePairs,
-                                entry.getKey().getName()));
-                        boolean filePassed = compareSingleFile(entry.getKey(), entry.getValue(), fileIndex,
-                                totalFilePairs, reportDocument, failureDetails, pageExecutor);
-                        if (filePassed) {
-                            filesPassed++;
-                        } else {
-                            filesFailed++;
-                        }
-                    }
-                }
-            } catch (OutOfMemoryError oom) {
-                logger.info("OutOfMemoryError while processing base/actual folders : " + ExceptionUtils.getStackTrace(oom));
-                setupError = (setupError == null ? "" : setupError + "; ") + "Visual testing failed due to the" +
-                        " JVM running out of memory (OutOfMemoryError) while processing the folders. Try" +
-                        " increasing the JVM heap size (-Xmx) for the agent, lowering the render DPI, or" +
-                        " processing fewer files per run.";
-            } catch (Exception e) {
-                logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-                setupError = (setupError == null ? "" : setupError + "; ") + "Unexpected error: " + e.getMessage();
-            }
-
-            if (setupError != null) {
-                addMessagePageToReport(reportDocument, setupError);
-            }
-            if (reportDocument.getNumberOfPages() == 0) {
-                addMessagePageToReport(reportDocument, "No pdf files found to compare in the given folders.");
-            }
-
-            reportFile = File.createTempFile("pdf_visual_testing_report_", ".pdf");
-            reportDocument.save(reportFile);
-        } catch (OutOfMemoryError oom) {
-            logger.info("OutOfMemoryError while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(oom));
-            setErrorMessage("Unable to generate the consolidated visual testing report pdf because the JVM ran" +
-                    " out of memory (OutOfMemoryError). Try increasing the JVM heap size (-Xmx) for the agent" +
-                    " or lowering the render DPI.");
-            pageExecutor.shutdownNow();
-            return Result.FAILED;
-        } catch (Exception e) {
-            logger.info("Exception while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(e));
-            setErrorMessage("Unable to generate the consolidated visual testing report pdf : " + e.getMessage());
-            pageExecutor.shutdownNow();
-            return Result.FAILED;
-        } finally {
-            pageExecutor.shutdown();
-            try {
-                pageExecutor.awaitTermination(60, TimeUnit.SECONDS);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        String reportLink = buildReportLink(reportFile);
-
-        if (setupError != null) {
-            setErrorMessage(setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+        PdfFolderComparisonEngine.Outcome outcome;
+        try {
+            outcome = new PdfFolderComparisonEngine(logger)
+                    .compareFolders(baseFolderPath, actualFolderPath, pairingStrategy);
+        } catch (PdfFolderComparisonEngine.ReportGenerationException e) {
+            setErrorMessage(e.getMessage());
             return Result.FAILED;
         }
 
-        int totalFiles = filesPassed + filesFailed;
-        if (filesFailed == 0) {
+        String reportLink = PdfFolderComparisonEngine.buildReportLink(outcome.reportFile);
+
+        if (outcome.setupError != null) {
+            setErrorMessage(outcome.setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+            return Result.FAILED;
+        }
+
+        int totalFiles = outcome.filesPassed + outcome.filesFailed;
+        if (outcome.filesFailed == 0) {
             setSuccessMessage(String.format("Visual testing completed for all <b>%d</b> file(s) - <b>%d passed</b>," +
                             " <b>%d failed</b>. Consolidated report: <b>%s</b>",
-                    totalFiles, filesPassed, filesFailed, reportLink));
+                    totalFiles, outcome.filesPassed, outcome.filesFailed, reportLink));
             return Result.SUCCESS;
         } else {
             setErrorMessage(String.format("Visual testing completed for <b>%d</b> file(s) - <b>%d passed</b>," +
                             " <b>%d failed</b>. Consolidated report: <b>%s</b>. Failures: %s",
-                    totalFiles, filesPassed, filesFailed, reportLink, failureDetails));
+                    totalFiles, outcome.filesPassed, outcome.filesFailed, reportLink, outcome.failureDetails));
             return Result.FAILED;
         }
     }
-
-    private String buildReportLink(File reportFile) {
-        String url = reportFile.toURI().toString();
-        return String.format("<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
-                url, reportFile.getAbsolutePath());
-    }
-
-    private Map<File, File> pairFiles(File baseFolder, File actualFolder, String pairingStrategy,
-                                      List<String> unmatchedBaseFiles) {
-        File[] baseFilesArr = baseFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
-        File[] actualFilesArr = actualFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
-        List<File> baseFiles = new ArrayList<>(baseFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(baseFilesArr));
-        List<File> actualFiles = new ArrayList<>(actualFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(actualFilesArr));
-        baseFiles.sort(Comparator.comparing(File::getName));
-        actualFiles.sort(Comparator.comparing(File::getName));
-
-        Map<File, File> pairs = new LinkedHashMap<>();
-        if ("position".equalsIgnoreCase(pairingStrategy)) {
-            int count = Math.min(baseFiles.size(), actualFiles.size());
-            for (int i = 0; i < count; i++) {
-                pairs.put(baseFiles.get(i), actualFiles.get(i));
-            }
-            for (int i = count; i < baseFiles.size(); i++) {
-                unmatchedBaseFiles.add(baseFiles.get(i).getName());
-            }
-        } else {
-            Map<String, File> actualByName = new HashMap<>();
-            for (File f : actualFiles) {
-                actualByName.put(f.getName(), f);
-            }
-            for (File base : baseFiles) {
-                File match = actualByName.get(base.getName());
-                if (match != null) {
-                    pairs.put(base, match);
-                } else {
-                    unmatchedBaseFiles.add(base.getName());
-                }
-            }
-        }
-        return pairs;
-    }
-
-    private boolean compareSingleFile(File basePdf, File actualPdf, int fileIndex, int totalFiles,
-                                      PDDocument reportDocument, StringBuilder failureDetails,
-                                      ExecutorService pageExecutor) {
-        String fileLabel = basePdf.getName();
-        int currentPage = 0;
-        int pagesToCompare = 0;
-        try (PDDocument baseDocument = Loader.loadPDF(basePdf);
-             PDDocument actualDocument = Loader.loadPDF(actualPdf)) {
-            int basePageCount = baseDocument.getNumberOfPages();
-            int actualPageCount = actualDocument.getNumberOfPages();
-            pagesToCompare = Math.min(basePageCount, actualPageCount);
-            int totalPagesToCompare = pagesToCompare;
-            boolean pageCountMismatch = basePageCount != actualPageCount;
-            AtomicBoolean allPagesPassed = new AtomicBoolean(true);
-
-            logger.info(String.format("File %d/%d (%s) - %d page(s) to compare (base has %d page(s), actual has" +
-                    " %d page(s))", fileIndex, totalFiles, fileLabel, pagesToCompare, basePageCount, actualPageCount));
-
-            // PDFRenderer/PDDocument are not safe for concurrent use, so rendering stays on this
-            // single thread. The remote comparison API call (the actual bottleneck - a network
-            // round trip) and writing the resulting page into the shared report run concurrently.
-            PDFRenderer baseRenderer = new PDFRenderer(baseDocument);
-            PDFRenderer actualRenderer = new PDFRenderer(actualDocument);
-
-            List<Future<Void>> pageFutures = new ArrayList<>(pagesToCompare);
-            for (int page = 1; page <= pagesToCompare; page++) {
-                currentPage = page;
-                int pageNumber = page;
-                logger.info(String.format("File %d/%d (%s) - rendering page %d/%d", fileIndex, totalFiles,
-                        fileLabel, page, pagesToCompare));
-                BufferedImage baseImage = baseRenderer.renderImageWithDPI(page - 1, 150);
-                BufferedImage actualImage = actualRenderer.renderImageWithDPI(page - 1, 150);
-
-                Callable<Void> pageTask = () -> {
-                    try {
-                        File baseTemp = File.createTempFile("base_page_", ".png");
-                        File actualTemp = File.createTempFile("actual_page_", ".png");
-                        try {
-                            ImageIO.write(baseImage, "png", baseTemp);
-                            ImageIO.write(actualImage, "png", actualTemp);
-
-                            boolean pagePassed;
-                            List<Coordinate> diffCoordinates;
-                            try {
-                                ResponseObject responseObject = performApiCall(baseTemp, actualTemp, pageNumber);
-                                pagePassed = responseObject.getPer_similar() == 1 && responseObject.getDiff_coordinates().isEmpty();
-                                diffCoordinates = pagePassed ? Collections.emptyList() : responseObject.getDiff_coordinates();
-                            } catch (Exception apiError) {
-                                logger.info(String.format("File %d/%d (%s) - page %d - API call failed : %s",
-                                        fileIndex, totalFiles, fileLabel, pageNumber, ExceptionUtils.getStackTrace(apiError)));
-                                pagePassed = false;
-                                diffCoordinates = Collections.emptyList();
-                            }
-
-                            String header = String.format("%s - page %d/%d - %s", fileLabel, pageNumber,
-                                    totalPagesToCompare, pagePassed ? "PASS" : "FAIL");
-                            BufferedImage comparisonPage = createComparisonPage(baseImage, actualImage, diffCoordinates, header);
-                            try {
-                                synchronized (reportDocument) {
-                                    addImagePageToReport(reportDocument, comparisonPage);
-                                }
-                            } finally {
-                                comparisonPage.flush();
-                            }
-
-                            if (!pagePassed) {
-                                allPagesPassed.set(false);
-                            }
-                        } finally {
-                            baseTemp.delete();
-                            actualTemp.delete();
-                        }
-                    } finally {
-                        baseImage.flush();
-                        actualImage.flush();
-                    }
-                    return null;
-                };
-                pageFutures.add(pageExecutor.submit(pageTask));
-            }
-
-            for (Future<Void> future : pageFutures) {
-                try {
-                    future.get();
-                } catch (ExecutionException ee) {
-                    logger.info(String.format("File %d/%d (%s) - a page comparison failed : %s", fileIndex,
-                            totalFiles, fileLabel, ExceptionUtils.getStackTrace(ee.getCause())));
-                    allPagesPassed.set(false);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    allPagesPassed.set(false);
-                }
-            }
-
-            if (pageCountMismatch) {
-                failureDetails.append(String.format("%s - page count mismatch (base=%d, actual=%d); ",
-                        fileLabel, basePageCount, actualPageCount));
-                addMessagePageToReport(reportDocument, String.format("%s - FAILED (page count mismatch: base has" +
-                        " %d pages, actual has %d pages)", fileLabel, basePageCount, actualPageCount));
-            } else if (!allPagesPassed.get()) {
-                failureDetails.append(fileLabel).append(" - visual differences found; ");
-            }
-            return allPagesPassed.get() && !pageCountMismatch;
-        } catch (OutOfMemoryError oom) {
-            logger.info(String.format("OutOfMemoryError while comparing file %d/%d (%s) at page %d/%d : %s",
-                    fileIndex, totalFiles, fileLabel, currentPage, pagesToCompare, ExceptionUtils.getStackTrace(oom)));
-            String reason = currentPage > 0
-                    ? String.format("ran out of memory (OutOfMemoryError) while rendering/comparing page %d of %d",
-                            currentPage, pagesToCompare)
-                    : "ran out of memory (OutOfMemoryError) before comparison could start";
-            failureDetails.append(fileLabel).append(" - ").append(reason)
-                    .append(" - try increasing the JVM heap size (-Xmx) for the agent or lowering the render DPI; ");
-            try {
-                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (" + reason + ")");
-            } catch (IOException | OutOfMemoryError innerError) {
-                logger.info("Exception while adding out-of-memory failure page to report : " + ExceptionUtils.getStackTrace(innerError));
-            }
-            return false;
-        } catch (Exception e) {
-            logger.info("Exception while comparing file " + fileLabel + " : " + ExceptionUtils.getStackTrace(e));
-            failureDetails.append(fileLabel).append(" - error during comparison: ").append(e.getMessage()).append("; ");
-            try {
-                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (error during comparison: " + e.getMessage() + ")");
-            } catch (IOException ioException) {
-                logger.info("Exception while adding failure page to report : " + ExceptionUtils.getStackTrace(ioException));
-            }
-            return false;
-        }
-    }
-
-    private BufferedImage createMessagePage(String message) {
-        int width = 1000;
-        int height = 150;
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = image.createGraphics();
-        g2d.setColor(Color.WHITE);
-        g2d.fillRect(0, 0, width, height);
-        g2d.setColor(Color.BLACK);
-        g2d.setFont(new Font("SansSerif", Font.PLAIN, 18));
-        g2d.drawString(message, 20, height / 2);
-        g2d.dispose();
-        return image;
-    }
-
-    private BufferedImage createComparisonPage(BufferedImage baseImage, BufferedImage actualImage,
-                                               List<Coordinate> diffCoordinates, String header) {
-        int headerHeight = 40;
-        int width = baseImage.getWidth() + actualImage.getWidth();
-        int height = Math.max(baseImage.getHeight(), actualImage.getHeight()) + headerHeight;
-        BufferedImage page = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = page.createGraphics();
-        g2d.setColor(Color.WHITE);
-        g2d.fillRect(0, 0, width, height);
-        g2d.setColor(Color.BLACK);
-        g2d.setFont(new Font("SansSerif", Font.BOLD, 20));
-        g2d.drawString(header, 10, 28);
-
-        g2d.drawImage(baseImage, 0, headerHeight, null);
-        g2d.drawImage(actualImage, baseImage.getWidth(), headerHeight, null);
-
-        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
-        g2d.setColor(new Color(255, 0, 0));
-        for (Coordinate coordinate : diffCoordinates) {
-            g2d.fillRect(coordinate.getX(), coordinate.getY() + headerHeight, coordinate.getW(), coordinate.getH());
-            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY() + headerHeight,
-                    coordinate.getW(), coordinate.getH());
-        }
-        g2d.dispose();
-        return page;
-    }
-
-    private void addMessagePageToReport(PDDocument reportDocument, String message) throws IOException {
-        BufferedImage image = createMessagePage(message);
-        try {
-            addImagePageToReport(reportDocument, image);
-        } finally {
-            image.flush();
-        }
-    }
-
-    private void addImagePageToReport(PDDocument reportDocument, BufferedImage image) throws IOException {
-        PDPage pdPage = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
-        reportDocument.addPage(pdPage);
-        PDImageXObject pdImage = LosslessFactory.createFromImage(reportDocument, image);
-        try (PDPageContentStream contentStream = new PDPageContentStream(reportDocument, pdPage)) {
-            contentStream.drawImage(pdImage, 0, 0, image.getWidth(), image.getHeight());
-        }
-    }
-
-    public ResponseObject performApiCall(File baseImage, File actualImage, int page) {
-        try {
-            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
-                    actualImage.getAbsolutePath()));
-            MultipartBody.Builder builder = new MultipartBody.Builder()
-                    .setType(MultipartBody.FORM)
-                    .addFormDataPart("action", "COMPARE")
-                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
-                    .addFormDataPart(
-                            "baseImageFile",
-                            baseImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), baseImage)
-                    )
-                    .addFormDataPart(
-                            "actualImageFile",
-                            actualImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), actualImage)
-                    );
-            RequestBody requestBody = builder.build();
-            Request request = new Request.Builder()
-                    .url(Constants.VISUAL_SERVER_API_END_POINT)
-                    .method("POST", requestBody)
-                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
-                    .build();
-            try (Response response = httpClient.newCall(request).execute()) {
-                if (response.isSuccessful()) {
-                    if (response.body() != null) {
-                        String responseBody = response.body().string();
-                        return mapper.readValue(responseBody, ResponseObject.class);
-                    } else {
-                        throw new RuntimeException(String.format("Visual testing failed at page %s, no response" +
-                                " body present in the visual test response", page));
-                    }
-                } else {
-                    throw new RuntimeException(String.format("Visual testing failed at page %s, error occurred" +
-                            " internally", page));
-                }
-            }
-        } catch (IOException e) {
-            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
-                    ExceptionUtils.getStackTrace(e)));
-            throw new RuntimeException("Error occurred while performing visual test at page " + page, e);
-        }
-    }
-
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForFolder.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForFolder.java
@@ -1,0 +1,488 @@
+package com.testsigma.addons.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.Coordinate;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WebAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Action(actionText = "Perform visual testing on all pdf files in base folder base-folder-path against the" +
+        " pdf files in actual folder actual-folder-path, pairing files by pairing-strategy",
+        description = "Iterates over every pdf file in the base folder and its corresponding pdf file in the" +
+                " actual folder (paired either by matching filename or by matching sorted position, controlled" +
+                " by pairing-strategy), performs page-by-page visual testing for each pair, and generates a" +
+                " single consolidated pdf report containing side-by-side comparison images for every page" +
+                " checked. The local path of this report is included in both the success and the error" +
+                " message, along with the number of files that passed and the number that failed.",
+        displayName = "PDF Visual Testing For Folder",
+        applicationType = ApplicationType.WEB,
+        useCustomScreenshot = false)
+public class PDFVisualTestingForFolder extends WebAction {
+
+    @TestData(reference = "base-folder-path")
+    private com.testsigma.sdk.TestData baseFolderPath_;
+
+    @TestData(reference = "actual-folder-path")
+    private com.testsigma.sdk.TestData actualFolderPath_;
+
+    @TestData(reference = "pairing-strategy", allowedValues = {"filename", "position"})
+    private com.testsigma.sdk.TestData pairingStrategy_;
+
+    // Number of pages compared concurrently per file. The remote visual-comparison API call is
+    // a network round trip and dominates page processing time; performing them one at a time
+    // per page serializes hundreds/thousands of round trips. PDF rendering itself stays
+    // single-threaded (PDFRenderer/PDDocument are not safe for concurrent use).
+    private static final int PAGE_CONCURRENCY = 10;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // Shared, connection-pooled HTTP client reused across every page/file so pages benefit from
+    // HTTP keep-alive instead of paying a fresh TCP+TLS handshake on every single page.
+    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
+            .connectionPool(new okhttp3.ConnectionPool(32, 5, TimeUnit.MINUTES))
+            .build();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution for PDFVisualTestingForFolder action");
+        String baseFolderPath = baseFolderPath_.getValue().toString();
+        String actualFolderPath = actualFolderPath_.getValue().toString();
+        String pairingStrategy = pairingStrategy_.getValue().toString();
+        logger.info("Base folder path: " + baseFolderPath + ", Actual folder path: " + actualFolderPath +
+                ", Pairing strategy: " + pairingStrategy);
+
+        int filesPassed = 0;
+        int filesFailed = 0;
+        StringBuilder failureDetails = new StringBuilder();
+        String setupError = null;
+
+        // Bounded queue + CallerRunsPolicy: once PAGE_CONCURRENCY*2 page-comparisons are queued,
+        // the calling thread runs the next one itself instead of racing ahead of the network
+        // and piling up rendered pages/temp PNGs in memory.
+        ExecutorService pageExecutor = new ThreadPoolExecutor(PAGE_CONCURRENCY, PAGE_CONCURRENCY,
+                60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(PAGE_CONCURRENCY * 2),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+
+        File reportFile;
+        try (PDDocument reportDocument = new PDDocument(IOUtils.createTempFileOnlyStreamCache())) {
+            try {
+                File baseFolder = new File(baseFolderPath);
+                File actualFolder = new File(actualFolderPath);
+                logger.info("checking if base folder and actual folder exist and are directories");
+
+                if (!baseFolder.isDirectory()) {
+                    setupError = "Base folder does not exist or is not a directory : " + baseFolderPath;
+                } else if (!actualFolder.isDirectory()) {
+                    setupError = "Actual folder does not exist or is not a directory : " + actualFolderPath;
+                } else {
+                    List<String> unmatchedBaseFiles = new ArrayList<>();
+                    logger.info("Pairing files in base folder and actual folder using pairing strategy: " + pairingStrategy);
+                    Map<File, File> pairs = pairFiles(baseFolder, actualFolder, pairingStrategy, unmatchedBaseFiles);
+                    int totalFilePairs = pairs.size();
+                    logger.info(String.format("Found %d matched pdf file pair(s) to compare and %d unmatched" +
+                            " file(s) in the base folder", totalFilePairs, unmatchedBaseFiles.size()));
+
+                    for (String unmatched : unmatchedBaseFiles) {
+                        filesFailed++;
+                        failureDetails.append(unmatched).append(" - no matching file found in actual folder; ");
+                        addMessagePageToReport(reportDocument,
+                                unmatched + " - FAILED (no matching file found in actual folder)");
+                    }
+
+                    int fileIndex = 0;
+                    for (Map.Entry<File, File> entry : pairs.entrySet()) {
+                        fileIndex++;
+                        logger.info(String.format("Iterating file %d/%d : %s", fileIndex, totalFilePairs,
+                                entry.getKey().getName()));
+                        boolean filePassed = compareSingleFile(entry.getKey(), entry.getValue(), fileIndex,
+                                totalFilePairs, reportDocument, failureDetails, pageExecutor);
+                        if (filePassed) {
+                            filesPassed++;
+                        } else {
+                            filesFailed++;
+                        }
+                    }
+                }
+            } catch (OutOfMemoryError oom) {
+                logger.info("OutOfMemoryError while processing base/actual folders : " + ExceptionUtils.getStackTrace(oom));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Visual testing failed due to the" +
+                        " JVM running out of memory (OutOfMemoryError) while processing the folders. Try" +
+                        " increasing the JVM heap size (-Xmx) for the agent, lowering the render DPI, or" +
+                        " processing fewer files per run.";
+            } catch (Exception e) {
+                logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Unexpected error: " + e.getMessage();
+            }
+
+            if (setupError != null) {
+                addMessagePageToReport(reportDocument, setupError);
+            }
+            if (reportDocument.getNumberOfPages() == 0) {
+                addMessagePageToReport(reportDocument, "No pdf files found to compare in the given folders.");
+            }
+
+            reportFile = File.createTempFile("pdf_visual_testing_report_", ".pdf");
+            reportDocument.save(reportFile);
+        } catch (OutOfMemoryError oom) {
+            logger.info("OutOfMemoryError while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(oom));
+            setErrorMessage("Unable to generate the consolidated visual testing report pdf because the JVM ran" +
+                    " out of memory (OutOfMemoryError). Try increasing the JVM heap size (-Xmx) for the agent" +
+                    " or lowering the render DPI.");
+            pageExecutor.shutdownNow();
+            return Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to generate the consolidated visual testing report pdf : " + e.getMessage());
+            pageExecutor.shutdownNow();
+            return Result.FAILED;
+        } finally {
+            pageExecutor.shutdown();
+            try {
+                pageExecutor.awaitTermination(60, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        String reportLink = buildReportLink(reportFile);
+
+        if (setupError != null) {
+            setErrorMessage(setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+            return Result.FAILED;
+        }
+
+        int totalFiles = filesPassed + filesFailed;
+        if (filesFailed == 0) {
+            setSuccessMessage(String.format("Visual testing completed for all <b>%d</b> file(s) - <b>%d passed</b>," +
+                            " <b>%d failed</b>. Consolidated report: <b>%s</b>",
+                    totalFiles, filesPassed, filesFailed, reportLink));
+            return Result.SUCCESS;
+        } else {
+            setErrorMessage(String.format("Visual testing completed for <b>%d</b> file(s) - <b>%d passed</b>," +
+                            " <b>%d failed</b>. Consolidated report: <b>%s</b>. Failures: %s",
+                    totalFiles, filesPassed, filesFailed, reportLink, failureDetails));
+            return Result.FAILED;
+        }
+    }
+
+    private String buildReportLink(File reportFile) {
+        String url = reportFile.toURI().toString();
+        return String.format("<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
+                url, reportFile.getAbsolutePath());
+    }
+
+    private Map<File, File> pairFiles(File baseFolder, File actualFolder, String pairingStrategy,
+                                      List<String> unmatchedBaseFiles) {
+        File[] baseFilesArr = baseFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        File[] actualFilesArr = actualFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        List<File> baseFiles = new ArrayList<>(baseFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(baseFilesArr));
+        List<File> actualFiles = new ArrayList<>(actualFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(actualFilesArr));
+        baseFiles.sort(Comparator.comparing(File::getName));
+        actualFiles.sort(Comparator.comparing(File::getName));
+
+        Map<File, File> pairs = new LinkedHashMap<>();
+        if ("position".equalsIgnoreCase(pairingStrategy)) {
+            int count = Math.min(baseFiles.size(), actualFiles.size());
+            for (int i = 0; i < count; i++) {
+                pairs.put(baseFiles.get(i), actualFiles.get(i));
+            }
+            for (int i = count; i < baseFiles.size(); i++) {
+                unmatchedBaseFiles.add(baseFiles.get(i).getName());
+            }
+        } else {
+            Map<String, File> actualByName = new HashMap<>();
+            for (File f : actualFiles) {
+                actualByName.put(f.getName(), f);
+            }
+            for (File base : baseFiles) {
+                File match = actualByName.get(base.getName());
+                if (match != null) {
+                    pairs.put(base, match);
+                } else {
+                    unmatchedBaseFiles.add(base.getName());
+                }
+            }
+        }
+        return pairs;
+    }
+
+    private boolean compareSingleFile(File basePdf, File actualPdf, int fileIndex, int totalFiles,
+                                      PDDocument reportDocument, StringBuilder failureDetails,
+                                      ExecutorService pageExecutor) {
+        String fileLabel = basePdf.getName();
+        int currentPage = 0;
+        int pagesToCompare = 0;
+        try (PDDocument baseDocument = Loader.loadPDF(basePdf);
+             PDDocument actualDocument = Loader.loadPDF(actualPdf)) {
+            int basePageCount = baseDocument.getNumberOfPages();
+            int actualPageCount = actualDocument.getNumberOfPages();
+            pagesToCompare = Math.min(basePageCount, actualPageCount);
+            int totalPagesToCompare = pagesToCompare;
+            boolean pageCountMismatch = basePageCount != actualPageCount;
+            AtomicBoolean allPagesPassed = new AtomicBoolean(true);
+
+            logger.info(String.format("File %d/%d (%s) - %d page(s) to compare (base has %d page(s), actual has" +
+                    " %d page(s))", fileIndex, totalFiles, fileLabel, pagesToCompare, basePageCount, actualPageCount));
+
+            // PDFRenderer/PDDocument are not safe for concurrent use, so rendering stays on this
+            // single thread. The remote comparison API call (the actual bottleneck - a network
+            // round trip) and writing the resulting page into the shared report run concurrently.
+            PDFRenderer baseRenderer = new PDFRenderer(baseDocument);
+            PDFRenderer actualRenderer = new PDFRenderer(actualDocument);
+
+            List<Future<Void>> pageFutures = new ArrayList<>(pagesToCompare);
+            for (int page = 1; page <= pagesToCompare; page++) {
+                currentPage = page;
+                int pageNumber = page;
+                logger.info(String.format("File %d/%d (%s) - rendering page %d/%d", fileIndex, totalFiles,
+                        fileLabel, page, pagesToCompare));
+                BufferedImage baseImage = baseRenderer.renderImageWithDPI(page - 1, 150);
+                BufferedImage actualImage = actualRenderer.renderImageWithDPI(page - 1, 150);
+
+                Callable<Void> pageTask = () -> {
+                    try {
+                        File baseTemp = File.createTempFile("base_page_", ".png");
+                        File actualTemp = File.createTempFile("actual_page_", ".png");
+                        try {
+                            ImageIO.write(baseImage, "png", baseTemp);
+                            ImageIO.write(actualImage, "png", actualTemp);
+
+                            boolean pagePassed;
+                            List<Coordinate> diffCoordinates;
+                            try {
+                                ResponseObject responseObject = performApiCall(baseTemp, actualTemp, pageNumber);
+                                pagePassed = responseObject.getPer_similar() == 1 && responseObject.getDiff_coordinates().isEmpty();
+                                diffCoordinates = pagePassed ? Collections.emptyList() : responseObject.getDiff_coordinates();
+                            } catch (Exception apiError) {
+                                logger.info(String.format("File %d/%d (%s) - page %d - API call failed : %s",
+                                        fileIndex, totalFiles, fileLabel, pageNumber, ExceptionUtils.getStackTrace(apiError)));
+                                pagePassed = false;
+                                diffCoordinates = Collections.emptyList();
+                            }
+
+                            String header = String.format("%s - page %d/%d - %s", fileLabel, pageNumber,
+                                    totalPagesToCompare, pagePassed ? "PASS" : "FAIL");
+                            BufferedImage comparisonPage = createComparisonPage(baseImage, actualImage, diffCoordinates, header);
+                            try {
+                                synchronized (reportDocument) {
+                                    addImagePageToReport(reportDocument, comparisonPage);
+                                }
+                            } finally {
+                                comparisonPage.flush();
+                            }
+
+                            if (!pagePassed) {
+                                allPagesPassed.set(false);
+                            }
+                        } finally {
+                            baseTemp.delete();
+                            actualTemp.delete();
+                        }
+                    } finally {
+                        baseImage.flush();
+                        actualImage.flush();
+                    }
+                    return null;
+                };
+                pageFutures.add(pageExecutor.submit(pageTask));
+            }
+
+            for (Future<Void> future : pageFutures) {
+                try {
+                    future.get();
+                } catch (ExecutionException ee) {
+                    logger.info(String.format("File %d/%d (%s) - a page comparison failed : %s", fileIndex,
+                            totalFiles, fileLabel, ExceptionUtils.getStackTrace(ee.getCause())));
+                    allPagesPassed.set(false);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    allPagesPassed.set(false);
+                }
+            }
+
+            if (pageCountMismatch) {
+                failureDetails.append(String.format("%s - page count mismatch (base=%d, actual=%d); ",
+                        fileLabel, basePageCount, actualPageCount));
+                addMessagePageToReport(reportDocument, String.format("%s - FAILED (page count mismatch: base has" +
+                        " %d pages, actual has %d pages)", fileLabel, basePageCount, actualPageCount));
+            } else if (!allPagesPassed.get()) {
+                failureDetails.append(fileLabel).append(" - visual differences found; ");
+            }
+            return allPagesPassed.get() && !pageCountMismatch;
+        } catch (OutOfMemoryError oom) {
+            logger.info(String.format("OutOfMemoryError while comparing file %d/%d (%s) at page %d/%d : %s",
+                    fileIndex, totalFiles, fileLabel, currentPage, pagesToCompare, ExceptionUtils.getStackTrace(oom)));
+            String reason = currentPage > 0
+                    ? String.format("ran out of memory (OutOfMemoryError) while rendering/comparing page %d of %d",
+                            currentPage, pagesToCompare)
+                    : "ran out of memory (OutOfMemoryError) before comparison could start";
+            failureDetails.append(fileLabel).append(" - ").append(reason)
+                    .append(" - try increasing the JVM heap size (-Xmx) for the agent or lowering the render DPI; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (" + reason + ")");
+            } catch (IOException | OutOfMemoryError innerError) {
+                logger.info("Exception while adding out-of-memory failure page to report : " + ExceptionUtils.getStackTrace(innerError));
+            }
+            return false;
+        } catch (Exception e) {
+            logger.info("Exception while comparing file " + fileLabel + " : " + ExceptionUtils.getStackTrace(e));
+            failureDetails.append(fileLabel).append(" - error during comparison: ").append(e.getMessage()).append("; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (error during comparison: " + e.getMessage() + ")");
+            } catch (IOException ioException) {
+                logger.info("Exception while adding failure page to report : " + ExceptionUtils.getStackTrace(ioException));
+            }
+            return false;
+        }
+    }
+
+    private BufferedImage createMessagePage(String message) {
+        int width = 1000;
+        int height = 150;
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.PLAIN, 18));
+        g2d.drawString(message, 20, height / 2);
+        g2d.dispose();
+        return image;
+    }
+
+    private BufferedImage createComparisonPage(BufferedImage baseImage, BufferedImage actualImage,
+                                               List<Coordinate> diffCoordinates, String header) {
+        int headerHeight = 40;
+        int width = baseImage.getWidth() + actualImage.getWidth();
+        int height = Math.max(baseImage.getHeight(), actualImage.getHeight()) + headerHeight;
+        BufferedImage page = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = page.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.BOLD, 20));
+        g2d.drawString(header, 10, 28);
+
+        g2d.drawImage(baseImage, 0, headerHeight, null);
+        g2d.drawImage(actualImage, baseImage.getWidth(), headerHeight, null);
+
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
+        g2d.setColor(new Color(255, 0, 0));
+        for (Coordinate coordinate : diffCoordinates) {
+            g2d.fillRect(coordinate.getX(), coordinate.getY() + headerHeight, coordinate.getW(), coordinate.getH());
+            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY() + headerHeight,
+                    coordinate.getW(), coordinate.getH());
+        }
+        g2d.dispose();
+        return page;
+    }
+
+    private void addMessagePageToReport(PDDocument reportDocument, String message) throws IOException {
+        BufferedImage image = createMessagePage(message);
+        try {
+            addImagePageToReport(reportDocument, image);
+        } finally {
+            image.flush();
+        }
+    }
+
+    private void addImagePageToReport(PDDocument reportDocument, BufferedImage image) throws IOException {
+        PDPage pdPage = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
+        reportDocument.addPage(pdPage);
+        PDImageXObject pdImage = LosslessFactory.createFromImage(reportDocument, image);
+        try (PDPageContentStream contentStream = new PDPageContentStream(reportDocument, pdPage)) {
+            contentStream.drawImage(pdImage, 0, 0, image.getWidth(), image.getHeight());
+        }
+    }
+
+    public ResponseObject performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    if (response.body() != null) {
+                        String responseBody = response.body().string();
+                        return mapper.readValue(responseBody, ResponseObject.class);
+                    } else {
+                        throw new RuntimeException(String.format("Visual testing failed at page %s, no response" +
+                                " body present in the visual test response", page));
+                    }
+                } else {
+                    throw new RuntimeException(String.format("Visual testing failed at page %s, error occurred" +
+                            " internally", page));
+                }
+            }
+        } catch (IOException e) {
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page, e);
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/PDFVisualTestingForGivenPage.java
@@ -94,7 +94,7 @@ public class PDFVisualTestingForGivenPage extends WebAction {
             File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
             File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
 
-            if (!basePDF.getName().endsWith(".pdf") || !actualPDF.getName().endsWith(".pdf")) {
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
                 String message = "Unsupported file types give only pdf files as input, screenshot" +
                         " might not be displayed";
                 errorMessageBuilder.append(message);

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/PdfFolderComparisonEngine.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/web/util/PdfFolderComparisonEngine.java
@@ -1,0 +1,517 @@
+package com.testsigma.addons.web.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.sdk.Logger;
+import okhttp3.ConnectionPool;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Shared implementation behind the "PDF Visual Testing For Folder" action, reused by both the
+ * web and windowsAdvanced application-type copies (which otherwise differed only in package,
+ * superclass, and applicationType). Pairs pdf files across two folders, compares them page by
+ * page against the visual-testing API, and builds one consolidated report pdf.
+ */
+public class PdfFolderComparisonEngine {
+
+    // Number of pages compared concurrently per file. The remote visual-comparison API call is
+    // a network round trip and dominates page processing time; performing them one at a time
+    // per page serializes hundreds/thousands of round trips. PDF rendering itself stays
+    // single-threaded (PDFRenderer/PDDocument are not safe for concurrent use).
+    private static final int PAGE_CONCURRENCY = 10;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // Shared, connection-pooled HTTP client reused across every page/file so pages benefit from
+    // HTTP keep-alive instead of paying a fresh TCP+TLS handshake on every single page. Explicit
+    // timeouts matter here: OkHttp's 10s connect/read/write defaults are too short for
+    // multi-megabyte PNG uploads and would otherwise surface as false FAILs.
+    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
+            .connectionPool(new ConnectionPool(32, 5, TimeUnit.MINUTES))
+            .connectTimeout(Duration.ofSeconds(60))
+            .readTimeout(Duration.ofSeconds(120))
+            .writeTimeout(Duration.ofSeconds(120))
+            .callTimeout(Duration.ofSeconds(180))
+            .build();
+
+    private final Logger logger;
+
+    public PdfFolderComparisonEngine(Logger logger) {
+        this.logger = logger;
+    }
+
+    /** Result of comparing every paired pdf file across the two folders. */
+    public static class Outcome {
+        public final int filesPassed;
+        public final int filesFailed;
+        public final String failureDetails;
+        public final String setupError;
+        public final File reportFile;
+
+        Outcome(int filesPassed, int filesFailed, String failureDetails, String setupError, File reportFile) {
+            this.filesPassed = filesPassed;
+            this.filesFailed = filesFailed;
+            this.failureDetails = failureDetails;
+            this.setupError = setupError;
+            this.reportFile = reportFile;
+        }
+    }
+
+    /** Thrown only when the consolidated report pdf itself could not be built/saved. */
+    public static class ReportGenerationException extends RuntimeException {
+        public ReportGenerationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static String buildReportLink(File reportFile) {
+        String url = reportFile.toURI().toString();
+        return String.format("<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
+                url, reportFile.getAbsolutePath());
+    }
+
+    public Outcome compareFolders(String baseFolderPath, String actualFolderPath, String pairingStrategy) {
+        int filesPassed = 0;
+        int filesFailed = 0;
+        StringBuilder failureDetails = new StringBuilder();
+        String setupError = null;
+
+        // Bounded queue + CallerRunsPolicy: once PAGE_CONCURRENCY*2 page-comparisons are queued,
+        // the calling thread runs the next one itself instead of racing ahead of the network
+        // and piling up rendered pages/temp PNGs in memory.
+        ExecutorService pageExecutor = new ThreadPoolExecutor(PAGE_CONCURRENCY, PAGE_CONCURRENCY,
+                60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(PAGE_CONCURRENCY * 2),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+
+        File reportFile;
+        try (PDDocument reportDocument = new PDDocument(IOUtils.createTempFileOnlyStreamCache())) {
+            try {
+                File baseFolder = new File(baseFolderPath);
+                File actualFolder = new File(actualFolderPath);
+
+                if (!baseFolder.isDirectory()) {
+                    setupError = "Base folder does not exist or is not a directory : " + baseFolderPath;
+                } else if (!actualFolder.isDirectory()) {
+                    setupError = "Actual folder does not exist or is not a directory : " + actualFolderPath;
+                } else {
+                    List<String> unmatchedBaseFiles = new ArrayList<>();
+                    logger.info("Pairing files in base folder and actual folder using pairing strategy: " + pairingStrategy);
+                    Map<File, File> pairs = pairFiles(baseFolder, actualFolder, pairingStrategy, unmatchedBaseFiles);
+                    int totalFilePairs = pairs.size();
+                    logger.info(String.format("Found %d matched pdf file pair(s) to compare and %d unmatched" +
+                            " file(s) in the base folder", totalFilePairs, unmatchedBaseFiles.size()));
+
+                    for (String unmatched : unmatchedBaseFiles) {
+                        filesFailed++;
+                        failureDetails.append(unmatched).append(" - no matching file found in actual folder; ");
+                        addMessagePageToReport(reportDocument,
+                                unmatched + " - FAILED (no matching file found in actual folder)");
+                    }
+
+                    int fileIndex = 0;
+                    for (Map.Entry<File, File> entry : pairs.entrySet()) {
+                        fileIndex++;
+                        logger.info(String.format("Iterating file %d/%d : %s", fileIndex, totalFilePairs,
+                                entry.getKey().getName()));
+                        boolean filePassed = compareSingleFile(entry.getKey(), entry.getValue(), fileIndex,
+                                totalFilePairs, reportDocument, failureDetails, pageExecutor);
+                        if (filePassed) {
+                            filesPassed++;
+                        } else {
+                            filesFailed++;
+                        }
+                    }
+                }
+            } catch (OutOfMemoryError oom) {
+                logger.info("OutOfMemoryError while processing base/actual folders : " + ExceptionUtils.getStackTrace(oom));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Visual testing failed due to the" +
+                        " JVM running out of memory (OutOfMemoryError) while processing the folders. Try" +
+                        " increasing the JVM heap size (-Xmx) for the agent, lowering the render DPI, or" +
+                        " processing fewer files per run.";
+            } catch (Exception e) {
+                logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Unexpected error: " + e.getMessage();
+            }
+
+            if (setupError != null) {
+                addMessagePageToReport(reportDocument, setupError);
+            }
+            if (reportDocument.getNumberOfPages() == 0) {
+                addMessagePageToReport(reportDocument, "No pdf files found to compare in the given folders.");
+            }
+
+            reportFile = File.createTempFile("pdf_visual_testing_report_", ".pdf");
+            reportDocument.save(reportFile);
+        } catch (OutOfMemoryError oom) {
+            logger.info("OutOfMemoryError while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(oom));
+            pageExecutor.shutdownNow();
+            throw new ReportGenerationException("Unable to generate the consolidated visual testing report pdf" +
+                    " because the JVM ran out of memory (OutOfMemoryError). Try increasing the JVM heap size" +
+                    " (-Xmx) for the agent or lowering the render DPI.", oom);
+        } catch (Exception e) {
+            logger.info("Exception while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(e));
+            pageExecutor.shutdownNow();
+            throw new ReportGenerationException("Unable to generate the consolidated visual testing report pdf : "
+                    + e.getMessage(), e);
+        } finally {
+            pageExecutor.shutdown();
+            try {
+                pageExecutor.awaitTermination(60, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        return new Outcome(filesPassed, filesFailed, failureDetails.toString(), setupError, reportFile);
+    }
+
+    private Map<File, File> pairFiles(File baseFolder, File actualFolder, String pairingStrategy,
+                                       List<String> unmatchedBaseFiles) {
+        File[] baseFilesArr = baseFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        File[] actualFilesArr = actualFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        List<File> baseFiles = new ArrayList<>(baseFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(baseFilesArr));
+        List<File> actualFiles = new ArrayList<>(actualFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(actualFilesArr));
+        baseFiles.sort(Comparator.comparing(File::getName));
+        actualFiles.sort(Comparator.comparing(File::getName));
+
+        logger.info(String.format("Found %d pdf file(s) in base folder and %d pdf file(s) in actual folder," +
+                " pairing by '%s'", baseFiles.size(), actualFiles.size(), pairingStrategy));
+
+        Map<File, File> pairs = new LinkedHashMap<>();
+        if ("position".equalsIgnoreCase(pairingStrategy)) {
+            int count = Math.min(baseFiles.size(), actualFiles.size());
+            for (int i = 0; i < count; i++) {
+                pairs.put(baseFiles.get(i), actualFiles.get(i));
+            }
+            for (int i = count; i < baseFiles.size(); i++) {
+                unmatchedBaseFiles.add(baseFiles.get(i).getName());
+            }
+        } else {
+            Map<String, File> actualByName = new HashMap<>();
+            for (File f : actualFiles) {
+                actualByName.put(f.getName(), f);
+            }
+            for (File base : baseFiles) {
+                File match = actualByName.get(base.getName());
+                if (match != null) {
+                    pairs.put(base, match);
+                } else {
+                    unmatchedBaseFiles.add(base.getName());
+                }
+            }
+        }
+        return pairs;
+    }
+
+    private boolean compareSingleFile(File basePdf, File actualPdf, int fileIndex, int totalFiles,
+                                       PDDocument reportDocument, StringBuilder failureDetails,
+                                       ExecutorService pageExecutor) {
+        String fileLabel = basePdf.getName();
+        int currentPage = 0;
+        int pagesToCompare = 0;
+        // Each page's rendered comparison image is written to its own temp PNG, keyed by page
+        // number, instead of being appended to reportDocument from the completing task. Pages
+        // are appended to the report in page order, on this single thread, only after every
+        // page task has been awaited below - so reportDocument is never mutated from more than
+        // one thread, and the report always reads in document order regardless of which page's
+        // API call happens to finish first.
+        ConcurrentSkipListMap<Integer, File> orderedPageImages = new ConcurrentSkipListMap<>();
+        AtomicBoolean allPagesPassed = new AtomicBoolean(true);
+        List<Future<Void>> pageFutures = new ArrayList<>();
+        try (PDDocument baseDocument = Loader.loadPDF(basePdf);
+             PDDocument actualDocument = Loader.loadPDF(actualPdf)) {
+            int basePageCount = baseDocument.getNumberOfPages();
+            int actualPageCount = actualDocument.getNumberOfPages();
+            pagesToCompare = Math.min(basePageCount, actualPageCount);
+            int totalPagesToCompare = pagesToCompare;
+            boolean pageCountMismatch = basePageCount != actualPageCount;
+
+            logger.info(String.format("File %d/%d (%s) - %d page(s) to compare (base has %d page(s), actual has" +
+                    " %d page(s))", fileIndex, totalFiles, fileLabel, pagesToCompare, basePageCount, actualPageCount));
+
+            PDFRenderer baseRenderer = new PDFRenderer(baseDocument);
+            PDFRenderer actualRenderer = new PDFRenderer(actualDocument);
+
+            try {
+                for (int page = 1; page <= pagesToCompare; page++) {
+                    currentPage = page;
+                    int pageNumber = page;
+                    logger.info(String.format("File %d/%d (%s) - rendering page %d/%d", fileIndex, totalFiles,
+                            fileLabel, page, pagesToCompare));
+                    BufferedImage baseImage = baseRenderer.renderImageWithDPI(page - 1, 150);
+                    BufferedImage actualImage = actualRenderer.renderImageWithDPI(page - 1, 150);
+
+                    Callable<Void> pageTask = () -> {
+                        try {
+                            File baseTemp = File.createTempFile("base_page_", ".png");
+                            File actualTemp = File.createTempFile("actual_page_", ".png");
+                            try {
+                                ImageIO.write(baseImage, "png", baseTemp);
+                                ImageIO.write(actualImage, "png", actualTemp);
+
+                                boolean pagePassed;
+                                List<Coordinate> diffCoordinates;
+                                try {
+                                    ResponseObject responseObject = performApiCall(baseTemp, actualTemp, pageNumber);
+                                    pagePassed = responseObject.getPer_similar() == 1 && responseObject.getDiff_coordinates().isEmpty();
+                                    diffCoordinates = pagePassed ? Collections.emptyList() : responseObject.getDiff_coordinates();
+                                } catch (Exception apiError) {
+                                    logger.info(String.format("File %d/%d (%s) - page %d - API call failed : %s",
+                                            fileIndex, totalFiles, fileLabel, pageNumber, ExceptionUtils.getStackTrace(apiError)));
+                                    pagePassed = false;
+                                    diffCoordinates = Collections.emptyList();
+                                }
+
+                                String header = String.format("%s - page %d/%d - %s", fileLabel, pageNumber,
+                                        totalPagesToCompare, pagePassed ? "PASS" : "FAIL");
+                                BufferedImage comparisonPage = createComparisonPage(baseImage, actualImage, diffCoordinates, header);
+                                File pageTemp = File.createTempFile("report_page_", ".png");
+                                try {
+                                    ImageIO.write(comparisonPage, "png", pageTemp);
+                                    orderedPageImages.put(pageNumber, pageTemp);
+                                } finally {
+                                    comparisonPage.flush();
+                                }
+
+                                if (!pagePassed) {
+                                    allPagesPassed.set(false);
+                                }
+                            } finally {
+                                baseTemp.delete();
+                                actualTemp.delete();
+                            }
+                        } finally {
+                            baseImage.flush();
+                            actualImage.flush();
+                        }
+                        return null;
+                    };
+                    pageFutures.add(pageExecutor.submit(pageTask));
+                }
+            } finally {
+                // Always await whatever was submitted so far - including when renderImageWithDPI
+                // throws partway through the loop - so that by the time control reaches the
+                // catch blocks below (or the report-appending step further down), no page task
+                // is still running.
+                for (Future<Void> future : pageFutures) {
+                    try {
+                        future.get();
+                    } catch (ExecutionException ee) {
+                        logger.info(String.format("File %d/%d (%s) - a page comparison failed : %s", fileIndex,
+                                totalFiles, fileLabel, ExceptionUtils.getStackTrace(ee.getCause())));
+                        allPagesPassed.set(false);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        allPagesPassed.set(false);
+                    }
+                }
+            }
+
+            appendOrderedPagesToReport(reportDocument, orderedPageImages);
+
+            if (pageCountMismatch) {
+                failureDetails.append(String.format("%s - page count mismatch (base=%d, actual=%d); ",
+                        fileLabel, basePageCount, actualPageCount));
+                addMessagePageToReport(reportDocument, String.format("%s - FAILED (page count mismatch: base has" +
+                        " %d pages, actual has %d pages)", fileLabel, basePageCount, actualPageCount));
+            } else if (!allPagesPassed.get()) {
+                failureDetails.append(fileLabel).append(" - visual differences found; ");
+            }
+            return allPagesPassed.get() && !pageCountMismatch;
+        } catch (OutOfMemoryError oom) {
+            deleteOrderedPages(orderedPageImages);
+            logger.info(String.format("OutOfMemoryError while comparing file %d/%d (%s) at page %d/%d : %s",
+                    fileIndex, totalFiles, fileLabel, currentPage, pagesToCompare, ExceptionUtils.getStackTrace(oom)));
+            String reason = currentPage > 0
+                    ? String.format("ran out of memory (OutOfMemoryError) while rendering/comparing page %d of %d",
+                            currentPage, pagesToCompare)
+                    : "ran out of memory (OutOfMemoryError) before comparison could start";
+            failureDetails.append(fileLabel).append(" - ").append(reason)
+                    .append(" - try increasing the JVM heap size (-Xmx) for the agent or lowering the render DPI; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (" + reason + ")");
+            } catch (IOException | OutOfMemoryError innerError) {
+                logger.info("Exception while adding out-of-memory failure page to report : " + ExceptionUtils.getStackTrace(innerError));
+            }
+            return false;
+        } catch (Exception e) {
+            deleteOrderedPages(orderedPageImages);
+            logger.info("Exception while comparing file " + fileLabel + " : " + ExceptionUtils.getStackTrace(e));
+            failureDetails.append(fileLabel).append(" - error during comparison: ").append(e.getMessage()).append("; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (error during comparison: " + e.getMessage() + ")");
+            } catch (IOException ioException) {
+                logger.info("Exception while adding failure page to report : " + ExceptionUtils.getStackTrace(ioException));
+            }
+            return false;
+        }
+    }
+
+    private void appendOrderedPagesToReport(PDDocument reportDocument, ConcurrentSkipListMap<Integer, File> orderedPageImages)
+            throws IOException {
+        for (File pageTemp : orderedPageImages.values()) {
+            try {
+                BufferedImage pageImage = ImageIO.read(pageTemp);
+                try {
+                    addImagePageToReport(reportDocument, pageImage);
+                } finally {
+                    pageImage.flush();
+                }
+            } finally {
+                pageTemp.delete();
+            }
+        }
+        orderedPageImages.clear();
+    }
+
+    private void deleteOrderedPages(ConcurrentSkipListMap<Integer, File> orderedPageImages) {
+        for (File pageTemp : orderedPageImages.values()) {
+            pageTemp.delete();
+        }
+        orderedPageImages.clear();
+    }
+
+    private BufferedImage createMessagePage(String message) {
+        int width = 1000;
+        int height = 150;
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.PLAIN, 18));
+        g2d.drawString(message, 20, height / 2);
+        g2d.dispose();
+        return image;
+    }
+
+    private BufferedImage createComparisonPage(BufferedImage baseImage, BufferedImage actualImage,
+                                                List<Coordinate> diffCoordinates, String header) {
+        int headerHeight = 40;
+        int width = baseImage.getWidth() + actualImage.getWidth();
+        int height = Math.max(baseImage.getHeight(), actualImage.getHeight()) + headerHeight;
+        BufferedImage page = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = page.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.BOLD, 20));
+        g2d.drawString(header, 10, 28);
+
+        g2d.drawImage(baseImage, 0, headerHeight, null);
+        g2d.drawImage(actualImage, baseImage.getWidth(), headerHeight, null);
+
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
+        g2d.setColor(new Color(255, 0, 0));
+        for (Coordinate coordinate : diffCoordinates) {
+            g2d.fillRect(coordinate.getX(), coordinate.getY() + headerHeight, coordinate.getW(), coordinate.getH());
+            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY() + headerHeight,
+                    coordinate.getW(), coordinate.getH());
+        }
+        g2d.dispose();
+        return page;
+    }
+
+    private void addMessagePageToReport(PDDocument reportDocument, String message) throws IOException {
+        BufferedImage image = createMessagePage(message);
+        try {
+            addImagePageToReport(reportDocument, image);
+        } finally {
+            image.flush();
+        }
+    }
+
+    private void addImagePageToReport(PDDocument reportDocument, BufferedImage image) throws IOException {
+        PDPage pdPage = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
+        reportDocument.addPage(pdPage);
+        PDImageXObject pdImage = LosslessFactory.createFromImage(reportDocument, image);
+        try (PDPageContentStream contentStream = new PDPageContentStream(reportDocument, pdPage)) {
+            contentStream.drawImage(pdImage, 0, 0, image.getWidth(), image.getHeight());
+        }
+    }
+
+    private ResponseObject performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    if (response.body() != null) {
+                        String responseBody = response.body().string();
+                        return mapper.readValue(responseBody, ResponseObject.class);
+                    } else {
+                        throw new RuntimeException(String.format("Visual testing failed at page %s, no response" +
+                                " body present in the visual test response", page));
+                    }
+                } else {
+                    throw new RuntimeException(String.format("Visual testing failed at page %s, error occurred" +
+                            " internally", page));
+                }
+            }
+        } catch (IOException e) {
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page, e);
+        }
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/DecodeBase64.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/DecodeBase64.java
@@ -1,0 +1,82 @@
+package com.testsigma.addons.windowsAdvanced;
+
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Action(actionText = "Convert base64 code base64-data into file with name (Ex:output.pdf) file-name and store " +
+        "filepath in runtime variable variable-name",
+        description = "Converts any type of file's base64 code into that type of file with given name and extension" +
+                " and stores the file path in run time variable",
+        displayName = "Decode Base64 To File",
+        applicationType = ApplicationType.WINDOWS_ADVANCED)
+public class DecodeBase64 extends WindowsAdvancedAction {
+
+    @TestData(reference = "base64-data")
+    private com.testsigma.sdk.TestData base64Data_;
+
+    @TestData(reference = "file-name")
+    private com.testsigma.sdk.TestData fileName_;
+
+    @TestData(reference = "variable-name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData variable_;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    protected Result execute() throws NoSuchElementException {
+        Result result = Result.SUCCESS;
+        String base64Data = base64Data_.getValue().toString();
+        String fileName = fileName_.getValue().toString();
+        String variable = variable_.getValue().toString();
+
+        try {
+            String[] list = fileName.split("\\.");
+            if (list.length == 2) {
+                File tempFile = File.createTempFile(
+                                    list[0], "." + list[1]
+                                );
+                String filePath = tempFile.getAbsolutePath();
+                decodeBase64ToPDF(base64Data, filePath);
+                runTimeData.setKey(variable);
+                runTimeData.setValue(filePath);
+                setSuccessMessage(String.format("Successfully converted the base64 data to the file with" +
+                        " name %s and stored the file path <b>%s</b> in run time variable <b>%s</b>", fileName,
+                        filePath, variable));
+            } else {
+                result = Result.FAILED;
+                setErrorMessage("Invalid file name input, file name format should be in filname.extension format (Ex: output.pdf)");
+            }
+        } catch (RuntimeException e) {
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception occurred: " + ExceptionUtils.getStackTrace(e));
+            result = Result.FAILED;
+            setErrorMessage("Unable to perform the operation");
+        }
+        return result;
+    }
+
+    public void decodeBase64ToPDF(String base64Str, String outputFilePath) {
+        byte[] decodedBytes = Base64.getDecoder().decode(base64Str);
+        try (FileOutputStream fos = new FileOutputStream(outputFilePath)) {
+            fos.write(decodedBytes);
+        } catch (IOException e) {
+            logger.info("Exception occurred while decoding : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to decode the base64 string to given file");
+            throw new RuntimeException("Decoding error");
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/GetThePageCountOfPDF.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/GetThePageCountOfPDF.java
@@ -1,0 +1,67 @@
+package com.testsigma.addons.windowsAdvanced;
+
+import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.RunTimeData;
+import com.testsigma.sdk.annotation.TestData;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openqa.selenium.NoSuchElementException;
+
+import java.io.File;
+
+@Data
+@Action(actionText = "store the page count of the pdf file pdf-file-path in runtime variable variable_name",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis",
+        displayName = "Get The Page Count Of PDF",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        useCustomScreenshot = false)
+public class GetThePageCountOfPDF extends WindowsAdvancedAction {
+    @TestData(reference = "pdf-file-path")
+    private com.testsigma.sdk.TestData pdfFilePath;
+    @TestData(reference = "variable_name", isRuntimeVariable = true)
+    private com.testsigma.sdk.TestData runtimeVariable;
+
+    @RunTimeData
+    private com.testsigma.sdk.RunTimeData runTimeData;
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        com.testsigma.sdk.Result result = com.testsigma.sdk.Result.SUCCESS;
+        PDFUtils pdfUtils = new PDFUtils(logger);
+        String basePdfPath = pdfFilePath.getValue().toString();
+
+        File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+
+        if (!basePDF.getName().endsWith(".pdf")) {
+            setErrorMessage("Unsupported file type give only pdf file as input");
+            throw new RuntimeException("Unsupported file types");
+        }
+
+        if (!basePDF.exists()) {
+            setErrorMessage("Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                    ", please given valid file input");
+            throw new RuntimeException("Base PDF not found");
+        }
+
+        try {
+            logger.info("getting page count of the pdf file");
+            int numberOfPagesInPdf = pdfUtils.getPdfPageCount(basePDF);
+            logger.info("Number of pages in the pdf file: " + numberOfPagesInPdf);
+            runTimeData.setValue(String.valueOf(numberOfPagesInPdf));
+            runTimeData.setKey(runtimeVariable.getValue().toString());
+            setSuccessMessage("Successfully stored the number of pages of a pdf file in runtime variable <b>"
+                    + runTimeData.getKey() + " = " + runTimeData.getValue() + "</b> " +
+                    "\n Screenshot might not be available for this step");
+        } catch (Exception e) {
+            logger.debug("Error creating temp directories and files" + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unexpected Error: " + ExceptionUtils.getStackTrace(e));
+            result = com.testsigma.sdk.Result.FAILED;
+        }
+        return result;
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTesting.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTesting.java
@@ -2,8 +2,8 @@ package com.testsigma.addons.windowsAdvanced;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.testsigma.addons.web.util.Constants;
-import com.testsigma.addons.web.util.Coordinate;
 import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WindowsAdvancedAction;
@@ -12,15 +12,7 @@ import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.TestStepResult;
 import lombok.Data;
 import okhttp3.*;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.EntityBuilder;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -28,12 +20,13 @@ import org.apache.pdfbox.tools.imageio.ImageIOUtil;
 import org.openqa.selenium.NoSuchElementException;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -57,12 +50,6 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
 
-
-    RequestConfig config = RequestConfig.custom()
-            .setSocketTimeout(10 * 60 * 1000)
-            .setConnectionRequestTimeout(60 * 1000)
-            .setConnectTimeout(60 * 1000)
-            .build();
     ObjectMapper mapper = new ObjectMapper();
     ResponseObject responseObject = new ResponseObject();
 
@@ -72,13 +59,14 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
         Result result = Result.SUCCESS;
         String basePdfPath = basePdfPath_.getValue().toString();
         String actualPdfPath = actualPdfPath_.getValue().toString();
+        PDFUtils pdfUtils = new PDFUtils(logger);
 
         int page;
         try {
-            File basePDF = urlToFileConverter("base.pdf", basePdfPath);
-            File actualPDF = urlToFileConverter("actual.pdf", actualPdfPath);
+            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
 
-            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+            if (!basePDF.getName().endsWith(".pdf") || !actualPDF.getName().endsWith(".pdf")) {
                 setErrorMessage("Unsupported file types give only pdf files as input");
                 throw new RuntimeException("Unsupported file types");
             }
@@ -122,8 +110,12 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
             logger.info("No errors in the directories");
             logger.info("Initiating visual testing");
             boolean compareResult = true;
-            BufferedImage combined = null;
 
+            // Each differing page gets its own merged side-by-side image (a fresh buffer per
+            // page, not one buffer overwritten across pages), then all of them are stacked into
+            // a single vertical strip below - otherwise only the last differing page would
+            // survive in the uploaded screenshot, cropped to that page's own dimensions.
+            List<BufferedImage> differingPageImages = new ArrayList<>();
             for (page = 1; page <= actualPdfDirImages.length; page++) {
                 File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
                 File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
@@ -134,7 +126,8 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
                     boolean apiResult = performApiCall(file1, file2, page);
                     if (!apiResult) {
                         compareResult = false;
-                        combined = mergeImagesAndHighlightDifferences(baseImage , actualImage, combined, responseObject.getDiff_coordinates());
+                        differingPageImages.add(pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
+                                null, responseObject.getDiff_coordinates()));
                     }
                 }
             }
@@ -142,16 +135,17 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
 
             // if there are no changes in the pdf, uploading the first page of the actualPdf
             if (compareResult) {
-                boolean uploadS3Result = uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
                 if (!uploadS3Result) {
                     logger.info("Error occurred while uploading combined image to s3, screenshot might not be displayed");
                 }
-                System.out.println("Upload complete.");
+                logger.info("Upload complete.");
                 setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. (Note: Step screenshot contains the image of actual PDF)");
             } else {
-                // uploading the screenshot of the image where we encounter the difference (side-by-side).
+                // uploading the screenshot of every differing page, stacked vertically.
+                BufferedImage combined = stackVertically(differingPageImages);
                 ImageIO.write(combined, "png", combinedImage);
-                boolean uploadS3Result = uploadFile(s3Url, combinedImage.getAbsolutePath());
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
                 if (!uploadS3Result) {
                     logger.info("Error occurred while uploading combined image to S3, screenshot might not be displayed");
                 }
@@ -169,38 +163,37 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
         return result;
     }
 
-
-    public File urlToFileConverter(String fileName, String url) {
-        try {
-            if (url.startsWith("https://") || url.startsWith("http://")) {
-                logger.info("Given is s3 url ...File name:" + fileName);
-                URL urlObject = new URL(url);
-                File tempFile = File.createTempFile(fileName.split("\\.")[0], "." + fileName.split("\\.")[1]);
-                FileUtils.copyURLToFile(urlObject, tempFile);
-                logger.info("Temp file created with name for s3 file" + tempFile.getName() + " at path " + tempFile.getAbsolutePath());
-                return tempFile;
-            } else {
-                logger.info("Given is local file path..");
-                return new File(url);
-            }
-        } catch (Exception e) {
-            setErrorMessage("Unable to access the given pdfs, please check the given inputs.");
-            logger.info("Error while accessing: " + url);
-            throw new RuntimeException("Unable to access pdfs");
+    private BufferedImage stackVertically(List<BufferedImage> images) {
+        int width = 0;
+        int height = 0;
+        for (BufferedImage image : images) {
+            width = Math.max(width, image.getWidth());
+            height += image.getHeight();
         }
+        BufferedImage combined = new BufferedImage(Math.max(width, 1), Math.max(height, 1), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = combined.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, combined.getWidth(), combined.getHeight());
+        int y = 0;
+        for (BufferedImage image : images) {
+            g2d.drawImage(image, 0, y, null);
+            y += image.getHeight();
+        }
+        g2d.dispose();
+        return combined;
     }
 
     public void pdfToImages(String pdfFilePath, String imageOutputDir, String type) {
         try {
             logger.info(String.format("Converting every page in pdf at %s path to image and storing those images" +
                     " in directory %s", pdfFilePath, imageOutputDir));
-            PDDocument document = Loader.loadPDF(new File(pdfFilePath));
-            PDFRenderer pdfRenderer = new PDFRenderer(document);
-            for (int page = 0; page < document.getNumberOfPages(); ++page) {
-                BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300);
-                ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, page + 1), 300);
+            try (PDDocument document = Loader.loadPDF(new File(pdfFilePath))) {
+                PDFRenderer pdfRenderer = new PDFRenderer(document);
+                for (int page = 0; page < document.getNumberOfPages(); ++page) {
+                    BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300);
+                    ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, page + 1), 300);
+                }
             }
-            document.close();
             logger.info("Pdf to image conversion successful for the pdf " + pdfFilePath);
         } catch (IOException e) {
             String message = "Unable to convert pdf into image pages";
@@ -238,97 +231,35 @@ public class PDFVisualTesting extends WindowsAdvancedAction {
                     .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
                     .build();
             logger.info("Making api call to visual server");
-            Response response = client.newCall(request).execute();
-            if (response.isSuccessful()) {
-                logger.info("Response is successful");
-                if (response.body() != null) {
-                    logger.info("Response body received");
-                    String responseBody = response.body().string();
-                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
-                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
-                    logger.info("Deserialized the response body");
-                    double percentage = responseObject.getPer_similar();
-                    logger.info("Percentage similarity: " + percentage * 100);
-                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    logger.info("Response is successful");
+                    if (response.body() != null) {
+                        logger.info("Response body received");
+                        String responseBody = response.body().string();
+                        logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                        responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                        logger.info("Deserialized the response body");
+                        double percentage = responseObject.getPer_similar();
+                        logger.info("Percentage similarity: " + percentage * 100);
+                        return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                    } else {
+                        setErrorMessage(String.format("Visual testing failed at <b>page %s</b> no response body " +
+                                "present in the visual test response", page));
+                        throw new RuntimeException("Visual testing failed with no response body");
+                    }
                 } else {
-                    setErrorMessage(String.format("Visual testing failed at <b>page %s</b> no response body " +
-                            "present in the visual test response", page));
-                    throw new RuntimeException("Visual testing failed with no response body");
+                    setErrorMessage(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                            page));
+                    throw new RuntimeException("Visual testing failed with internal server error");
                 }
-            } else {
-                setErrorMessage(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
-                        page));
-                throw new RuntimeException("Visual testing failed with internal server error");
             }
         } catch (IOException e) {
-
             logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
                     ExceptionUtils.getStackTrace(e)));
             setErrorMessage(String.format("Unable to perform visual testing for : <b>page %s</b>", page));
             throw new RuntimeException("Error occurred while performing visual test at page " + page);
         }
     }
-
-    private boolean uploadFile(String s3SignedURL, String localPath) {
-        logger.debug("s3SignedURL - " + s3SignedURL);
-        logger.debug("localPath - " + localPath);
-        boolean localUrlExists = new File(localPath).exists();
-        if (localUrlExists) {
-            logger.info(String.format("Uploading test asset to storage, presigned-URL:%s, localFilePath:%s", s3SignedURL, localPath));
-            try (CloseableHttpClient httpclient = HttpClients.custom().setDefaultRequestConfig(config).build()) {
-                HttpPut httpPut = new HttpPut(s3SignedURL);
-
-                File file = new File(localPath);
-                HttpEntity entity = EntityBuilder.create().setFile(file).build();
-                httpPut.setEntity(entity);
-                HttpResponse response = httpclient.execute(httpPut);
-                logger.info("Response from s3: " + response.getStatusLine().getStatusCode());
-                logger.info("Upload completed");
-                return true;
-            } catch (Exception e) {
-                logger.info("Exception while uploading custom screenshot to s3: "+ExceptionUtils.getStackTrace(e));
-                return false;
-            }
-        }
-        else {
-            logger.info("Local path does not exist");
-            return false;
-        }
-    }
-
-    private BufferedImage mergeImagesAndHighlightDifferences(BufferedImage baseImage, BufferedImage overlayImage, BufferedImage combined, List<Coordinate> coordinates) {
-        int height = Math.max(baseImage.getHeight(), overlayImage.getHeight());
-        int width = baseImage.getWidth() + overlayImage.getWidth();
-
-        if (combined == null) {
-            combined = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        }
-
-        Graphics2D g2d = combined.createGraphics();
-        g2d.setColor(Color.WHITE); // Optional: Set a background color
-        g2d.fillRect(0, 0, width, height); // Optional: Fill the background
-
-        g2d.drawImage(baseImage, 0, 0, null);
-        g2d.drawImage(overlayImage, baseImage.getWidth(), 0, null);
-
-        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f)); // 0.5f for 50% transparency
-
-        // Set the color for filling rectangles
-        g2d.setColor(new Color(255, 0, 0)); // Red color
-
-        // Iterate over the list of coordinates and fill rectangles
-        for (Coordinate coordinate : coordinates) {
-            g2d.fillRect(coordinate.getX(), coordinate.getY(), coordinate.getW(), coordinate.getH());
-        }
-
-        for (Coordinate coordinate : coordinates) {
-            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY(), coordinate.getW(), coordinate.getH());
-        }
-
-        g2d.dispose();
-
-        return combined;
-    }
-
 
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTesting.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTesting.java
@@ -1,0 +1,334 @@
+package com.testsigma.addons.windowsAdvanced;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.Coordinate;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.TestStepResult;
+import lombok.Data;
+import okhttp3.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.List;
+
+
+@Data
+@Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
+        " same by performing visual analysis",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis",
+        displayName = "PDF Visual Testing",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        useCustomScreenshot = true)
+public class PDFVisualTesting extends WindowsAdvancedAction {
+
+
+    @TestData(reference = "base-pdf-file-path")
+    private com.testsigma.sdk.TestData basePdfPath_;
+
+    @TestData(reference = "actual-pdf-file-path")
+    private com.testsigma.sdk.TestData actualPdfPath_;
+
+    @TestStepResult
+    private com.testsigma.sdk.TestStepResult testStepResult;
+
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+    ObjectMapper mapper = new ObjectMapper();
+    ResponseObject responseObject = new ResponseObject();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+        String basePdfPath = basePdfPath_.getValue().toString();
+        String actualPdfPath = actualPdfPath_.getValue().toString();
+
+        int page;
+        try {
+            File basePDF = urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+                setErrorMessage("Unsupported file types give only pdf files as input");
+                throw new RuntimeException("Unsupported file types");
+            }
+
+            if (!basePDF.exists()) {
+                setErrorMessage("Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input");
+                throw new RuntimeException("Base PDF not found");
+            }
+
+            if (!actualPDF.exists()) {
+                setErrorMessage("Actual PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input");
+                throw new RuntimeException("Actual PDF not found");
+            }
+
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            File combinedImage = File.createTempFile("combined",".png");
+            logger.info("Created.");
+
+
+            logger.info("Converting pages of both pdfs to images");
+            pdfToImages(basePDF.getAbsolutePath(), basePdfDirectoryPath, "input1");
+            pdfToImages(actualPDF.getAbsolutePath(), actualPdfDirectoryPath, "input2");
+            logger.info("Converted both pdf pages into images");
+
+            logger.info("Validating the pages of images at both directories");
+            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
+            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
+            if (basePdfDirImages == null || actualPdfDirImages == null) {
+                setErrorMessage("Unable to retrieve pages from the pdfs, make sure both pdfs are not empty and accessible");
+                throw new RuntimeException("Unable retrieve pages from pdfs");
+            }
+            if (basePdfDirImages.length != actualPdfDirImages.length) {
+                setErrorMessage(String.format("Unequal page counts - pages in base pdf are %s, pages in actual " +
+                        "pdf are %s", basePdfDirImages.length, actualPdfDirImages.length));
+                throw new RuntimeException("Unequal page count");
+            }
+            logger.info("No errors in the directories");
+            logger.info("Initiating visual testing");
+            boolean compareResult = true;
+            BufferedImage combined = null;
+
+            for (page = 1; page <= actualPdfDirImages.length; page++) {
+                File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+                File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+                if (file1.exists() && file2.exists()) {
+                    BufferedImage baseImage = ImageIO.read(file1);
+                    BufferedImage actualImage = ImageIO.read(file2);
+
+                    boolean apiResult = performApiCall(file1, file2, page);
+                    if (!apiResult) {
+                        compareResult = false;
+                        combined = mergeImagesAndHighlightDifferences(baseImage , actualImage, combined, responseObject.getDiff_coordinates());
+                    }
+                }
+            }
+            String s3Url = testStepResult.getScreenshotUrl();
+
+            // if there are no changes in the pdf, uploading the first page of the actualPdf
+            if (compareResult) {
+                boolean uploadS3Result = uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to s3, screenshot might not be displayed");
+                }
+                System.out.println("Upload complete.");
+                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. (Note: Step screenshot contains the image of actual PDF)");
+            } else {
+                // uploading the screenshot of the image where we encounter the difference (side-by-side).
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = uploadFile(s3Url, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to S3, screenshot might not be displayed");
+                }
+                result = Result.FAILED;
+                setErrorMessage("Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results");
+            }
+        } catch (RuntimeException e) {
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation");
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+
+    public File urlToFileConverter(String fileName, String url) {
+        try {
+            if (url.startsWith("https://") || url.startsWith("http://")) {
+                logger.info("Given is s3 url ...File name:" + fileName);
+                URL urlObject = new URL(url);
+                File tempFile = File.createTempFile(fileName.split("\\.")[0], "." + fileName.split("\\.")[1]);
+                FileUtils.copyURLToFile(urlObject, tempFile);
+                logger.info("Temp file created with name for s3 file" + tempFile.getName() + " at path " + tempFile.getAbsolutePath());
+                return tempFile;
+            } else {
+                logger.info("Given is local file path..");
+                return new File(url);
+            }
+        } catch (Exception e) {
+            setErrorMessage("Unable to access the given pdfs, please check the given inputs.");
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access pdfs");
+        }
+    }
+
+    public void pdfToImages(String pdfFilePath, String imageOutputDir, String type) {
+        try {
+            logger.info(String.format("Converting every page in pdf at %s path to image and storing those images" +
+                    " in directory %s", pdfFilePath, imageOutputDir));
+            PDDocument document = Loader.loadPDF(new File(pdfFilePath));
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            for (int page = 0; page < document.getNumberOfPages(); ++page) {
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300);
+                ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, page + 1), 300);
+            }
+            document.close();
+            logger.info("Pdf to image conversion successful for the pdf " + pdfFilePath);
+        } catch (IOException e) {
+            String message = "Unable to convert pdf into image pages";
+            logger.info(String.format("Exception while converting pdf %s into pages: %s", pdfFilePath,
+                    ExceptionUtils.getStackTrace(e)));
+            setErrorMessage(message);
+            throw new RuntimeException(message);
+        }
+    }
+
+    public boolean performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            OkHttpClient client = new OkHttpClient();
+            logger.info("Initiating http client");
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            logger.info("Making api call to visual server");
+            Response response = client.newCall(request).execute();
+            if (response.isSuccessful()) {
+                logger.info("Response is successful");
+                if (response.body() != null) {
+                    logger.info("Response body received");
+                    String responseBody = response.body().string();
+                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                    logger.info("Deserialized the response body");
+                    double percentage = responseObject.getPer_similar();
+                    logger.info("Percentage similarity: " + percentage * 100);
+                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                } else {
+                    setErrorMessage(String.format("Visual testing failed at <b>page %s</b> no response body " +
+                            "present in the visual test response", page));
+                    throw new RuntimeException("Visual testing failed with no response body");
+                }
+            } else {
+                setErrorMessage(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                        page));
+                throw new RuntimeException("Visual testing failed with internal server error");
+            }
+        } catch (IOException e) {
+
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            setErrorMessage(String.format("Unable to perform visual testing for : <b>page %s</b>", page));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page);
+        }
+    }
+
+    private boolean uploadFile(String s3SignedURL, String localPath) {
+        logger.debug("s3SignedURL - " + s3SignedURL);
+        logger.debug("localPath - " + localPath);
+        boolean localUrlExists = new File(localPath).exists();
+        if (localUrlExists) {
+            logger.info(String.format("Uploading test asset to storage, presigned-URL:%s, localFilePath:%s", s3SignedURL, localPath));
+            try (CloseableHttpClient httpclient = HttpClients.custom().setDefaultRequestConfig(config).build()) {
+                HttpPut httpPut = new HttpPut(s3SignedURL);
+
+                File file = new File(localPath);
+                HttpEntity entity = EntityBuilder.create().setFile(file).build();
+                httpPut.setEntity(entity);
+                HttpResponse response = httpclient.execute(httpPut);
+                logger.info("Response from s3: " + response.getStatusLine().getStatusCode());
+                logger.info("Upload completed");
+                return true;
+            } catch (Exception e) {
+                logger.info("Exception while uploading custom screenshot to s3: "+ExceptionUtils.getStackTrace(e));
+                return false;
+            }
+        }
+        else {
+            logger.info("Local path does not exist");
+            return false;
+        }
+    }
+
+    private BufferedImage mergeImagesAndHighlightDifferences(BufferedImage baseImage, BufferedImage overlayImage, BufferedImage combined, List<Coordinate> coordinates) {
+        int height = Math.max(baseImage.getHeight(), overlayImage.getHeight());
+        int width = baseImage.getWidth() + overlayImage.getWidth();
+
+        if (combined == null) {
+            combined = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        }
+
+        Graphics2D g2d = combined.createGraphics();
+        g2d.setColor(Color.WHITE); // Optional: Set a background color
+        g2d.fillRect(0, 0, width, height); // Optional: Fill the background
+
+        g2d.drawImage(baseImage, 0, 0, null);
+        g2d.drawImage(overlayImage, baseImage.getWidth(), 0, null);
+
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f)); // 0.5f for 50% transparency
+
+        // Set the color for filling rectangles
+        g2d.setColor(new Color(255, 0, 0)); // Red color
+
+        // Iterate over the list of coordinates and fill rectangles
+        for (Coordinate coordinate : coordinates) {
+            g2d.fillRect(coordinate.getX(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+        }
+
+        for (Coordinate coordinate : coordinates) {
+            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+        }
+
+        g2d.dispose();
+
+        return combined;
+    }
+
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForFolder.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForFolder.java
@@ -1,55 +1,12 @@
 package com.testsigma.addons.windowsAdvanced;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.testsigma.addons.web.util.Constants;
-import com.testsigma.addons.web.util.Coordinate;
-import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.addons.web.util.PdfFolderComparisonEngine;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WindowsAdvancedAction;
 import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.io.IOUtils;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
-import org.apache.pdfbox.rendering.PDFRenderer;
 import org.openqa.selenium.NoSuchElementException;
-
-import javax.imageio.ImageIO;
-import java.awt.AlphaComposite;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Action(actionText = "Perform visual testing on all pdf files in base folder base-folder-path against the" +
         " pdf files in actual folder actual-folder-path, pairing files by pairing-strategy",
@@ -73,418 +30,42 @@ public class PDFVisualTestingForFolder extends WindowsAdvancedAction {
     @TestData(reference = "pairing-strategy", allowedValues = {"filename", "position"})
     private com.testsigma.sdk.TestData pairingStrategy_;
 
-    // Number of pages compared concurrently per file. The remote visual-comparison API call is
-    // a network round trip and dominates page processing time; performing them one at a time
-    // per page serializes hundreds/thousands of round trips. PDF rendering itself stays
-    // single-threaded (PDFRenderer/PDDocument are not safe for concurrent use).
-    private static final int PAGE_CONCURRENCY = 10;
-
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    // Shared, connection-pooled HTTP client reused across every page/file so pages benefit from
-    // HTTP keep-alive instead of paying a fresh TCP+TLS handshake on every single page.
-    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
-            .connectionPool(new okhttp3.ConnectionPool(32, 5, TimeUnit.MINUTES))
-            .build();
-
     @Override
     public Result execute() throws NoSuchElementException {
-
         logger.info("Initiating execution");
         String baseFolderPath = baseFolderPath_.getValue().toString();
         String actualFolderPath = actualFolderPath_.getValue().toString();
         String pairingStrategy = pairingStrategy_.getValue().toString();
+        logger.info("Base folder path: " + baseFolderPath + ", Actual folder path: " + actualFolderPath +
+                ", Pairing strategy: " + pairingStrategy);
 
-        int filesPassed = 0;
-        int filesFailed = 0;
-        StringBuilder failureDetails = new StringBuilder();
-        String setupError = null;
-
-        // Bounded queue + CallerRunsPolicy: once PAGE_CONCURRENCY*2 page-comparisons are queued,
-        // the calling thread runs the next one itself instead of racing ahead of the network
-        // and piling up rendered pages/temp PNGs in memory.
-        ExecutorService pageExecutor = new ThreadPoolExecutor(PAGE_CONCURRENCY, PAGE_CONCURRENCY,
-                60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(PAGE_CONCURRENCY * 2),
-                new ThreadPoolExecutor.CallerRunsPolicy());
-
-        File reportFile;
-        try (PDDocument reportDocument = new PDDocument(IOUtils.createTempFileOnlyStreamCache())) {
-            try {
-                File baseFolder = new File(baseFolderPath);
-                File actualFolder = new File(actualFolderPath);
-
-                if (!baseFolder.isDirectory()) {
-                    setupError = "Base folder does not exist or is not a directory : " + baseFolderPath;
-                } else if (!actualFolder.isDirectory()) {
-                    setupError = "Actual folder does not exist or is not a directory : " + actualFolderPath;
-                } else {
-                    List<String> unmatchedBaseFiles = new ArrayList<>();
-                    logger.info("Pairing files in base folder and actual folder using pairing strategy : " + pairingStrategy);
-                    Map<File, File> pairs = pairFiles(baseFolder, actualFolder, pairingStrategy, unmatchedBaseFiles);
-                    logger.info("File pairing completed");
-                    int totalFilePairs = pairs.size();
-                    logger.info(String.format("Found %d matched pdf file pair(s) to compare and %d unmatched" +
-                            " file(s) in the base folder", totalFilePairs, unmatchedBaseFiles.size()));
-
-                    for (String unmatched : unmatchedBaseFiles) {
-                        filesFailed++;
-                        failureDetails.append(unmatched).append(" - no matching file found in actual folder; ");
-                        addMessagePageToReport(reportDocument,
-                                unmatched + " - FAILED (no matching file found in actual folder)");
-                    }
-
-                    int fileIndex = 0;
-                    for (Map.Entry<File, File> entry : pairs.entrySet()) {
-                        fileIndex++;
-                        logger.info(String.format("Iterating file %d/%d : %s", fileIndex, totalFilePairs,
-                                entry.getKey().getName()));
-                        boolean filePassed = compareSingleFile(entry.getKey(), entry.getValue(), fileIndex,
-                                totalFilePairs, reportDocument, failureDetails, pageExecutor);
-                        if (filePassed) {
-                            filesPassed++;
-                        } else {
-                            filesFailed++;
-                        }
-                    }
-                }
-            } catch (OutOfMemoryError oom) {
-                logger.info("OutOfMemoryError while processing base/actual folders : " + ExceptionUtils.getStackTrace(oom));
-                setupError = (setupError == null ? "" : setupError + "; ") + "Visual testing failed due to the" +
-                        " JVM running out of memory (OutOfMemoryError) while processing the folders. Try" +
-                        " increasing the JVM heap size (-Xmx) for the agent, lowering the render DPI, or" +
-                        " processing fewer files per run.";
-            } catch (Exception e) {
-                logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-                setupError = (setupError == null ? "" : setupError + "; ") + "Unexpected error: " + e.getMessage();
-            }
-
-            if (setupError != null) {
-                addMessagePageToReport(reportDocument, setupError);
-            }
-            if (reportDocument.getNumberOfPages() == 0) {
-                addMessagePageToReport(reportDocument, "No pdf files found to compare in the given folders.");
-            }
-
-            reportFile = File.createTempFile("pdf_visual_testing_report_", ".pdf");
-            reportDocument.save(reportFile);
-        } catch (OutOfMemoryError oom) {
-            logger.info("OutOfMemoryError while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(oom));
-            setErrorMessage("Unable to generate the consolidated visual testing report pdf because the JVM ran" +
-                    " out of memory (OutOfMemoryError). Try increasing the JVM heap size (-Xmx) for the agent" +
-                    " or lowering the render DPI.");
-            pageExecutor.shutdownNow();
-            return Result.FAILED;
-        } catch (Exception e) {
-            logger.info("Exception while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(e));
-            setErrorMessage("Unable to generate the consolidated visual testing report pdf : " + e.getMessage());
-            pageExecutor.shutdownNow();
-            return Result.FAILED;
-        } finally {
-            pageExecutor.shutdown();
-            try {
-                pageExecutor.awaitTermination(60, TimeUnit.SECONDS);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        String reportLink = buildReportLink(reportFile);
-
-        if (setupError != null) {
-            setErrorMessage(setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+        PdfFolderComparisonEngine.Outcome outcome;
+        try {
+            outcome = new PdfFolderComparisonEngine(logger)
+                    .compareFolders(baseFolderPath, actualFolderPath, pairingStrategy);
+        } catch (PdfFolderComparisonEngine.ReportGenerationException e) {
+            setErrorMessage(e.getMessage());
             return Result.FAILED;
         }
 
-        int totalFiles = filesPassed + filesFailed;
-        if (filesFailed == 0) {
+        String reportLink = PdfFolderComparisonEngine.buildReportLink(outcome.reportFile);
+
+        if (outcome.setupError != null) {
+            setErrorMessage(outcome.setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+            return Result.FAILED;
+        }
+
+        int totalFiles = outcome.filesPassed + outcome.filesFailed;
+        if (outcome.filesFailed == 0) {
             setSuccessMessage(String.format("Visual testing completed for all <b>%d</b> file(s) - <b>%d passed</b>," +
                             " <b>%d failed</b>. Consolidated report: <b>%s</b>",
-                    totalFiles, filesPassed, filesFailed, reportLink));
+                    totalFiles, outcome.filesPassed, outcome.filesFailed, reportLink));
             return Result.SUCCESS;
         } else {
             setErrorMessage(String.format("Visual testing completed for <b>%d</b> file(s) - <b>%d passed</b>," +
                             " <b>%d failed</b>. Consolidated report: <b>%s</b>. Failures: %s",
-                    totalFiles, filesPassed, filesFailed, reportLink, failureDetails));
+                    totalFiles, outcome.filesPassed, outcome.filesFailed, reportLink, outcome.failureDetails));
             return Result.FAILED;
         }
     }
-
-    private String buildReportLink(File reportFile) {
-        String url = reportFile.toURI().toString();
-        return String.format("<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
-                url, reportFile.getAbsolutePath());
-    }
-
-    private Map<File, File> pairFiles(File baseFolder, File actualFolder, String pairingStrategy,
-                                      List<String> unmatchedBaseFiles) {
-        File[] baseFilesArr = baseFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
-        File[] actualFilesArr = actualFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
-        List<File> baseFiles = new ArrayList<>(baseFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(baseFilesArr));
-        List<File> actualFiles = new ArrayList<>(actualFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(actualFilesArr));
-        baseFiles.sort(Comparator.comparing(File::getName));
-        actualFiles.sort(Comparator.comparing(File::getName));
-
-        logger.info(String.format("Found %d pdf file(s) in base folder and %d pdf file(s) in actual folder," +
-                " pairing by '%s'", baseFiles.size(), actualFiles.size(), pairingStrategy));
-
-        Map<File, File> pairs = new LinkedHashMap<>();
-        if ("position".equalsIgnoreCase(pairingStrategy)) {
-            int count = Math.min(baseFiles.size(), actualFiles.size());
-            for (int i = 0; i < count; i++) {
-                pairs.put(baseFiles.get(i), actualFiles.get(i));
-            }
-            for (int i = count; i < baseFiles.size(); i++) {
-                unmatchedBaseFiles.add(baseFiles.get(i).getName());
-            }
-        } else {
-            Map<String, File> actualByName = new HashMap<>();
-            for (File f : actualFiles) {
-                actualByName.put(f.getName(), f);
-            }
-            for (File base : baseFiles) {
-                File match = actualByName.get(base.getName());
-                if (match != null) {
-                    pairs.put(base, match);
-                } else {
-                    unmatchedBaseFiles.add(base.getName());
-                }
-            }
-        }
-        return pairs;
-    }
-
-    private boolean compareSingleFile(File basePdf, File actualPdf, int fileIndex, int totalFiles,
-                                      PDDocument reportDocument, StringBuilder failureDetails,
-                                      ExecutorService pageExecutor) {
-        String fileLabel = basePdf.getName();
-        int currentPage = 0;
-        int pagesToCompare = 0;
-        try (PDDocument baseDocument = Loader.loadPDF(basePdf);
-             PDDocument actualDocument = Loader.loadPDF(actualPdf)) {
-            int basePageCount = baseDocument.getNumberOfPages();
-            int actualPageCount = actualDocument.getNumberOfPages();
-            pagesToCompare = Math.min(basePageCount, actualPageCount);
-            int totalPagesToCompare = pagesToCompare;
-            boolean pageCountMismatch = basePageCount != actualPageCount;
-            AtomicBoolean allPagesPassed = new AtomicBoolean(true);
-
-            logger.info(String.format("File %d/%d (%s) - %d page(s) to compare (base has %d page(s), actual has" +
-                    " %d page(s))", fileIndex, totalFiles, fileLabel, pagesToCompare, basePageCount, actualPageCount));
-
-            // PDFRenderer/PDDocument are not safe for concurrent use, so rendering stays on this
-            // single thread. The remote comparison API call (the actual bottleneck - a network
-            // round trip) and writing the resulting page into the shared report run concurrently.
-            PDFRenderer baseRenderer = new PDFRenderer(baseDocument);
-            PDFRenderer actualRenderer = new PDFRenderer(actualDocument);
-
-            List<Future<Void>> pageFutures = new ArrayList<>(pagesToCompare);
-            for (int page = 1; page <= pagesToCompare; page++) {
-                currentPage = page;
-                int pageNumber = page;
-                logger.info(String.format("File %d/%d (%s) - rendering page %d/%d", fileIndex, totalFiles,
-                        fileLabel, page, pagesToCompare));
-                BufferedImage baseImage = baseRenderer.renderImageWithDPI(page - 1, 150);
-                BufferedImage actualImage = actualRenderer.renderImageWithDPI(page - 1, 150);
-
-                Callable<Void> pageTask = () -> {
-                    try {
-                        File baseTemp = File.createTempFile("base_page_", ".png");
-                        File actualTemp = File.createTempFile("actual_page_", ".png");
-                        try {
-                            ImageIO.write(baseImage, "png", baseTemp);
-                            ImageIO.write(actualImage, "png", actualTemp);
-
-                            boolean pagePassed;
-                            List<Coordinate> diffCoordinates;
-                            try {
-                                ResponseObject responseObject = performApiCall(baseTemp, actualTemp, pageNumber);
-                                pagePassed = responseObject.getPer_similar() == 1 && responseObject.getDiff_coordinates().isEmpty();
-                                diffCoordinates = pagePassed ? Collections.emptyList() : responseObject.getDiff_coordinates();
-                            } catch (Exception apiError) {
-                                logger.info(String.format("File %d/%d (%s) - page %d - API call failed : %s",
-                                        fileIndex, totalFiles, fileLabel, pageNumber, ExceptionUtils.getStackTrace(apiError)));
-                                pagePassed = false;
-                                diffCoordinates = Collections.emptyList();
-                            }
-
-                            String header = String.format("%s - page %d/%d - %s", fileLabel, pageNumber,
-                                    totalPagesToCompare, pagePassed ? "PASS" : "FAIL");
-                            BufferedImage comparisonPage = createComparisonPage(baseImage, actualImage, diffCoordinates, header);
-                            try {
-                                synchronized (reportDocument) {
-                                    addImagePageToReport(reportDocument, comparisonPage);
-                                }
-                            } finally {
-                                comparisonPage.flush();
-                            }
-
-                            if (!pagePassed) {
-                                allPagesPassed.set(false);
-                            }
-                        } finally {
-                            baseTemp.delete();
-                            actualTemp.delete();
-                        }
-                    } finally {
-                        baseImage.flush();
-                        actualImage.flush();
-                    }
-                    return null;
-                };
-                pageFutures.add(pageExecutor.submit(pageTask));
-            }
-
-            for (Future<Void> future : pageFutures) {
-                try {
-                    future.get();
-                } catch (ExecutionException ee) {
-                    logger.info(String.format("File %d/%d (%s) - a page comparison failed : %s", fileIndex,
-                            totalFiles, fileLabel, ExceptionUtils.getStackTrace(ee.getCause())));
-                    allPagesPassed.set(false);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    allPagesPassed.set(false);
-                }
-            }
-
-            if (pageCountMismatch) {
-                failureDetails.append(String.format("%s - page count mismatch (base=%d, actual=%d); ",
-                        fileLabel, basePageCount, actualPageCount));
-                addMessagePageToReport(reportDocument, String.format("%s - FAILED (page count mismatch: base has" +
-                        " %d pages, actual has %d pages)", fileLabel, basePageCount, actualPageCount));
-            } else if (!allPagesPassed.get()) {
-                failureDetails.append(fileLabel).append(" - visual differences found; ");
-            }
-            return allPagesPassed.get() && !pageCountMismatch;
-        } catch (OutOfMemoryError oom) {
-            logger.info(String.format("OutOfMemoryError while comparing file %d/%d (%s) at page %d/%d : %s",
-                    fileIndex, totalFiles, fileLabel, currentPage, pagesToCompare, ExceptionUtils.getStackTrace(oom)));
-            String reason = currentPage > 0
-                    ? String.format("ran out of memory (OutOfMemoryError) while rendering/comparing page %d of %d",
-                            currentPage, pagesToCompare)
-                    : "ran out of memory (OutOfMemoryError) before comparison could start";
-            failureDetails.append(fileLabel).append(" - ").append(reason)
-                    .append(" - try increasing the JVM heap size (-Xmx) for the agent or lowering the render DPI; ");
-            try {
-                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (" + reason + ")");
-            } catch (IOException | OutOfMemoryError innerError) {
-                logger.info("Exception while adding out-of-memory failure page to report : " + ExceptionUtils.getStackTrace(innerError));
-            }
-            return false;
-        } catch (Exception e) {
-            logger.info("Exception while comparing file " + fileLabel + " : " + ExceptionUtils.getStackTrace(e));
-            failureDetails.append(fileLabel).append(" - error during comparison: ").append(e.getMessage()).append("; ");
-            try {
-                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (error during comparison: " + e.getMessage() + ")");
-            } catch (IOException ioException) {
-                logger.info("Exception while adding failure page to report : " + ExceptionUtils.getStackTrace(ioException));
-            }
-            return false;
-        }
-    }
-
-    private BufferedImage createMessagePage(String message) {
-        int width = 1000;
-        int height = 150;
-        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = image.createGraphics();
-        g2d.setColor(Color.WHITE);
-        g2d.fillRect(0, 0, width, height);
-        g2d.setColor(Color.BLACK);
-        g2d.setFont(new Font("SansSerif", Font.PLAIN, 18));
-        g2d.drawString(message, 20, height / 2);
-        g2d.dispose();
-        return image;
-    }
-
-    private BufferedImage createComparisonPage(BufferedImage baseImage, BufferedImage actualImage,
-                                               List<Coordinate> diffCoordinates, String header) {
-        int headerHeight = 40;
-        int width = baseImage.getWidth() + actualImage.getWidth();
-        int height = Math.max(baseImage.getHeight(), actualImage.getHeight()) + headerHeight;
-        BufferedImage page = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = page.createGraphics();
-        g2d.setColor(Color.WHITE);
-        g2d.fillRect(0, 0, width, height);
-        g2d.setColor(Color.BLACK);
-        g2d.setFont(new Font("SansSerif", Font.BOLD, 20));
-        g2d.drawString(header, 10, 28);
-
-        g2d.drawImage(baseImage, 0, headerHeight, null);
-        g2d.drawImage(actualImage, baseImage.getWidth(), headerHeight, null);
-
-        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
-        g2d.setColor(new Color(255, 0, 0));
-        for (Coordinate coordinate : diffCoordinates) {
-            g2d.fillRect(coordinate.getX(), coordinate.getY() + headerHeight, coordinate.getW(), coordinate.getH());
-            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY() + headerHeight,
-                    coordinate.getW(), coordinate.getH());
-        }
-        g2d.dispose();
-        return page;
-    }
-
-    private void addMessagePageToReport(PDDocument reportDocument, String message) throws IOException {
-        BufferedImage image = createMessagePage(message);
-        try {
-            addImagePageToReport(reportDocument, image);
-        } finally {
-            image.flush();
-        }
-    }
-
-    private void addImagePageToReport(PDDocument reportDocument, BufferedImage image) throws IOException {
-        PDPage pdPage = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
-        reportDocument.addPage(pdPage);
-        PDImageXObject pdImage = LosslessFactory.createFromImage(reportDocument, image);
-        try (PDPageContentStream contentStream = new PDPageContentStream(reportDocument, pdPage)) {
-            contentStream.drawImage(pdImage, 0, 0, image.getWidth(), image.getHeight());
-        }
-    }
-
-    public ResponseObject performApiCall(File baseImage, File actualImage, int page) {
-        try {
-            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
-                    actualImage.getAbsolutePath()));
-            MultipartBody.Builder builder = new MultipartBody.Builder()
-                    .setType(MultipartBody.FORM)
-                    .addFormDataPart("action", "COMPARE")
-                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
-                    .addFormDataPart(
-                            "baseImageFile",
-                            baseImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), baseImage)
-                    )
-                    .addFormDataPart(
-                            "actualImageFile",
-                            actualImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), actualImage)
-                    );
-            RequestBody requestBody = builder.build();
-            Request request = new Request.Builder()
-                    .url(Constants.VISUAL_SERVER_API_END_POINT)
-                    .method("POST", requestBody)
-                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
-                    .build();
-            try (Response response = httpClient.newCall(request).execute()) {
-                if (response.isSuccessful()) {
-                    if (response.body() != null) {
-                        String responseBody = response.body().string();
-                        return mapper.readValue(responseBody, ResponseObject.class);
-                    } else {
-                        throw new RuntimeException(String.format("Visual testing failed at page %s, no response" +
-                                " body present in the visual test response", page));
-                    }
-                } else {
-                    throw new RuntimeException(String.format("Visual testing failed at page %s, error occurred" +
-                            " internally", page));
-                }
-            }
-        } catch (IOException e) {
-            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
-                    ExceptionUtils.getStackTrace(e)));
-            throw new RuntimeException("Error occurred while performing visual test at page " + page, e);
-        }
-    }
-
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForFolder.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForFolder.java
@@ -1,0 +1,490 @@
+package com.testsigma.addons.windowsAdvanced;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.Coordinate;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Action(actionText = "Perform visual testing on all pdf files in base folder base-folder-path against the" +
+        " pdf files in actual folder actual-folder-path, pairing files by pairing-strategy",
+        description = "Iterates over every pdf file in the base folder and its corresponding pdf file in the" +
+                " actual folder (paired either by matching filename or by matching sorted position, controlled" +
+                " by pairing-strategy), performs page-by-page visual testing for each pair, and generates a" +
+                " single consolidated pdf report containing side-by-side comparison images for every page" +
+                " checked. The local path of this report is included in both the success and the error" +
+                " message, along with the number of files that passed and the number that failed.",
+        displayName = "PDF Visual Testing For Folder",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        useCustomScreenshot = false)
+public class PDFVisualTestingForFolder extends WindowsAdvancedAction {
+
+    @TestData(reference = "base-folder-path")
+    private com.testsigma.sdk.TestData baseFolderPath_;
+
+    @TestData(reference = "actual-folder-path")
+    private com.testsigma.sdk.TestData actualFolderPath_;
+
+    @TestData(reference = "pairing-strategy", allowedValues = {"filename", "position"})
+    private com.testsigma.sdk.TestData pairingStrategy_;
+
+    // Number of pages compared concurrently per file. The remote visual-comparison API call is
+    // a network round trip and dominates page processing time; performing them one at a time
+    // per page serializes hundreds/thousands of round trips. PDF rendering itself stays
+    // single-threaded (PDFRenderer/PDDocument are not safe for concurrent use).
+    private static final int PAGE_CONCURRENCY = 10;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // Shared, connection-pooled HTTP client reused across every page/file so pages benefit from
+    // HTTP keep-alive instead of paying a fresh TCP+TLS handshake on every single page.
+    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
+            .connectionPool(new okhttp3.ConnectionPool(32, 5, TimeUnit.MINUTES))
+            .build();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+
+        logger.info("Initiating execution");
+        String baseFolderPath = baseFolderPath_.getValue().toString();
+        String actualFolderPath = actualFolderPath_.getValue().toString();
+        String pairingStrategy = pairingStrategy_.getValue().toString();
+
+        int filesPassed = 0;
+        int filesFailed = 0;
+        StringBuilder failureDetails = new StringBuilder();
+        String setupError = null;
+
+        // Bounded queue + CallerRunsPolicy: once PAGE_CONCURRENCY*2 page-comparisons are queued,
+        // the calling thread runs the next one itself instead of racing ahead of the network
+        // and piling up rendered pages/temp PNGs in memory.
+        ExecutorService pageExecutor = new ThreadPoolExecutor(PAGE_CONCURRENCY, PAGE_CONCURRENCY,
+                60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(PAGE_CONCURRENCY * 2),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+
+        File reportFile;
+        try (PDDocument reportDocument = new PDDocument(IOUtils.createTempFileOnlyStreamCache())) {
+            try {
+                File baseFolder = new File(baseFolderPath);
+                File actualFolder = new File(actualFolderPath);
+
+                if (!baseFolder.isDirectory()) {
+                    setupError = "Base folder does not exist or is not a directory : " + baseFolderPath;
+                } else if (!actualFolder.isDirectory()) {
+                    setupError = "Actual folder does not exist or is not a directory : " + actualFolderPath;
+                } else {
+                    List<String> unmatchedBaseFiles = new ArrayList<>();
+                    logger.info("Pairing files in base folder and actual folder using pairing strategy : " + pairingStrategy);
+                    Map<File, File> pairs = pairFiles(baseFolder, actualFolder, pairingStrategy, unmatchedBaseFiles);
+                    logger.info("File pairing completed");
+                    int totalFilePairs = pairs.size();
+                    logger.info(String.format("Found %d matched pdf file pair(s) to compare and %d unmatched" +
+                            " file(s) in the base folder", totalFilePairs, unmatchedBaseFiles.size()));
+
+                    for (String unmatched : unmatchedBaseFiles) {
+                        filesFailed++;
+                        failureDetails.append(unmatched).append(" - no matching file found in actual folder; ");
+                        addMessagePageToReport(reportDocument,
+                                unmatched + " - FAILED (no matching file found in actual folder)");
+                    }
+
+                    int fileIndex = 0;
+                    for (Map.Entry<File, File> entry : pairs.entrySet()) {
+                        fileIndex++;
+                        logger.info(String.format("Iterating file %d/%d : %s", fileIndex, totalFilePairs,
+                                entry.getKey().getName()));
+                        boolean filePassed = compareSingleFile(entry.getKey(), entry.getValue(), fileIndex,
+                                totalFilePairs, reportDocument, failureDetails, pageExecutor);
+                        if (filePassed) {
+                            filesPassed++;
+                        } else {
+                            filesFailed++;
+                        }
+                    }
+                }
+            } catch (OutOfMemoryError oom) {
+                logger.info("OutOfMemoryError while processing base/actual folders : " + ExceptionUtils.getStackTrace(oom));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Visual testing failed due to the" +
+                        " JVM running out of memory (OutOfMemoryError) while processing the folders. Try" +
+                        " increasing the JVM heap size (-Xmx) for the agent, lowering the render DPI, or" +
+                        " processing fewer files per run.";
+            } catch (Exception e) {
+                logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+                setupError = (setupError == null ? "" : setupError + "; ") + "Unexpected error: " + e.getMessage();
+            }
+
+            if (setupError != null) {
+                addMessagePageToReport(reportDocument, setupError);
+            }
+            if (reportDocument.getNumberOfPages() == 0) {
+                addMessagePageToReport(reportDocument, "No pdf files found to compare in the given folders.");
+            }
+
+            reportFile = File.createTempFile("pdf_visual_testing_report_", ".pdf");
+            reportDocument.save(reportFile);
+        } catch (OutOfMemoryError oom) {
+            logger.info("OutOfMemoryError while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(oom));
+            setErrorMessage("Unable to generate the consolidated visual testing report pdf because the JVM ran" +
+                    " out of memory (OutOfMemoryError). Try increasing the JVM heap size (-Xmx) for the agent" +
+                    " or lowering the render DPI.");
+            pageExecutor.shutdownNow();
+            return Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception while building the consolidated report pdf : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to generate the consolidated visual testing report pdf : " + e.getMessage());
+            pageExecutor.shutdownNow();
+            return Result.FAILED;
+        } finally {
+            pageExecutor.shutdown();
+            try {
+                pageExecutor.awaitTermination(60, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        String reportLink = buildReportLink(reportFile);
+
+        if (setupError != null) {
+            setErrorMessage(setupError + ". Consolidated report: <b>" + reportLink + "</b>");
+            return Result.FAILED;
+        }
+
+        int totalFiles = filesPassed + filesFailed;
+        if (filesFailed == 0) {
+            setSuccessMessage(String.format("Visual testing completed for all <b>%d</b> file(s) - <b>%d passed</b>," +
+                            " <b>%d failed</b>. Consolidated report: <b>%s</b>",
+                    totalFiles, filesPassed, filesFailed, reportLink));
+            return Result.SUCCESS;
+        } else {
+            setErrorMessage(String.format("Visual testing completed for <b>%d</b> file(s) - <b>%d passed</b>," +
+                            " <b>%d failed</b>. Consolidated report: <b>%s</b>. Failures: %s",
+                    totalFiles, filesPassed, filesFailed, reportLink, failureDetails));
+            return Result.FAILED;
+        }
+    }
+
+    private String buildReportLink(File reportFile) {
+        String url = reportFile.toURI().toString();
+        return String.format("<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
+                url, reportFile.getAbsolutePath());
+    }
+
+    private Map<File, File> pairFiles(File baseFolder, File actualFolder, String pairingStrategy,
+                                      List<String> unmatchedBaseFiles) {
+        File[] baseFilesArr = baseFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        File[] actualFilesArr = actualFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".pdf"));
+        List<File> baseFiles = new ArrayList<>(baseFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(baseFilesArr));
+        List<File> actualFiles = new ArrayList<>(actualFilesArr == null ? Collections.emptyList() : java.util.Arrays.asList(actualFilesArr));
+        baseFiles.sort(Comparator.comparing(File::getName));
+        actualFiles.sort(Comparator.comparing(File::getName));
+
+        logger.info(String.format("Found %d pdf file(s) in base folder and %d pdf file(s) in actual folder," +
+                " pairing by '%s'", baseFiles.size(), actualFiles.size(), pairingStrategy));
+
+        Map<File, File> pairs = new LinkedHashMap<>();
+        if ("position".equalsIgnoreCase(pairingStrategy)) {
+            int count = Math.min(baseFiles.size(), actualFiles.size());
+            for (int i = 0; i < count; i++) {
+                pairs.put(baseFiles.get(i), actualFiles.get(i));
+            }
+            for (int i = count; i < baseFiles.size(); i++) {
+                unmatchedBaseFiles.add(baseFiles.get(i).getName());
+            }
+        } else {
+            Map<String, File> actualByName = new HashMap<>();
+            for (File f : actualFiles) {
+                actualByName.put(f.getName(), f);
+            }
+            for (File base : baseFiles) {
+                File match = actualByName.get(base.getName());
+                if (match != null) {
+                    pairs.put(base, match);
+                } else {
+                    unmatchedBaseFiles.add(base.getName());
+                }
+            }
+        }
+        return pairs;
+    }
+
+    private boolean compareSingleFile(File basePdf, File actualPdf, int fileIndex, int totalFiles,
+                                      PDDocument reportDocument, StringBuilder failureDetails,
+                                      ExecutorService pageExecutor) {
+        String fileLabel = basePdf.getName();
+        int currentPage = 0;
+        int pagesToCompare = 0;
+        try (PDDocument baseDocument = Loader.loadPDF(basePdf);
+             PDDocument actualDocument = Loader.loadPDF(actualPdf)) {
+            int basePageCount = baseDocument.getNumberOfPages();
+            int actualPageCount = actualDocument.getNumberOfPages();
+            pagesToCompare = Math.min(basePageCount, actualPageCount);
+            int totalPagesToCompare = pagesToCompare;
+            boolean pageCountMismatch = basePageCount != actualPageCount;
+            AtomicBoolean allPagesPassed = new AtomicBoolean(true);
+
+            logger.info(String.format("File %d/%d (%s) - %d page(s) to compare (base has %d page(s), actual has" +
+                    " %d page(s))", fileIndex, totalFiles, fileLabel, pagesToCompare, basePageCount, actualPageCount));
+
+            // PDFRenderer/PDDocument are not safe for concurrent use, so rendering stays on this
+            // single thread. The remote comparison API call (the actual bottleneck - a network
+            // round trip) and writing the resulting page into the shared report run concurrently.
+            PDFRenderer baseRenderer = new PDFRenderer(baseDocument);
+            PDFRenderer actualRenderer = new PDFRenderer(actualDocument);
+
+            List<Future<Void>> pageFutures = new ArrayList<>(pagesToCompare);
+            for (int page = 1; page <= pagesToCompare; page++) {
+                currentPage = page;
+                int pageNumber = page;
+                logger.info(String.format("File %d/%d (%s) - rendering page %d/%d", fileIndex, totalFiles,
+                        fileLabel, page, pagesToCompare));
+                BufferedImage baseImage = baseRenderer.renderImageWithDPI(page - 1, 150);
+                BufferedImage actualImage = actualRenderer.renderImageWithDPI(page - 1, 150);
+
+                Callable<Void> pageTask = () -> {
+                    try {
+                        File baseTemp = File.createTempFile("base_page_", ".png");
+                        File actualTemp = File.createTempFile("actual_page_", ".png");
+                        try {
+                            ImageIO.write(baseImage, "png", baseTemp);
+                            ImageIO.write(actualImage, "png", actualTemp);
+
+                            boolean pagePassed;
+                            List<Coordinate> diffCoordinates;
+                            try {
+                                ResponseObject responseObject = performApiCall(baseTemp, actualTemp, pageNumber);
+                                pagePassed = responseObject.getPer_similar() == 1 && responseObject.getDiff_coordinates().isEmpty();
+                                diffCoordinates = pagePassed ? Collections.emptyList() : responseObject.getDiff_coordinates();
+                            } catch (Exception apiError) {
+                                logger.info(String.format("File %d/%d (%s) - page %d - API call failed : %s",
+                                        fileIndex, totalFiles, fileLabel, pageNumber, ExceptionUtils.getStackTrace(apiError)));
+                                pagePassed = false;
+                                diffCoordinates = Collections.emptyList();
+                            }
+
+                            String header = String.format("%s - page %d/%d - %s", fileLabel, pageNumber,
+                                    totalPagesToCompare, pagePassed ? "PASS" : "FAIL");
+                            BufferedImage comparisonPage = createComparisonPage(baseImage, actualImage, diffCoordinates, header);
+                            try {
+                                synchronized (reportDocument) {
+                                    addImagePageToReport(reportDocument, comparisonPage);
+                                }
+                            } finally {
+                                comparisonPage.flush();
+                            }
+
+                            if (!pagePassed) {
+                                allPagesPassed.set(false);
+                            }
+                        } finally {
+                            baseTemp.delete();
+                            actualTemp.delete();
+                        }
+                    } finally {
+                        baseImage.flush();
+                        actualImage.flush();
+                    }
+                    return null;
+                };
+                pageFutures.add(pageExecutor.submit(pageTask));
+            }
+
+            for (Future<Void> future : pageFutures) {
+                try {
+                    future.get();
+                } catch (ExecutionException ee) {
+                    logger.info(String.format("File %d/%d (%s) - a page comparison failed : %s", fileIndex,
+                            totalFiles, fileLabel, ExceptionUtils.getStackTrace(ee.getCause())));
+                    allPagesPassed.set(false);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    allPagesPassed.set(false);
+                }
+            }
+
+            if (pageCountMismatch) {
+                failureDetails.append(String.format("%s - page count mismatch (base=%d, actual=%d); ",
+                        fileLabel, basePageCount, actualPageCount));
+                addMessagePageToReport(reportDocument, String.format("%s - FAILED (page count mismatch: base has" +
+                        " %d pages, actual has %d pages)", fileLabel, basePageCount, actualPageCount));
+            } else if (!allPagesPassed.get()) {
+                failureDetails.append(fileLabel).append(" - visual differences found; ");
+            }
+            return allPagesPassed.get() && !pageCountMismatch;
+        } catch (OutOfMemoryError oom) {
+            logger.info(String.format("OutOfMemoryError while comparing file %d/%d (%s) at page %d/%d : %s",
+                    fileIndex, totalFiles, fileLabel, currentPage, pagesToCompare, ExceptionUtils.getStackTrace(oom)));
+            String reason = currentPage > 0
+                    ? String.format("ran out of memory (OutOfMemoryError) while rendering/comparing page %d of %d",
+                            currentPage, pagesToCompare)
+                    : "ran out of memory (OutOfMemoryError) before comparison could start";
+            failureDetails.append(fileLabel).append(" - ").append(reason)
+                    .append(" - try increasing the JVM heap size (-Xmx) for the agent or lowering the render DPI; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (" + reason + ")");
+            } catch (IOException | OutOfMemoryError innerError) {
+                logger.info("Exception while adding out-of-memory failure page to report : " + ExceptionUtils.getStackTrace(innerError));
+            }
+            return false;
+        } catch (Exception e) {
+            logger.info("Exception while comparing file " + fileLabel + " : " + ExceptionUtils.getStackTrace(e));
+            failureDetails.append(fileLabel).append(" - error during comparison: ").append(e.getMessage()).append("; ");
+            try {
+                addMessagePageToReport(reportDocument, fileLabel + " - FAILED (error during comparison: " + e.getMessage() + ")");
+            } catch (IOException ioException) {
+                logger.info("Exception while adding failure page to report : " + ExceptionUtils.getStackTrace(ioException));
+            }
+            return false;
+        }
+    }
+
+    private BufferedImage createMessagePage(String message) {
+        int width = 1000;
+        int height = 150;
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.PLAIN, 18));
+        g2d.drawString(message, 20, height / 2);
+        g2d.dispose();
+        return image;
+    }
+
+    private BufferedImage createComparisonPage(BufferedImage baseImage, BufferedImage actualImage,
+                                               List<Coordinate> diffCoordinates, String header) {
+        int headerHeight = 40;
+        int width = baseImage.getWidth() + actualImage.getWidth();
+        int height = Math.max(baseImage.getHeight(), actualImage.getHeight()) + headerHeight;
+        BufferedImage page = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = page.createGraphics();
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(0, 0, width, height);
+        g2d.setColor(Color.BLACK);
+        g2d.setFont(new Font("SansSerif", Font.BOLD, 20));
+        g2d.drawString(header, 10, 28);
+
+        g2d.drawImage(baseImage, 0, headerHeight, null);
+        g2d.drawImage(actualImage, baseImage.getWidth(), headerHeight, null);
+
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
+        g2d.setColor(new Color(255, 0, 0));
+        for (Coordinate coordinate : diffCoordinates) {
+            g2d.fillRect(coordinate.getX(), coordinate.getY() + headerHeight, coordinate.getW(), coordinate.getH());
+            g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY() + headerHeight,
+                    coordinate.getW(), coordinate.getH());
+        }
+        g2d.dispose();
+        return page;
+    }
+
+    private void addMessagePageToReport(PDDocument reportDocument, String message) throws IOException {
+        BufferedImage image = createMessagePage(message);
+        try {
+            addImagePageToReport(reportDocument, image);
+        } finally {
+            image.flush();
+        }
+    }
+
+    private void addImagePageToReport(PDDocument reportDocument, BufferedImage image) throws IOException {
+        PDPage pdPage = new PDPage(new PDRectangle(image.getWidth(), image.getHeight()));
+        reportDocument.addPage(pdPage);
+        PDImageXObject pdImage = LosslessFactory.createFromImage(reportDocument, image);
+        try (PDPageContentStream contentStream = new PDPageContentStream(reportDocument, pdPage)) {
+            contentStream.drawImage(pdImage, 0, 0, image.getWidth(), image.getHeight());
+        }
+    }
+
+    public ResponseObject performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    if (response.body() != null) {
+                        String responseBody = response.body().string();
+                        return mapper.readValue(responseBody, ResponseObject.class);
+                    } else {
+                        throw new RuntimeException(String.format("Visual testing failed at page %s, no response" +
+                                " body present in the visual test response", page));
+                    }
+                } else {
+                    throw new RuntimeException(String.format("Visual testing failed at page %s, error occurred" +
+                            " internally", page));
+                }
+            }
+        } catch (IOException e) {
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page, e);
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPage.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPage.java
@@ -1,9 +1,6 @@
 package com.testsigma.addons.windowsAdvanced;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.testsigma.addons.web.util.Constants;
-import com.testsigma.addons.web.util.ResponseObject;
-import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
+import com.testsigma.addons.windowsAdvanced.util.GivenPageComparisonEngine;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WindowsAdvancedAction;
@@ -11,17 +8,8 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.TestStepResult;
 import lombok.Data;
-import okhttp3.*;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.http.ParseException;
-import org.apache.http.client.config.RequestConfig;
 import org.openqa.selenium.NoSuchElementException;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 
 @Data
 @Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
@@ -45,253 +33,30 @@ public class PDFVisualTestingForGivenPage extends WindowsAdvancedAction {
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
 
-    RequestConfig config = RequestConfig.custom()
-            .setSocketTimeout(10 * 60 * 1000)
-            .setConnectionRequestTimeout(60 * 1000)
-            .setConnectTimeout(60 * 1000)
-            .build();
-    ObjectMapper mapper = new ObjectMapper();
-    ResponseObject responseObject = new ResponseObject();
-
     @Override
     public Result execute() throws NoSuchElementException {
         logger.info("Initiating execution");
-        Result result = Result.SUCCESS;
-        String basePdfPath = basePdfPath_.getValue().toString();
-        String actualPdfPath = actualPdfPath_.getValue().toString();
-        PDFUtils pdfUtils = new PDFUtils(logger);
-
         try {
-            // Use StringBuilder to capture error messages
-            StringBuilder errorMessageBuilder = new StringBuilder();
-            result = checkBaseConditions(basePdfPath, actualPdfPath, pdfUtils, errorMessageBuilder);
-            if (result != Result.SUCCESS) {
-                setErrorMessage(errorMessageBuilder.toString());
-                return result;
+            GivenPageComparisonEngine.Outcome outcome = new GivenPageComparisonEngine(logger).compareGivenPage(
+                    basePdfPath_.getValue().toString(),
+                    actualPdfPath_.getValue().toString(),
+                    pageNumber_.getValue().toString(),
+                    true,
+                    testStepResult.getScreenshotUrl());
+            if (outcome.result == Result.SUCCESS) {
+                setSuccessMessage(outcome.message);
+            } else {
+                setErrorMessage(outcome.message);
             }
-
-            int page = Integer.parseInt(pageNumber_.getValue().toString());
-            result = performVisualTesting(basePdfPath, actualPdfPath, page, pdfUtils, errorMessageBuilder);
-            if (result != Result.SUCCESS) {
-                setErrorMessage(errorMessageBuilder.toString());
-            }
-            setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. " +
-                    "(Note: Step screenshot contains the image of actual PDF)");
+            return outcome.result;
         } catch (RuntimeException e) {
             logger.info("Runtime Exception : " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to perform the operation : " + e.getMessage());
-            result = Result.FAILED;
+            return Result.FAILED;
         } catch (Exception e) {
             logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to perform the operation : " + e.getMessage());
-            result = Result.FAILED;
-        }
-        return result;
-    }
-
-    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, PDFUtils pdfUtils,
-                                       StringBuilder errorMessageBuilder) {
-        try {
-            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
-            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
-
-            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
-                String message = "Unsupported file types give only pdf files as input, screenshot" +
-                        " might not be displayed";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            if (!basePDF.exists()) {
-                String message = "Base PDF does not exist : " + basePDF.getAbsolutePath() +
-                        ", please given valid file input, screenshot might not be displayed";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            if (!actualPDF.exists()) {
-                String message = "Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
-                        ", please given valid file input. (Note: screenshot is not displayed)";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
-            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
-
-            if (basePdfPageCount != actualPdfPageCount) {
-                String message = "Number of pages in the base pdf and actual pdf are not same, " +
-                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
-                        + actualPdfPageCount + "</b>";
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }
-
-            int page = Integer.parseInt(pageNumber_.getValue().toString());
-            if (page > basePdfPageCount) {
-                logger.info(String.format("page = %s, base pdf page count = %s", page, actualPdfPageCount));
-                String message = String.format("given page number is greater than the number of pages in base pdf. " +
-                                "page number = <b>%s</b> and base pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
-                        page, basePdfPageCount);
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }
-        } catch (ParseException e) {
-            String message = "Unsupported input for page-number, please provide a valid integer value " +
-                    "(Note: screenshot is not displayed)";
-            errorMessageBuilder.append(message);
-            return Result.FAILURE;
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation : " + e.getMessage();
-            errorMessageBuilder.append(message);
-            return Result.FAILURE;
-        }
-        return Result.SUCCESS;
-    }
-
-    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page, PDFUtils pdfUtils,
-                                        StringBuilder errorMessageBuilder) {
-        try {
-            logger.info("Creating necessary temp directories and files...");
-            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
-            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
-            File combinedImage = File.createTempFile("combined", ".png");
-            logger.info("Converting pages of both pdfs to images");
-            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
-            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
-            logger.info("Converted both pdf pages into images");
-
-            logger.info("Validating the pages of images at both directories");
-            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
-            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
-            if (basePdfDirImages == null || actualPdfDirImages == null) {
-                String message = "Unable to retrieve pages from the pdfs, make sure both pdfs " +
-                        "are not empty and accessible";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-            logger.info("Initiating visual testing");
-            boolean compareResult = true;
-            BufferedImage combined = null;
-
-            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
-            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
-            if (file1.exists() && file2.exists()) {
-                BufferedImage baseImage = ImageIO.read(file1);
-                BufferedImage actualImage = ImageIO.read(file2);
-
-                boolean apiResult = performApiCall(file1, file2, page, errorMessageBuilder);
-                if (!apiResult) {
-                    compareResult = false;
-                    logger.info("dissimilarities found in the pdfs, creating side-by-side image");
-                    logger.info("responseObject " + responseObject.getDiff_coordinates());
-                    logger.info("responseObject " + responseObject);
-                    combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
-                            combined, responseObject.getDiff_coordinates());
-                    logger.info("Created side-by-side image");
-                }
-            }
-            return uploadScreenshot(compareResult, actualPdfDirImages, combined, combinedImage, errorMessageBuilder);
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation during visual testing: " + e.getMessage();
-            errorMessageBuilder.append(message);
             return Result.FAILED;
         }
     }
-
-    private Result uploadScreenshot(boolean compareResult, File[] actualPdfDirImages, BufferedImage combined,
-                                    File combinedImage, StringBuilder errorMessageBuilder) {
-        try {
-            PDFUtils pdfUtils = new PDFUtils(logger);
-            String s3Url = testStepResult.getScreenshotUrl();
-            if (compareResult) {
-                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
-                if (!uploadS3Result) {
-                    logger.info("Error occurred while uploading combined image to s3," +
-                            " screenshot might not be displayed");
-                }
-                logger.info("Upload complete.");
-                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing." +
-                        " (Note: Step screenshot contains the image of actual PDF)");
-            } else {
-                ImageIO.write(combined, "png", combinedImage);
-                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
-                if (!uploadS3Result) {
-                    logger.debug("Error occurred while uploading combined image to S3," +
-                            " screenshot might not be displayed");
-                }
-                String message = "Comparison failed because visual testing detected dissimilarities," +
-                        " check step screenshot for visual results";
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation during screenshot upload: " + e.getMessage();
-            errorMessageBuilder.append(message);
-            return Result.FAILED;
-        }
-        return Result.SUCCESS;
-    }
-
-    public boolean performApiCall(File baseImage, File actualImage, int page, StringBuilder errorMessageBuilder) {
-        try {
-            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
-                    actualImage.getAbsolutePath()));
-            OkHttpClient client = new OkHttpClient();
-            logger.info("Initiating http client");
-            MultipartBody.Builder builder = new MultipartBody.Builder()
-                    .setType(MultipartBody.FORM)
-                    .addFormDataPart("action", "COMPARE")
-                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
-                    .addFormDataPart(
-                            "baseImageFile",
-                            baseImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), baseImage)
-                    )
-                    .addFormDataPart(
-                            "actualImageFile",
-                            actualImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), actualImage)
-                    );
-            RequestBody requestBody = builder.build();
-            Request request = new Request.Builder()
-                    .url(Constants.VISUAL_SERVER_API_END_POINT)
-                    .method("POST", requestBody)
-                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
-                    .build();
-            logger.info("Making api call to visual server");
-            Response response = client.newCall(request).execute();
-            if (response.isSuccessful()) {
-                logger.info("Response is successful");
-                if (response.body() != null) {
-                    logger.info("Response body received");
-                    String responseBody = response.body().string();
-                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
-                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
-                    logger.info("Deserialized the response body");
-                    double percentage = responseObject.getPer_similar();
-                    logger.info("Percentage similarity: " + percentage * 100);
-                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
-                } else {
-                    errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> no response" +
-                            " body present in the visual test response", page));
-                    throw new RuntimeException("Visual testing failed with no response body");
-                }
-            } else {
-                errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
-                        page));
-                throw new RuntimeException("Visual testing failed with internal server error");
-            }
-        } catch (IOException e) {
-            errorMessageBuilder.append(String.format("Exception occurred while performing visual test at page %s : %s",
-                    page, ExceptionUtils.getStackTrace(e)));
-            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
-                    ExceptionUtils.getStackTrace(e)));
-            throw new RuntimeException("Error occurred while performing visual test at page " + page);
-        }
-    }
-
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPage.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPage.java
@@ -1,0 +1,297 @@
+package com.testsigma.addons.windowsAdvanced;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.TestStepResult;
+import lombok.Data;
+import okhttp3.*;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.ParseException;
+import org.apache.http.client.config.RequestConfig;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Data
+@Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
+        " same for page page-number by performing visual analysis",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis. (indexing starts from 1)",
+        displayName = "PDF Visual Testing For Given Page",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        useCustomScreenshot = true)
+public class PDFVisualTestingForGivenPage extends WindowsAdvancedAction {
+
+    @TestData(reference = "base-pdf-file-path")
+    private com.testsigma.sdk.TestData basePdfPath_;
+
+    @TestData(reference = "actual-pdf-file-path")
+    private com.testsigma.sdk.TestData actualPdfPath_;
+
+    @TestData(reference = "page-number")
+    private com.testsigma.sdk.TestData pageNumber_;
+
+    @TestStepResult
+    private com.testsigma.sdk.TestStepResult testStepResult;
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+    ObjectMapper mapper = new ObjectMapper();
+    ResponseObject responseObject = new ResponseObject();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+        String basePdfPath = basePdfPath_.getValue().toString();
+        String actualPdfPath = actualPdfPath_.getValue().toString();
+        PDFUtils pdfUtils = new PDFUtils(logger);
+
+        try {
+            // Use StringBuilder to capture error messages
+            StringBuilder errorMessageBuilder = new StringBuilder();
+            result = checkBaseConditions(basePdfPath, actualPdfPath, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+                return result;
+            }
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            result = performVisualTesting(basePdfPath, actualPdfPath, page, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+            }
+            setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. " +
+                    "(Note: Step screenshot contains the image of actual PDF)");
+        } catch (RuntimeException e) {
+            logger.info("Runtime Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, PDFUtils pdfUtils,
+                                       StringBuilder errorMessageBuilder) {
+        try {
+            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+                String message = "Unsupported file types give only pdf files as input, screenshot" +
+                        " might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!basePDF.exists()) {
+                String message = "Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input, screenshot might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!actualPDF.exists()) {
+                String message = "Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
+                        ", please given valid file input. (Note: screenshot is not displayed)";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
+            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
+
+            if (basePdfPageCount != actualPdfPageCount) {
+                String message = "Number of pages in the base pdf and actual pdf are not same, " +
+                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
+                        + actualPdfPageCount + "</b>";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            if (page > basePdfPageCount) {
+                logger.info(String.format("page = %s, base pdf page count = %s", page, actualPdfPageCount));
+                String message = String.format("given page number is greater than the number of pages in base pdf. " +
+                                "page number = <b>%s</b> and base pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
+                        page, basePdfPageCount);
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (ParseException e) {
+            String message = "Unsupported input for page-number, please provide a valid integer value " +
+                    "(Note: screenshot is not displayed)";
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation : " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        }
+        return Result.SUCCESS;
+    }
+
+    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page, PDFUtils pdfUtils,
+                                        StringBuilder errorMessageBuilder) {
+        try {
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            File combinedImage = File.createTempFile("combined", ".png");
+            logger.info("Converting pages of both pdfs to images");
+            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
+            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
+            logger.info("Converted both pdf pages into images");
+
+            logger.info("Validating the pages of images at both directories");
+            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
+            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
+            if (basePdfDirImages == null || actualPdfDirImages == null) {
+                String message = "Unable to retrieve pages from the pdfs, make sure both pdfs " +
+                        "are not empty and accessible";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+            logger.info("Initiating visual testing");
+            boolean compareResult = true;
+            BufferedImage combined = null;
+
+            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+            if (file1.exists() && file2.exists()) {
+                BufferedImage baseImage = ImageIO.read(file1);
+                BufferedImage actualImage = ImageIO.read(file2);
+
+                boolean apiResult = performApiCall(file1, file2, page, errorMessageBuilder);
+                if (!apiResult) {
+                    compareResult = false;
+                    logger.info("dissimilarities found in the pdfs, creating side-by-side image");
+                    logger.info("responseObject " + responseObject.getDiff_coordinates());
+                    logger.info("responseObject " + responseObject);
+                    combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
+                            combined, responseObject.getDiff_coordinates());
+                    logger.info("Created side-by-side image");
+                }
+            }
+            return uploadScreenshot(compareResult, actualPdfDirImages, combined, combinedImage, errorMessageBuilder);
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during visual testing: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+    }
+
+    private Result uploadScreenshot(boolean compareResult, File[] actualPdfDirImages, BufferedImage combined,
+                                    File combinedImage, StringBuilder errorMessageBuilder) {
+        try {
+            PDFUtils pdfUtils = new PDFUtils(logger);
+            String s3Url = testStepResult.getScreenshotUrl();
+            if (compareResult) {
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to s3," +
+                            " screenshot might not be displayed");
+                }
+                logger.info("Upload complete.");
+                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing." +
+                        " (Note: Step screenshot contains the image of actual PDF)");
+            } else {
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.debug("Error occurred while uploading combined image to S3," +
+                            " screenshot might not be displayed");
+                }
+                String message = "Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during screenshot upload: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+        return Result.SUCCESS;
+    }
+
+    public boolean performApiCall(File baseImage, File actualImage, int page, StringBuilder errorMessageBuilder) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            OkHttpClient client = new OkHttpClient();
+            logger.info("Initiating http client");
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            logger.info("Making api call to visual server");
+            Response response = client.newCall(request).execute();
+            if (response.isSuccessful()) {
+                logger.info("Response is successful");
+                if (response.body() != null) {
+                    logger.info("Response body received");
+                    String responseBody = response.body().string();
+                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                    logger.info("Deserialized the response body");
+                    double percentage = responseObject.getPer_similar();
+                    logger.info("Percentage similarity: " + percentage * 100);
+                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                } else {
+                    errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> no response" +
+                            " body present in the visual test response", page));
+                    throw new RuntimeException("Visual testing failed with no response body");
+                }
+            } else {
+                errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                        page));
+                throw new RuntimeException("Visual testing failed with internal server error");
+            }
+        } catch (IOException e) {
+            errorMessageBuilder.append(String.format("Exception occurred while performing visual test at page %s : %s",
+                    page, ExceptionUtils.getStackTrace(e)));
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page);
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPageIgnoringPageCount.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPageIgnoringPageCount.java
@@ -1,10 +1,6 @@
 package com.testsigma.addons.windowsAdvanced;
 
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.testsigma.addons.web.util.Constants;
-import com.testsigma.addons.web.util.ResponseObject;
-import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
+import com.testsigma.addons.windowsAdvanced.util.GivenPageComparisonEngine;
 import com.testsigma.sdk.ApplicationType;
 import com.testsigma.sdk.Result;
 import com.testsigma.sdk.WindowsAdvancedAction;
@@ -12,17 +8,8 @@ import com.testsigma.sdk.annotation.Action;
 import com.testsigma.sdk.annotation.TestData;
 import com.testsigma.sdk.annotation.TestStepResult;
 import lombok.Data;
-import okhttp3.*;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.http.ParseException;
-import org.apache.http.client.config.RequestConfig;
 import org.openqa.selenium.NoSuchElementException;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 
 @Data
 @Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
@@ -46,260 +33,30 @@ public class PDFVisualTestingForGivenPageIgnoringPageCount extends WindowsAdvanc
     @TestStepResult
     private com.testsigma.sdk.TestStepResult testStepResult;
 
-    RequestConfig config = RequestConfig.custom()
-            .setSocketTimeout(10 * 60 * 1000)
-            .setConnectionRequestTimeout(60 * 1000)
-            .setConnectTimeout(60 * 1000)
-            .build();
-    ObjectMapper mapper = new ObjectMapper();
-    ResponseObject responseObject = new ResponseObject();
-
     @Override
     public Result execute() throws NoSuchElementException {
         logger.info("Initiating execution");
-        Result result = Result.SUCCESS;
-        String basePdfPath = basePdfPath_.getValue().toString();
-        String actualPdfPath = actualPdfPath_.getValue().toString();
-        PDFUtils pdfUtils = new PDFUtils(logger);
-
         try {
-            // Use StringBuilder to capture error messages
-            StringBuilder errorMessageBuilder = new StringBuilder();
-            result = checkBaseConditions(basePdfPath, actualPdfPath, pdfUtils, errorMessageBuilder);
-            if (result != Result.SUCCESS) {
-                setErrorMessage(errorMessageBuilder.toString());
-                return result;
+            GivenPageComparisonEngine.Outcome outcome = new GivenPageComparisonEngine(logger).compareGivenPage(
+                    basePdfPath_.getValue().toString(),
+                    actualPdfPath_.getValue().toString(),
+                    pageNumber_.getValue().toString(),
+                    false,
+                    testStepResult.getScreenshotUrl());
+            if (outcome.result == Result.SUCCESS) {
+                setSuccessMessage(outcome.message);
+            } else {
+                setErrorMessage(outcome.message);
             }
-
-            int page = Integer.parseInt(pageNumber_.getValue().toString());
-            result = performVisualTesting(basePdfPath, actualPdfPath, page, pdfUtils, errorMessageBuilder);
-            if (result != Result.SUCCESS) {
-                setErrorMessage(errorMessageBuilder.toString());
-            }
-            setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. " +
-                    "(Note: Step screenshot contains the image of actual PDF)");
+            return outcome.result;
         } catch (RuntimeException e) {
             logger.info("Runtime Exception : " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to perform the operation : " + e.getMessage());
-            result = Result.FAILED;
+            return Result.FAILED;
         } catch (Exception e) {
             logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
             setErrorMessage("Unable to perform the operation : " + e.getMessage());
-            result = Result.FAILED;
-        }
-        return result;
-    }
-
-    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, PDFUtils pdfUtils,
-                                       StringBuilder errorMessageBuilder) {
-        try {
-            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
-            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
-
-            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
-                String message = "Unsupported file types give only pdf files as input, screenshot" +
-                        " might not be displayed";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            if (!basePDF.exists()) {
-                String message = "Base PDF does not exist : " + basePDF.getAbsolutePath() +
-                        ", please given valid file input, screenshot might not be displayed";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            if (!actualPDF.exists()) {
-                String message = "Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
-                        ", please given valid file input. (Note: screenshot is not displayed)";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-
-            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
-            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
-
-            /*if (basePdfPageCount != actualPdfPageCount) {
-                String message = "Number of pages in the base pdf and actual pdf are not same, " +
-                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
-                        + actualPdfPageCount + "</b>";
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }*/
-
-            int page = Integer.parseInt(pageNumber_.getValue().toString());
-            if (page > basePdfPageCount ) {
-                logger.info(String.format("page = %s, base pdf page count = %s", page, actualPdfPageCount));
-                String message = String.format("given page number is greater than the number of pages in base pdf. " +
-                                "page number = <b>%s</b> and base pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
-                        page, basePdfPageCount);
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            } else if (page > actualPdfPageCount) {
-                logger.info(String.format("page = %s, actual pdf page count = %s", page, actualPdfPageCount));
-                String message = String.format("given page number is greater than the number of pages in actual pdf. " +
-                                "page number = <b>%s</b> and actual pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
-                        page, actualPdfPageCount);
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }
-        } catch (ParseException e) {
-            String message = "Unsupported input for page-number, please provide a valid integer value " +
-                    "(Note: screenshot is not displayed)";
-            errorMessageBuilder.append(message);
-            return Result.FAILURE;
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation : " + e.getMessage();
-            errorMessageBuilder.append(message);
-            return Result.FAILURE;
-        }
-        return Result.SUCCESS;
-    }
-
-    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page, PDFUtils pdfUtils,
-                                        StringBuilder errorMessageBuilder) {
-        try {
-            logger.info("Creating necessary temp directories and files...");
-            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
-            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
-            File combinedImage = File.createTempFile("combined", ".png");
-            logger.info("Converting pages of both pdfs to images");
-            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
-            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
-            logger.info("Converted both pdf pages into images");
-
-            logger.info("Validating the pages of images at both directories");
-            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
-            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
-            if (basePdfDirImages == null || actualPdfDirImages == null) {
-                String message = "Unable to retrieve pages from the pdfs, make sure both pdfs " +
-                        "are not empty and accessible";
-                errorMessageBuilder.append(message);
-                return Result.FAILURE;
-            }
-            logger.info("Initiating visual testing");
-            boolean compareResult = true;
-            BufferedImage combined = null;
-
-            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
-            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
-            if (file1.exists() && file2.exists()) {
-                BufferedImage baseImage = ImageIO.read(file1);
-                BufferedImage actualImage = ImageIO.read(file2);
-
-                boolean apiResult = performApiCall(file1, file2, page, errorMessageBuilder);
-                if (!apiResult) {
-                    compareResult = false;
-                    logger.info("dissimilarities found in the pdfs, creating side-by-side image");
-                    logger.info("responseObject " + responseObject.getDiff_coordinates());
-                    logger.info("responseObject " + responseObject);
-                    combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
-                            combined, responseObject.getDiff_coordinates());
-                    logger.info("Created side-by-side image");
-                }
-            }
-            return uploadScreenshot(compareResult, actualPdfDirImages, combined, combinedImage, errorMessageBuilder);
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation during visual testing: " + e.getMessage();
-            errorMessageBuilder.append(message);
             return Result.FAILED;
         }
     }
-
-    private Result uploadScreenshot(boolean compareResult, File[] actualPdfDirImages, BufferedImage combined,
-                                    File combinedImage, StringBuilder errorMessageBuilder) {
-        try {
-            PDFUtils pdfUtils = new PDFUtils(logger);
-            String s3Url = testStepResult.getScreenshotUrl();
-            if (compareResult) {
-                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
-                if (!uploadS3Result) {
-                    logger.info("Error occurred while uploading combined image to s3," +
-                            " screenshot might not be displayed");
-                }
-                logger.info("Upload complete.");
-                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing." +
-                        " (Note: Step screenshot contains the image of actual PDF)");
-            } else {
-                ImageIO.write(combined, "png", combinedImage);
-                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
-                if (!uploadS3Result) {
-                    logger.debug("Error occurred while uploading combined image to S3," +
-                            " screenshot might not be displayed");
-                }
-                String message = "Comparison failed because visual testing detected dissimilarities," +
-                        " check step screenshot for visual results";
-                errorMessageBuilder.append(message);
-                return Result.FAILED;
-            }
-        } catch (Exception e) {
-            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
-            String message = "Unable to perform the operation during screenshot upload: " + e.getMessage();
-            errorMessageBuilder.append(message);
-            return Result.FAILED;
-        }
-        return Result.SUCCESS;
-    }
-
-    public boolean performApiCall(File baseImage, File actualImage, int page, StringBuilder errorMessageBuilder) {
-        try {
-            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
-                    actualImage.getAbsolutePath()));
-            OkHttpClient client = new OkHttpClient();
-            logger.info("Initiating http client");
-            MultipartBody.Builder builder = new MultipartBody.Builder()
-                    .setType(MultipartBody.FORM)
-                    .addFormDataPart("action", "COMPARE")
-                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
-                    .addFormDataPart(
-                            "baseImageFile",
-                            baseImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), baseImage)
-                    )
-                    .addFormDataPart(
-                            "actualImageFile",
-                            actualImage.getName(),
-                            RequestBody.create(MediaType.parse("image/png"), actualImage)
-                    );
-            RequestBody requestBody = builder.build();
-            Request request = new Request.Builder()
-                    .url(Constants.VISUAL_SERVER_API_END_POINT)
-                    .method("POST", requestBody)
-                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
-                    .build();
-            logger.info("Making api call to visual server");
-            Response response = client.newCall(request).execute();
-            if (response.isSuccessful()) {
-                logger.info("Response is successful");
-                if (response.body() != null) {
-                    logger.info("Response body received");
-                    String responseBody = response.body().string();
-                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
-                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
-                    logger.info("Deserialized the response body");
-                    double percentage = responseObject.getPer_similar();
-                    logger.info("Percentage similarity: " + percentage * 100);
-                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
-                } else {
-                    errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> no response" +
-                            " body present in the visual test response", page));
-                    throw new RuntimeException("Visual testing failed with no response body");
-                }
-            } else {
-                errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
-                        page));
-                throw new RuntimeException("Visual testing failed with internal server error");
-            }
-        } catch (IOException e) {
-            errorMessageBuilder.append(String.format("Exception occurred while performing visual test at page %s : %s",
-                    page, ExceptionUtils.getStackTrace(e)));
-            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
-                    ExceptionUtils.getStackTrace(e)));
-            throw new RuntimeException("Error occurred while performing visual test at page " + page);
-        }
-    }
-
 }

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPageIgnoringPageCount.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/PDFVisualTestingForGivenPageIgnoringPageCount.java
@@ -1,0 +1,305 @@
+package com.testsigma.addons.windowsAdvanced;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.addons.windowsAdvanced.util.PDFUtils;
+import com.testsigma.sdk.ApplicationType;
+import com.testsigma.sdk.Result;
+import com.testsigma.sdk.WindowsAdvancedAction;
+import com.testsigma.sdk.annotation.Action;
+import com.testsigma.sdk.annotation.TestData;
+import com.testsigma.sdk.annotation.TestStepResult;
+import lombok.Data;
+import okhttp3.*;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.ParseException;
+import org.apache.http.client.config.RequestConfig;
+import org.openqa.selenium.NoSuchElementException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Data
+@Action(actionText = "Verify that the base pdf base-pdf-file-path and the actual pdf actual-pdf-file-path is" +
+        " same for page page-number by performing visual analysis (ignoring page count)",
+        description = "Verifies that the base pdf and the actual pdf is same by performing visual" +
+                " analysis. (indexing starts from 1)",
+        displayName = "PDF Visual Testing For Given Page Ignoring Page Count",
+        applicationType = ApplicationType.WINDOWS_ADVANCED,
+        useCustomScreenshot = true)
+public class PDFVisualTestingForGivenPageIgnoringPageCount extends WindowsAdvancedAction {
+
+    @TestData(reference = "base-pdf-file-path")
+    private com.testsigma.sdk.TestData basePdfPath_;
+
+    @TestData(reference = "actual-pdf-file-path")
+    private com.testsigma.sdk.TestData actualPdfPath_;
+
+    @TestData(reference = "page-number")
+    private com.testsigma.sdk.TestData pageNumber_;
+
+    @TestStepResult
+    private com.testsigma.sdk.TestStepResult testStepResult;
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+    ObjectMapper mapper = new ObjectMapper();
+    ResponseObject responseObject = new ResponseObject();
+
+    @Override
+    public Result execute() throws NoSuchElementException {
+        logger.info("Initiating execution");
+        Result result = Result.SUCCESS;
+        String basePdfPath = basePdfPath_.getValue().toString();
+        String actualPdfPath = actualPdfPath_.getValue().toString();
+        PDFUtils pdfUtils = new PDFUtils(logger);
+
+        try {
+            // Use StringBuilder to capture error messages
+            StringBuilder errorMessageBuilder = new StringBuilder();
+            result = checkBaseConditions(basePdfPath, actualPdfPath, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+                return result;
+            }
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            result = performVisualTesting(basePdfPath, actualPdfPath, page, pdfUtils, errorMessageBuilder);
+            if (result != Result.SUCCESS) {
+                setErrorMessage(errorMessageBuilder.toString());
+            }
+            setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing. " +
+                    "(Note: Step screenshot contains the image of actual PDF)");
+        } catch (RuntimeException e) {
+            logger.info("Runtime Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            setErrorMessage("Unable to perform the operation : " + e.getMessage());
+            result = Result.FAILED;
+        }
+        return result;
+    }
+
+    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, PDFUtils pdfUtils,
+                                       StringBuilder errorMessageBuilder) {
+        try {
+            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") && !actualPDF.getName().endsWith(".pdf")) {
+                String message = "Unsupported file types give only pdf files as input, screenshot" +
+                        " might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!basePDF.exists()) {
+                String message = "Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input, screenshot might not be displayed";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            if (!actualPDF.exists()) {
+                String message = "Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
+                        ", please given valid file input. (Note: screenshot is not displayed)";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+
+            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
+            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
+
+            /*if (basePdfPageCount != actualPdfPageCount) {
+                String message = "Number of pages in the base pdf and actual pdf are not same, " +
+                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
+                        + actualPdfPageCount + "</b>";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }*/
+
+            int page = Integer.parseInt(pageNumber_.getValue().toString());
+            if (page > basePdfPageCount ) {
+                logger.info(String.format("page = %s, base pdf page count = %s", page, actualPdfPageCount));
+                String message = String.format("given page number is greater than the number of pages in base pdf. " +
+                                "page number = <b>%s</b> and base pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
+                        page, basePdfPageCount);
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            } else if (page > actualPdfPageCount) {
+                logger.info(String.format("page = %s, actual pdf page count = %s", page, actualPdfPageCount));
+                String message = String.format("given page number is greater than the number of pages in actual pdf. " +
+                                "page number = <b>%s</b> and actual pdf page count = <b>%s</b>. (Note: screenshot is not displayed)",
+                        page, actualPdfPageCount);
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (ParseException e) {
+            String message = "Unsupported input for page-number, please provide a valid integer value " +
+                    "(Note: screenshot is not displayed)";
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation : " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILURE;
+        }
+        return Result.SUCCESS;
+    }
+
+    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page, PDFUtils pdfUtils,
+                                        StringBuilder errorMessageBuilder) {
+        try {
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            File combinedImage = File.createTempFile("combined", ".png");
+            logger.info("Converting pages of both pdfs to images");
+            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
+            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
+            logger.info("Converted both pdf pages into images");
+
+            logger.info("Validating the pages of images at both directories");
+            File[] basePdfDirImages = new File(basePdfDirectoryPath).listFiles();
+            File[] actualPdfDirImages = new File(actualPdfDirectoryPath).listFiles();
+            if (basePdfDirImages == null || actualPdfDirImages == null) {
+                String message = "Unable to retrieve pages from the pdfs, make sure both pdfs " +
+                        "are not empty and accessible";
+                errorMessageBuilder.append(message);
+                return Result.FAILURE;
+            }
+            logger.info("Initiating visual testing");
+            boolean compareResult = true;
+            BufferedImage combined = null;
+
+            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+            if (file1.exists() && file2.exists()) {
+                BufferedImage baseImage = ImageIO.read(file1);
+                BufferedImage actualImage = ImageIO.read(file2);
+
+                boolean apiResult = performApiCall(file1, file2, page, errorMessageBuilder);
+                if (!apiResult) {
+                    compareResult = false;
+                    logger.info("dissimilarities found in the pdfs, creating side-by-side image");
+                    logger.info("responseObject " + responseObject.getDiff_coordinates());
+                    logger.info("responseObject " + responseObject);
+                    combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
+                            combined, responseObject.getDiff_coordinates());
+                    logger.info("Created side-by-side image");
+                }
+            }
+            return uploadScreenshot(compareResult, actualPdfDirImages, combined, combinedImage, errorMessageBuilder);
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during visual testing: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+    }
+
+    private Result uploadScreenshot(boolean compareResult, File[] actualPdfDirImages, BufferedImage combined,
+                                    File combinedImage, StringBuilder errorMessageBuilder) {
+        try {
+            PDFUtils pdfUtils = new PDFUtils(logger);
+            String s3Url = testStepResult.getScreenshotUrl();
+            if (compareResult) {
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, actualPdfDirImages[0].getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading combined image to s3," +
+                            " screenshot might not be displayed");
+                }
+                logger.info("Upload complete.");
+                setSuccessMessage("Successfully verified that the base pdf and actual pdf is same by visual testing." +
+                        " (Note: Step screenshot contains the image of actual PDF)");
+            } else {
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = pdfUtils.uploadFile(s3Url, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.debug("Error occurred while uploading combined image to S3," +
+                            " screenshot might not be displayed");
+                }
+                String message = "Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results";
+                errorMessageBuilder.append(message);
+                return Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            String message = "Unable to perform the operation during screenshot upload: " + e.getMessage();
+            errorMessageBuilder.append(message);
+            return Result.FAILED;
+        }
+        return Result.SUCCESS;
+    }
+
+    public boolean performApiCall(File baseImage, File actualImage, int page, StringBuilder errorMessageBuilder) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            OkHttpClient client = new OkHttpClient();
+            logger.info("Initiating http client");
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            RequestBody requestBody = builder.build();
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            logger.info("Making api call to visual server");
+            Response response = client.newCall(request).execute();
+            if (response.isSuccessful()) {
+                logger.info("Response is successful");
+                if (response.body() != null) {
+                    logger.info("Response body received");
+                    String responseBody = response.body().string();
+                    logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                    responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                    logger.info("Deserialized the response body");
+                    double percentage = responseObject.getPer_similar();
+                    logger.info("Percentage similarity: " + percentage * 100);
+                    return percentage == 1 && responseObject.getDiff_coordinates().isEmpty();
+                } else {
+                    errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> no response" +
+                            " body present in the visual test response", page));
+                    throw new RuntimeException("Visual testing failed with no response body");
+                }
+            } else {
+                errorMessageBuilder.append(String.format("Visual testing failed at <b>page %s</b> error occurred internally",
+                        page));
+                throw new RuntimeException("Visual testing failed with internal server error");
+            }
+        } catch (IOException e) {
+            errorMessageBuilder.append(String.format("Exception occurred while performing visual test at page %s : %s",
+                    page, ExceptionUtils.getStackTrace(e)));
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException("Error occurred while performing visual test at page " + page);
+        }
+    }
+
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/GivenPageComparisonEngine.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/GivenPageComparisonEngine.java
@@ -1,0 +1,276 @@
+package com.testsigma.addons.windowsAdvanced.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.testsigma.addons.web.util.Constants;
+import com.testsigma.addons.web.util.ResponseObject;
+import com.testsigma.sdk.Logger;
+import com.testsigma.sdk.Result;
+import okhttp3.ConnectionPool;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared implementation behind "PDF Visual Testing For Given Page" and its "...Ignoring Page
+ * Count" counterpart, which otherwise differed only in whether a base/actual page-count mismatch
+ * is treated as an immediate failure. {@code enforcePageCountMatch} carries that one difference;
+ * every other action stays a thin execute() wrapper around this engine.
+ */
+public class GivenPageComparisonEngine {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final OkHttpClient httpClient = new OkHttpClient.Builder()
+            .connectionPool(new ConnectionPool(8, 5, TimeUnit.MINUTES))
+            .connectTimeout(Duration.ofSeconds(60))
+            .readTimeout(Duration.ofSeconds(120))
+            .writeTimeout(Duration.ofSeconds(120))
+            .callTimeout(Duration.ofSeconds(180))
+            .build();
+
+    private final Logger logger;
+    private final PDFUtils pdfUtils;
+
+    public GivenPageComparisonEngine(Logger logger) {
+        this.logger = logger;
+        this.pdfUtils = new PDFUtils(logger);
+    }
+
+    public static class Outcome {
+        public final Result result;
+        public final String message;
+
+        Outcome(Result result, String message) {
+            this.result = result;
+            this.message = message;
+        }
+    }
+
+    public Outcome compareGivenPage(String basePdfPath, String actualPdfPath, String pageNumberRaw,
+                                     boolean enforcePageCountMatch, String screenshotUploadUrl) {
+        int page;
+        try {
+            page = Integer.parseInt(pageNumberRaw);
+        } catch (NumberFormatException e) {
+            return new Outcome(Result.FAILURE, "Unsupported input for page-number, please provide a valid" +
+                    " integer value (Note: screenshot is not displayed)");
+        }
+        if (page < 1) {
+            return new Outcome(Result.FAILURE, "page-number must be 1 or greater, given value = <b>" + page +
+                    "</b> (Note: screenshot is not displayed)");
+        }
+
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        Result conditionResult = checkBaseConditions(basePdfPath, actualPdfPath, page, enforcePageCountMatch,
+                errorMessageBuilder);
+        if (conditionResult != Result.SUCCESS) {
+            return new Outcome(conditionResult, errorMessageBuilder.toString());
+        }
+
+        Result visualResult = performVisualTesting(basePdfPath, actualPdfPath, page, screenshotUploadUrl,
+                errorMessageBuilder);
+        if (visualResult != Result.SUCCESS) {
+            return new Outcome(visualResult, errorMessageBuilder.toString());
+        }
+        return new Outcome(Result.SUCCESS, "Successfully verified that the base pdf and actual pdf is same by" +
+                " visual testing. (Note: Step screenshot contains the image of actual PDF)");
+    }
+
+    private Result checkBaseConditions(String basePdfPath, String actualPdfPath, int page,
+                                        boolean enforcePageCountMatch, StringBuilder errorMessageBuilder) {
+        try {
+            File basePDF = pdfUtils.urlToFileConverter("base.pdf", basePdfPath);
+            File actualPDF = pdfUtils.urlToFileConverter("actual.pdf", actualPdfPath);
+
+            if (!basePDF.getName().endsWith(".pdf") || !actualPDF.getName().endsWith(".pdf")) {
+                errorMessageBuilder.append("Unsupported file types give only pdf files as input, screenshot" +
+                        " might not be displayed");
+                return Result.FAILURE;
+            }
+
+            if (!basePDF.exists()) {
+                errorMessageBuilder.append("Base PDF does not exist : " + basePDF.getAbsolutePath() +
+                        ", please given valid file input, screenshot might not be displayed");
+                return Result.FAILURE;
+            }
+
+            if (!actualPDF.exists()) {
+                errorMessageBuilder.append("Actual PDF does not exist : " + actualPDF.getAbsolutePath() +
+                        ", please given valid file input. (Note: screenshot is not displayed)");
+                return Result.FAILURE;
+            }
+
+            int basePdfPageCount = pdfUtils.getPdfPageCount(basePDF);
+            int actualPdfPageCount = pdfUtils.getPdfPageCount(actualPDF);
+
+            if (enforcePageCountMatch && basePdfPageCount != actualPdfPageCount) {
+                errorMessageBuilder.append("Number of pages in the base pdf and actual pdf are not same, " +
+                        "Base pdf page count = <b>" + basePdfPageCount + "</b>, Actual pdf page count = <b>"
+                        + actualPdfPageCount + "</b>");
+                return Result.FAILED;
+            }
+
+            if (page > basePdfPageCount) {
+                logger.info(String.format("page = %s, base pdf page count = %s", page, basePdfPageCount));
+                errorMessageBuilder.append(String.format("given page number is greater than the number of pages" +
+                                " in base pdf. page number = <b>%s</b> and base pdf page count = <b>%s</b>." +
+                                " (Note: screenshot is not displayed)", page, basePdfPageCount));
+                return Result.FAILED;
+            }
+            if (page > actualPdfPageCount) {
+                logger.info(String.format("page = %s, actual pdf page count = %s", page, actualPdfPageCount));
+                errorMessageBuilder.append(String.format("given page number is greater than the number of pages" +
+                                " in actual pdf. page number = <b>%s</b> and actual pdf page count = <b>%s</b>." +
+                                " (Note: screenshot is not displayed)", page, actualPdfPageCount));
+                return Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            errorMessageBuilder.append("Unable to perform the operation : " + e.getMessage());
+            return Result.FAILURE;
+        }
+        return Result.SUCCESS;
+    }
+
+    private Result performVisualTesting(String basePdfPath, String actualPdfPath, int page,
+                                         String screenshotUploadUrl, StringBuilder errorMessageBuilder) {
+        try {
+            logger.info("Creating necessary temp directories and files...");
+            String basePdfDirectoryPath = String.valueOf(Files.createTempDirectory("basePdfDirectory"));
+            String actualPdfDirectoryPath = String.valueOf(Files.createTempDirectory("actualPdfDirectory"));
+            logger.info("Converting pages of both pdfs to images");
+            pdfUtils.pdfToImage(basePdfPath, basePdfDirectoryPath, "input1", page);
+            pdfUtils.pdfToImage(actualPdfPath, actualPdfDirectoryPath, "input2", page);
+            logger.info("Converted both pdf pages into images");
+
+            File file1 = new File(basePdfDirectoryPath + File.separator + "input1_page_" + page + ".png");
+            File file2 = new File(actualPdfDirectoryPath + File.separator + "input2_page_" + page + ".png");
+            if (!file1.exists() || !file2.exists()) {
+                errorMessageBuilder.append(String.format("Unable to render page %d from the given pdfs." +
+                        " (Note: screenshot is not displayed)", page));
+                return Result.FAILED;
+            }
+
+            BufferedImage baseImage = ImageIO.read(file1);
+            BufferedImage actualImage = ImageIO.read(file2);
+
+            ApiCallResult apiCallResult = performApiCall(file1, file2, page);
+            if (apiCallResult.responseObject == null) {
+                errorMessageBuilder.append(apiCallResult.errorMessage);
+                return Result.FAILED;
+            }
+
+            boolean pagesMatch = apiCallResult.responseObject.getPer_similar() == 1
+                    && apiCallResult.responseObject.getDiff_coordinates().isEmpty();
+
+            if (pagesMatch) {
+                return uploadScreenshot(true, file2, null, screenshotUploadUrl, errorMessageBuilder);
+            } else {
+                logger.info("dissimilarities found in the pdfs, creating side-by-side image");
+                BufferedImage combined = pdfUtils.mergeImagesAndHighlightDifferences(baseImage, actualImage,
+                        null, apiCallResult.responseObject.getDiff_coordinates());
+                return uploadScreenshot(false, file2, combined, screenshotUploadUrl, errorMessageBuilder);
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            errorMessageBuilder.append("Unable to perform the operation during visual testing: " + e.getMessage());
+            return Result.FAILED;
+        }
+    }
+
+    private Result uploadScreenshot(boolean pagesMatch, File actualPageImage, BufferedImage combined,
+                                      String screenshotUploadUrl, StringBuilder errorMessageBuilder) {
+        try {
+            if (pagesMatch) {
+                boolean uploadS3Result = pdfUtils.uploadFile(screenshotUploadUrl, actualPageImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.info("Error occurred while uploading screenshot to s3, screenshot might not be displayed");
+                }
+                return Result.SUCCESS;
+            } else {
+                File combinedImage = File.createTempFile("combined", ".png");
+                ImageIO.write(combined, "png", combinedImage);
+                boolean uploadS3Result = pdfUtils.uploadFile(screenshotUploadUrl, combinedImage.getAbsolutePath());
+                if (!uploadS3Result) {
+                    logger.debug("Error occurred while uploading combined image to S3, screenshot might not be displayed");
+                }
+                errorMessageBuilder.append("Comparison failed because visual testing detected dissimilarities," +
+                        " check step screenshot for visual results");
+                return Result.FAILED;
+            }
+        } catch (Exception e) {
+            logger.info("Exception : " + ExceptionUtils.getStackTrace(e));
+            errorMessageBuilder.append("Unable to perform the operation during screenshot upload: " + e.getMessage());
+            return Result.FAILED;
+        }
+    }
+
+    private static class ApiCallResult {
+        final ResponseObject responseObject;
+        final String errorMessage;
+
+        ApiCallResult(ResponseObject responseObject, String errorMessage) {
+            this.responseObject = responseObject;
+            this.errorMessage = errorMessage;
+        }
+    }
+
+    private ApiCallResult performApiCall(File baseImage, File actualImage, int page) {
+        try {
+            logger.info(String.format("Performing visual testing for %s and %s", baseImage.getAbsolutePath(),
+                    actualImage.getAbsolutePath()));
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("action", "COMPARE")
+                    .addFormDataPart("scalingType", "BASE_IMAGE_SCALING")
+                    .addFormDataPart(
+                            "baseImageFile",
+                            baseImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), baseImage)
+                    )
+                    .addFormDataPart(
+                            "actualImageFile",
+                            actualImage.getName(),
+                            RequestBody.create(MediaType.parse("image/png"), actualImage)
+                    );
+            Request request = new Request.Builder()
+                    .url(Constants.VISUAL_SERVER_API_END_POINT)
+                    .method("POST", builder.build())
+                    .addHeader("Authorization", "Bearer " + Constants.API_TOKEN)
+                    .build();
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    if (response.body() != null) {
+                        String responseBody = response.body().string();
+                        logger.info(String.format("Response body for page %s testing: %s", page, responseBody));
+                        ResponseObject responseObject = mapper.readValue(responseBody, ResponseObject.class);
+                        return new ApiCallResult(responseObject, null);
+                    } else {
+                        return new ApiCallResult(null, String.format("Visual testing failed at <b>page %s</b>" +
+                                " no response body present in the visual test response", page));
+                    }
+                } else {
+                    return new ApiCallResult(null, String.format("Visual testing failed at <b>page %s</b> error" +
+                            " occurred internally", page));
+                }
+            }
+        } catch (IOException e) {
+            logger.info(String.format("Exception occurred while performing visual test at page %s : %s", page,
+                    ExceptionUtils.getStackTrace(e)));
+            return new ApiCallResult(null, String.format("Exception occurred while performing visual test at" +
+                    " page %s : %s", page, e.getMessage()));
+        }
+    }
+}

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/PDFUtils.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/PDFUtils.java
@@ -74,7 +74,13 @@ public class PDFUtils {
                 HttpEntity entity = EntityBuilder.create().setFile(file).build();
                 httpPut.setEntity(entity);
                 HttpResponse response = httpclient.execute(httpPut);
-                logger.info("Upload completed");
+                int statusCode = response.getStatusLine().getStatusCode();
+                org.apache.http.util.EntityUtils.consumeQuietly(response.getEntity());
+                if (statusCode < 200 || statusCode >= 300) {
+                    logger.info("Upload failed with status code: " + statusCode);
+                    return false;
+                }
+                logger.info("Upload completed with status code: " + statusCode);
                 return true;
             } catch (Exception e) {
                 logger.info("Exception while uploading custom screenshot to s3: " + ExceptionUtils.getStackTrace(e));
@@ -127,42 +133,39 @@ public class PDFUtils {
     }
 
     public int getPdfPageCount(File pdfFile) {
-        try {
-            PDDocument document = Loader.loadPDF(pdfFile);
-            int numberOfPagesInPdf = document.getNumberOfPages();
-            document.close();
-            return numberOfPagesInPdf;
+        try (PDDocument document = Loader.loadPDF(pdfFile)) {
+            return document.getNumberOfPages();
         } catch (IOException e) {
             logger.info("Exception while getting the number of pages in the pdf: " + ExceptionUtils.getStackTrace(e));
-            return -1;
+            throw new RuntimeException("Unable to read the pdf " + pdfFile.getName()
+                    + ", make sure it is a valid and non-encrypted pdf file.", e);
         }
     }
 
     public void pdfToImage(String pdfFilePath, String imageOutputDir, String type, int index) {
+        File pdfFile = null;
+        boolean isTempDownload = false;
         try {
             logger.info(String.format("Converting page %d in pdf to image and storing in directory %s",
                     index, imageOutputDir));
 
-            File pdfFile;
             if (pdfFilePath.startsWith("http://") || pdfFilePath.startsWith("https://")) {
                 String tempFileName = "temp_" + System.currentTimeMillis() + ".pdf";
                 pdfFile = downloadFromUrl(pdfFilePath, tempFileName);
+                isTempDownload = true;
                 logger.info("Downloaded S3 URL to temporary file: " + pdfFile.getAbsolutePath());
             } else {
                 pdfFile = new File(pdfFilePath);
             }
 
-            PDDocument document = Loader.loadPDF(pdfFile);
-            PDFRenderer pdfRenderer = new PDFRenderer(document);
-            BufferedImage bim = pdfRenderer.renderImageWithDPI(index - 1, 300);
-            ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, index), 300);
-            document.close();
-
-            if (pdfFilePath.startsWith("http")) {
-                boolean deleted = pdfFile.delete();
-                if (deleted) {
-                    logger.info("Temporary PDF file deleted successfully");
+            try (PDDocument document = Loader.loadPDF(pdfFile)) {
+                if (index < 1 || index > document.getNumberOfPages()) {
+                    throw new RuntimeException(String.format("Requested page %d is outside the pdf page range 1-%d",
+                            index, document.getNumberOfPages()));
                 }
+                PDFRenderer pdfRenderer = new PDFRenderer(document);
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(index - 1, 300);
+                ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, index), 300);
             }
 
             logger.info("Pdf to image conversion successful for page " + index);
@@ -171,6 +174,10 @@ public class PDFUtils {
             logger.info(String.format("Exception while converting pdf %s into pages: %s", pdfFilePath,
                     ExceptionUtils.getStackTrace(e)));
             throw new RuntimeException(message);
+        } finally {
+            if (isTempDownload && pdfFile != null && pdfFile.delete()) {
+                logger.info("Temporary PDF file deleted successfully");
+            }
         }
     }
 

--- a/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/PDFUtils.java
+++ b/pdf_visual_testing/src/main/java/com/testsigma/addons/windowsAdvanced/util/PDFUtils.java
@@ -1,0 +1,186 @@
+package com.testsigma.addons.windowsAdvanced.util;
+
+import com.testsigma.sdk.Logger;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.tools.imageio.ImageIOUtil;
+
+import com.testsigma.addons.web.util.Coordinate;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+public class PDFUtils {
+    Logger logger;
+
+    public PDFUtils(Logger logger) {
+        this.logger = logger;
+    }
+
+    RequestConfig config = RequestConfig.custom()
+            .setSocketTimeout(10 * 60 * 1000)
+            .setConnectionRequestTimeout(60 * 1000)
+            .setConnectTimeout(60 * 1000)
+            .build();
+
+    public File urlToFileConverter(String fileName, String url) {
+        try {
+            if (url.startsWith("https://") || url.startsWith("http://")) {
+                logger.info("Given is s3 url ...File name:" + fileName);
+                URL urlObject = new URL(url);
+                File tempFile = File.createTempFile(fileName.split("\\.")[0], "."
+                        + fileName.split("\\.")[1]);
+                FileUtils.copyURLToFile(urlObject, tempFile);
+                logger.info("Temp file created with name for s3 file" + tempFile.getName()
+                        + " at path " + tempFile.getAbsolutePath());
+                return tempFile;
+            } else {
+                logger.info("Given is local file path, reading it directly from local machine..");
+                return new File(url);
+            }
+        } catch (Exception e) {
+            logger.info("Error while accessing: " + url);
+            throw new RuntimeException("Unable to access the given pdfs, please check the given inputs.");
+        }
+    }
+
+    public boolean uploadFile(String s3SignedURL, String localPath) {
+        logger.debug("s3SignedURL - " + s3SignedURL);
+        logger.debug("localPath - " + localPath);
+        boolean localUrlExists = new File(localPath).exists();
+        if (localUrlExists) {
+            logger.info(String.format("Uploading test asset to storage, presigned-URL:%s, localFilePath:%s", s3SignedURL, localPath));
+            try (CloseableHttpClient httpclient = HttpClients.custom().setDefaultRequestConfig(config).build()) {
+                HttpPut httpPut = new HttpPut(s3SignedURL);
+
+                File file = new File(localPath);
+                HttpEntity entity = EntityBuilder.create().setFile(file).build();
+                httpPut.setEntity(entity);
+                HttpResponse response = httpclient.execute(httpPut);
+                logger.info("Upload completed");
+                return true;
+            } catch (Exception e) {
+                logger.info("Exception while uploading custom screenshot to s3: " + ExceptionUtils.getStackTrace(e));
+                return false;
+            }
+        } else {
+            logger.info("Local path does not exist");
+            return false;
+        }
+    }
+
+    public BufferedImage mergeImagesAndHighlightDifferences(BufferedImage baseImage, BufferedImage overlayImage,
+                                                            BufferedImage combined, List<Coordinate> coordinates) {
+        try {
+            logger.info("Coordinates: " + coordinates);
+            int height = Math.max(baseImage.getHeight(), overlayImage.getHeight());
+            int width = baseImage.getWidth() + overlayImage.getWidth();
+            logger.info("Height: " + height + ", Width: " + width);
+            if (combined == null) {
+                combined = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            }
+
+            Graphics2D g2d = combined.createGraphics();
+            g2d.setColor(Color.WHITE);
+            g2d.fillRect(0, 0, width, height);
+
+            g2d.drawImage(baseImage, 0, 0, null);
+            g2d.drawImage(overlayImage, baseImage.getWidth(), 0, null);
+
+            g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.2f));
+
+            g2d.setColor(new Color(255, 0, 0));
+
+            for (Coordinate coordinate : coordinates) {
+                g2d.fillRect(coordinate.getX(), coordinate.getY(), coordinate.getW(), coordinate.getH());
+            }
+
+            for (Coordinate coordinate : coordinates) {
+                g2d.fillRect(coordinate.getX() + baseImage.getWidth(), coordinate.getY(),
+                        coordinate.getW(), coordinate.getH());
+            }
+
+            g2d.dispose();
+        } catch (Exception e) {
+            logger.debug("Error while merging images and highlighting differences: " + ExceptionUtils.getStackTrace(e));
+            throw new RuntimeException(e);
+        }
+        logger.info("Images merged and differences highlighted");
+        return combined;
+    }
+
+    public int getPdfPageCount(File pdfFile) {
+        try {
+            PDDocument document = Loader.loadPDF(pdfFile);
+            int numberOfPagesInPdf = document.getNumberOfPages();
+            document.close();
+            return numberOfPagesInPdf;
+        } catch (IOException e) {
+            logger.info("Exception while getting the number of pages in the pdf: " + ExceptionUtils.getStackTrace(e));
+            return -1;
+        }
+    }
+
+    public void pdfToImage(String pdfFilePath, String imageOutputDir, String type, int index) {
+        try {
+            logger.info(String.format("Converting page %d in pdf to image and storing in directory %s",
+                    index, imageOutputDir));
+
+            File pdfFile;
+            if (pdfFilePath.startsWith("http://") || pdfFilePath.startsWith("https://")) {
+                String tempFileName = "temp_" + System.currentTimeMillis() + ".pdf";
+                pdfFile = downloadFromUrl(pdfFilePath, tempFileName);
+                logger.info("Downloaded S3 URL to temporary file: " + pdfFile.getAbsolutePath());
+            } else {
+                pdfFile = new File(pdfFilePath);
+            }
+
+            PDDocument document = Loader.loadPDF(pdfFile);
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            BufferedImage bim = pdfRenderer.renderImageWithDPI(index - 1, 300);
+            ImageIOUtil.writeImage(bim, String.format("%s/%s_page_%d.png", imageOutputDir, type, index), 300);
+            document.close();
+
+            if (pdfFilePath.startsWith("http")) {
+                boolean deleted = pdfFile.delete();
+                if (deleted) {
+                    logger.info("Temporary PDF file deleted successfully");
+                }
+            }
+
+            logger.info("Pdf to image conversion successful for page " + index);
+        } catch (IOException e) {
+            String message = "Unable to convert pdf into image pages: " + e.getMessage();
+            logger.info(String.format("Exception while converting pdf %s into pages: %s", pdfFilePath,
+                    ExceptionUtils.getStackTrace(e)));
+            throw new RuntimeException(message);
+        }
+    }
+
+    private File downloadFromUrl(String url, String fileName) throws IOException {
+        File tempFile = File.createTempFile(fileName, ".pdf");
+        try (InputStream in = new URL(url).openStream()) {
+            Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return tempFile;
+    }
+
+}


### PR DESCRIPTION

# please review this addon and publish as PUBLIC

Addon name : PDF visual testing
Addon accont: https://jarvis.testsigma.com/ui/tenants/2817/addons
Jira: https://testsigma.atlassian.net/browse/CUS-14381


# fix 
1. Added Bulk pdf visual testing by taking pdf folder as input.
2. Used Multithreading for faster execution.
3. added all these files in windows advanced application type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PDF visual comparison for complete documents, selected pages, and folders.
  - Added selected-page comparison with optional page-count matching.
  - Added folder pairing by filename or sorted order, with consolidated reports.
  - Added Base64 decoding to PDF files with runtime path storage.
  - Added PDF page-count retrieval with runtime variable support.
  - Added support for local and remote PDF sources, highlighted difference screenshots, and detailed failure reporting.

- **Improvements**
  - Improved PDF validation and comparison error handling.
  - Updated project and SDK components for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->